### PR TITLE
Re-exports tonic

### DIFF
--- a/yellowstone-grpc-proto/src/lib.rs
+++ b/yellowstone-grpc-proto/src/lib.rs
@@ -15,4 +15,5 @@ pub mod solana {
 pub mod prelude {
     pub use super::geyser::*;
     pub use super::solana::storage::confirmed_block::*;
+    pub use tonic::*;
 }


### PR DESCRIPTION
This allows people to use the tonic version that we have compiled for. This is helpful for people who use other tonic versions elsewhere.