### PR TITLE
plugin: remove connection after disconnect

### DIFF
--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -201,6 +201,7 @@ impl<'a> From<&'a ReplicaBlockInfoV2<'a>> for MessageBlockMeta {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Message {
     Slot(MessageSlot),
     Account(MessageAccount),

--- a/yellowstone-grpc-geyser/src/lib.rs
+++ b/yellowstone-grpc-geyser/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::large_enum_variant)]
-
 pub mod config;
 pub mod filters;
 pub mod grpc;


### PR DESCRIPTION
Previously connection would be removed from `HashMap` only on filter match and already disconnected client. With this patch, the connection would be removed immediately after disconnecting.