### PR TITLE
toolchain: use 1.69 as global and 1.66.1 for plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets #-- --deny=warnings
+          args: --workspace --all-targets --tests #-- --deny=warnings
 
       - name: Build
         run: ./ci/cargo-build-test.sh

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -28,7 +28,7 @@ else
   # pacify shellcheck: cannot follow dynamic path
   # shellcheck disable=SC1090,SC1091
   source "$base/../ci/read-cargo-variable.sh"
-  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
+  stable_version=$(readCargoVariable channel "$base/../yellowstone-grpc-geyser/rust-toolchain.toml")
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.69.0"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"

--- a/yellowstone-grpc-geyser/rust-toolchain.toml
+++ b/yellowstone-grpc-geyser/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.66.1"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"

--- a/yellowstone-grpc-geyser/tests/test_filters.rs
+++ b/yellowstone-grpc-geyser/tests/test_filters.rs
@@ -53,7 +53,7 @@ mod tests {
         let sig = sanitized_transaction.signature();
         MessageTransaction {
             transaction: MessageTransactionInfo {
-                signature: sig.clone(),
+                signature: *sig,
                 is_vote: true,
                 transaction: sanitized_transaction,
                 meta,

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -166,4 +166,3 @@ message GetSlotRequest {}
 message GetSlotResponse {
   uint64 slot = 1;
 }
-


### PR DESCRIPTION
Update of https://github.com/rpcpool/yellowstone-grpc/pull/116