### PR TITLE
update to geyser interface with less locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,8 +2570,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -2594,8 +2594,8 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2604,9 +2604,9 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-frozen-abi-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-program 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-frozen-abi 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-frozen-abi-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-program 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
@@ -2614,8 +2614,8 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "bincode",
  "chrono",
@@ -2627,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.14.15"
+version = "1.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f651fd3d06d9aa6c66d2ceb7230278ddad59403dc1cc4abf82a69970dc6f631d"
+checksum = "23b4953578272ac0fadec245e85e83ae86454611f0c0a7fff7d906835124bdcf"
 dependencies = [
  "ahash",
  "blake3",
@@ -2654,15 +2654,15 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "solana-frozen-abi-macro 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "ahash",
  "blake3",
@@ -2687,16 +2687,16 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "solana-frozen-abi-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-frozen-abi-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "subtle",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.14.15"
+version = "1.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301bb4bd66f592d4b799db0fb0ed1ae9fc7a8453476961faef1223127091574b"
+checksum = "57892538250428ad3dc3cbe05f6cd75ad14f4f16734fcb91bc7cd5fbb63d6315"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2706,8 +2706,8 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-grpc"
-version = "0.5.3+solana.1.14.15"
+version = "0.5.3+solana.1.14.16"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-grpc-client"
-version = "0.5.3+solana.1.14.15"
+version = "0.5.3+solana.1.14.16"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2763,8 +2763,8 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "log",
  "solana-sdk",
@@ -2774,8 +2774,8 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -2784,8 +2784,8 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "log",
  "solana-sdk",
@@ -2793,8 +2793,8 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -2806,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.14.15"
+version = "1.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a52d34820e44c56a23ef540a9c996873885c4834e7e36bc5901990c675603c"
+checksum = "3f99052873619df68913cb8e92e28ff251a5483828925e87fa97ba15a9cbad51"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2844,9 +2844,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "solana-frozen-abi 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk-macro 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk-macro 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -2855,8 +2855,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2892,9 +2892,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "solana-frozen-abi 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-frozen-abi-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-sdk-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-frozen-abi 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-frozen-abi-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-sdk-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -2903,8 +2903,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2919,8 +2919,8 @@ dependencies = [
  "rand 0.7.3",
  "rustc_version",
  "serde",
- "solana-frozen-abi 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-frozen-abi-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-frozen-abi 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-frozen-abi-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
@@ -2929,8 +2929,8 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -2967,11 +2967,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "solana-frozen-abi 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-frozen-abi-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-frozen-abi 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-frozen-abi-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "solana-logger",
- "solana-program 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-sdk-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-program 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-sdk-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -2979,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.14.15"
+version = "1.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7f28d94a4ed37c6eb7c62221da0e2206f11af051e91c045f2cce60111d3020"
+checksum = "7d41a09b9cecd0a4df63c78a192adee99ebf2d3757c19713a68246e1d9789c7c"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2992,8 +2992,8 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -3004,8 +3004,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -3032,8 +3032,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.14.15"
-source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2#3891feedce26dc7ebfe41f02b798c4b51cf7694c"
+version = "1.14.16"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2#fd28169abc66b64bf16cdf7e5abbc4b101ad3b84"
 dependencies = [
  "bincode",
  "log",
@@ -3042,8 +3042,8 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
- "solana-frozen-abi-macro 1.14.15 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-geyser-block-v2)",
+ "solana-frozen-abi 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
+ "solana-frozen-abi-macro 1.14.16 (git+https://github.com/rpcpool/solana-public.git?tag=v1.14.16-geyser-block-v2-2)",
  "solana-metrics",
  "solana-program-runtime",
  "solana-sdk",
@@ -3052,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.14.15"
+version = "1.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b25e1c3a45dfb9e4307cd5f655e0fb2efc64eb5011e517a8f6abc9c88c44566"
+checksum = "7ab38abd096769f79fd8e3fe8465070f04742395db724606a5263c8ebc215567"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -3074,7 +3074,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
  "subtle",
  "thiserror",
@@ -3097,7 +3097,7 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -3109,7 +3109,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3123,7 +3123,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -3138,7 +3138,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-token",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ members = [
 ]
 
 [patch.crates-io]
-solana-geyser-plugin-interface = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-geyser-block-v2" }
-solana-logger = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-geyser-block-v2" }
-solana-sdk = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-geyser-block-v2" }
-solana-transaction-status = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-geyser-block-v2" }
+solana-geyser-plugin-interface = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.16-geyser-block-v2-2" }
+solana-logger = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.16-geyser-block-v2-2" }
+solana-sdk = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.16-geyser-block-v2-2" }
+solana-transaction-status = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.16-geyser-block-v2-2" }
 
 [profile.release]
 debug = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-geyser-grpc-client"
-version = "0.5.3+solana.1.14.15"
+version = "0.5.3+solana.1.14.16"
 authors = ["Triton One"]
 edition = "2021"
 

--- a/solana-geyser-grpc/Cargo.toml
+++ b/solana-geyser-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-geyser-grpc"
-version = "0.5.3+solana.1.14.15"
+version = "0.5.3+solana.1.14.16"
 authors = ["Triton One"]
 edition = "2021"
 
@@ -23,10 +23,10 @@ prometheus = "0.13.2"
 prost = "0.11.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
-solana-geyser-plugin-interface = "=1.14.15"
-solana-logger = "=1.14.15"
-solana-sdk = "=1.14.15"
-solana-transaction-status = "=1.14.15"
+solana-geyser-plugin-interface = "=1.14.16"
+solana-logger = "=1.14.16"
+solana-sdk = "=1.14.16"
+solana-transaction-status = "=1.14.16"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time"] }
 tokio-stream = "0.1.11"
 tonic = { version = "0.8.2", features = ["gzip", "tls", "tls-roots"] }

--- a/solana-geyser-grpc/src/filters.rs
+++ b/solana-geyser-grpc/src/filters.rs
@@ -69,6 +69,7 @@ impl Filter {
 
     pub fn get_filters(&self, message: &Message) -> Vec<String> {
         match message {
+            Message::EndOfStartup => unreachable!(),
             Message::Account(message) => self.accounts.get_filters(message),
             Message::Slot(message) => self.slots.get_filters(message),
             Message::Transaction(message) => self.transactions.get_filters(message),

--- a/solana-geyser-grpc/src/grpc.rs
+++ b/solana-geyser-grpc/src/grpc.rs
@@ -196,6 +196,7 @@ impl<'a> From<&'a ReplicaBlockInfoV2<'a>> for MessageBlockMeta {
 
 #[derive(Debug)]
 pub enum Message {
+    EndOfStartup,
     Slot(MessageSlot),
     Account(MessageAccount),
     Transaction(MessageTransaction),
@@ -206,6 +207,7 @@ pub enum Message {
 impl From<&Message> for UpdateOneof {
     fn from(message: &Message) -> Self {
         match message {
+            Message::EndOfStartup => unreachable!(),
             Message::Slot(message) => UpdateOneof::Slot(SubscribeUpdateSlot {
                 slot: message.slot,
                 parent: message.parent,


### PR DESCRIPTION
Looks like a patch with fewer locks in the geyser introduce some problems to `validator`. `owner` size in the account info on `update_account` is not 32 because of this I get a segmentation fault. Maybe it will be good to wait a while. We can re-use this code when `validator` with a changed geyser interface will be released.