### PR TITLE
grpc, proto: add getVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ For additional documentation,  please see: https://docs.triton.one/rpc-pool/grpc
 ### Validator
 
 ```bash
-$ solana-validator --geyser-plugin-config yellowstone-grpc-proto/config.json
+$ solana-validator --geyser-plugin-config yellowstone-grpc-geyser/config.json
 ```
 
 ### Plugin config check
 
 ```
-cargo-fmt && cargo run --bin config-check -- --config yellowstone-grpc-proto/config.json
+cargo-fmt && cargo run --bin config-check -- --config yellowstone-grpc-geyser/config.json
 ```
 
 ### Filters

--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -78,6 +78,7 @@ enum Action {
     GetLatestBlockhash,
     GetBlockHeight,
     GetSlot,
+    GetVersion,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -328,6 +329,11 @@ async fn main() -> anyhow::Result<()> {
                     .map(|response| info!("response: {:?}", response)),
                 Action::GetSlot => client
                     .get_slot(commitment)
+                    .await
+                    .map_err(anyhow::Error::new)
+                    .map(|response| info!("response: {:?}", response)),
+                Action::GetVersion => client
+                    .get_version()
                     .await
                     .map_err(anyhow::Error::new)
                     .map(|response| info!("response: {:?}", response)),

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -17,10 +17,10 @@ use {
     yellowstone_grpc_proto::prelude::{
         geyser_client::GeyserClient, CommitmentLevel, GetBlockHeightRequest,
         GetBlockHeightResponse, GetLatestBlockhashRequest, GetLatestBlockhashResponse,
-        GetSlotRequest, GetSlotResponse, PingRequest, PongResponse, SubscribeRequest,
-        SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocks,
-        SubscribeRequestFilterBlocksMeta, SubscribeRequestFilterSlots,
-        SubscribeRequestFilterTransactions, SubscribeUpdate,
+        GetSlotRequest, GetSlotResponse, GetVersionRequest, GetVersionResponse, PingRequest,
+        PongResponse, SubscribeRequest, SubscribeRequestFilterAccounts,
+        SubscribeRequestFilterBlocks, SubscribeRequestFilterBlocksMeta,
+        SubscribeRequestFilterSlots, SubscribeRequestFilterTransactions, SubscribeUpdate,
     },
 };
 
@@ -160,6 +160,12 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
             commitment: commitment.map(|value| value as i32),
         });
         let response = self.client.get_slot(request).await?;
+        Ok(response.into_inner())
+    }
+
+    pub async fn get_version(&mut self) -> GeyserGrpcClientResult<GetVersionResponse> {
+        let request = tonic::Request::new(GetVersionRequest {});
+        let response = self.client.get_version(request).await?;
         Ok(response.into_inner())
     }
 }

--- a/yellowstone-grpc-geyser/build.rs
+++ b/yellowstone-grpc-geyser/build.rs
@@ -13,20 +13,28 @@ fn main() -> anyhow::Result<()> {
         git_version::git_version!()
     );
 
-    // Extract Solana version
+    // Extract packages version
     let lockfile = Lockfile::load("../Cargo.lock")?;
     println!(
         "cargo:rustc-env=SOLANA_SDK_VERSION={}",
-        lockfile
-            .packages
-            .iter()
-            .filter(|pkg| pkg.name.as_str() == "solana-sdk")
-            .map(|pkg| pkg.version.to_string())
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .join(",")
+        get_pkg_version(&lockfile, "solana-sdk")
+    );
+    println!(
+        "cargo:rustc-env=YELLOWSTONE_GRPC_PROTO_VERSION={}",
+        get_pkg_version(&lockfile, "yellowstone-grpc-proto")
     );
 
     Ok(())
+}
+
+fn get_pkg_version(lockfile: &Lockfile, pkg_name: &str) -> String {
+    lockfile
+        .packages
+        .iter()
+        .filter(|pkg| pkg.name.as_str() == pkg_name)
+        .map(|pkg| pkg.version.to_string())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(",")
 }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -9,11 +9,12 @@ use {
             subscribe_update::UpdateOneof,
             CommitmentLevel, GetBlockHeightRequest, GetBlockHeightResponse,
             GetLatestBlockhashRequest, GetLatestBlockhashResponse, GetSlotRequest, GetSlotResponse,
-            PingRequest, PongResponse, SubscribeRequest, SubscribeUpdate, SubscribeUpdateAccount,
-            SubscribeUpdateAccountInfo, SubscribeUpdateBlock, SubscribeUpdateBlockMeta,
-            SubscribeUpdatePing, SubscribeUpdateSlot, SubscribeUpdateTransaction,
-            SubscribeUpdateTransactionInfo,
+            GetVersionRequest, GetVersionResponse, PingRequest, PongResponse, SubscribeRequest,
+            SubscribeUpdate, SubscribeUpdateAccount, SubscribeUpdateAccountInfo,
+            SubscribeUpdateBlock, SubscribeUpdateBlockMeta, SubscribeUpdatePing,
+            SubscribeUpdateSlot, SubscribeUpdateTransaction, SubscribeUpdateTransactionInfo,
         },
+        version::VERSION,
     },
     log::*,
     solana_geyser_plugin_interface::geyser_plugin_interface::{
@@ -669,5 +670,14 @@ impl Geyser for GrpcService {
                 request.get_ref().commitment,
             )
             .await
+    }
+
+    async fn get_version(
+        &self,
+        _request: Request<GetVersionRequest>,
+    ) -> Result<Response<GetVersionResponse>, Status> {
+        Ok(Response::new(GetVersionResponse {
+            version: serde_json::to_string(&VERSION).unwrap(),
+        }))
     }
 }

--- a/yellowstone-grpc-geyser/src/prom.rs
+++ b/yellowstone-grpc-geyser/src/prom.rs
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
 
     static ref VERSION: IntCounterVec = IntCounterVec::new(
         Opts::new("version", "Plugin version info"),
-        &["buildts", "git", "rustc", "solana", "version"]
+        &["buildts", "git", "proto", "rustc", "solana", "version"]
     ).unwrap();
 
     pub static ref SLOT_STATUS: IntGaugeVec = IntGaugeVec::new(
@@ -60,6 +60,7 @@ impl PrometheusService {
                 .with_label_values(&[
                     VERSION_INFO.buildts,
                     VERSION_INFO.git,
+                    VERSION_INFO.proto,
                     VERSION_INFO.rustc,
                     VERSION_INFO.solana,
                     VERSION_INFO.version,

--- a/yellowstone-grpc-geyser/src/version.rs
+++ b/yellowstone-grpc-geyser/src/version.rs
@@ -3,6 +3,7 @@ use {serde::Serialize, std::env};
 #[derive(Debug, Serialize)]
 pub struct Version {
     pub version: &'static str,
+    pub proto: &'static str,
     pub solana: &'static str,
     pub git: &'static str,
     pub rustc: &'static str,
@@ -11,6 +12,7 @@ pub struct Version {
 
 pub const VERSION: Version = Version {
     version: env!("VERGEN_BUILD_SEMVER"),
+    proto: env!("YELLOWSTONE_GRPC_PROTO_VERSION"),
     solana: env!("SOLANA_SDK_VERSION"),
     git: env!("GIT_VERSION"),
     rustc: env!("VERGEN_RUSTC_SEMVER"),

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -12,6 +12,7 @@ service Geyser {
   rpc GetLatestBlockhash(GetLatestBlockhashRequest) returns (GetLatestBlockhashResponse) {}
   rpc GetBlockHeight(GetBlockHeightRequest) returns (GetBlockHeightResponse) {}
   rpc GetSlot(GetSlotRequest) returns (GetSlotResponse) {}
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {}
 }
 
 enum CommitmentLevel {
@@ -175,4 +176,10 @@ message GetSlotRequest {
 
 message GetSlotResponse {
   uint64 slot = 1;
+}
+
+message GetVersionRequest {}
+
+message GetVersionResponse {
+  string version = 1;
 }


### PR DESCRIPTION
Based on #128 
Closes #47 

Return version as string:
```
[2023-05-24T20:11:32Z INFO  client] response: GetVersionResponse { version: "{\"version\":\"0.6.1+solana.1.15.2\",\"solana\":\"1.15.2\",\"git\":\"41d1bad-modified\",\"rustc\":\"1.66.1\",\"buildts\":\"2023-05-24T19:39:04.796311939Z\"}" }
```