### PR TITLE
add full block notification with no account defined.

### DIFF
--- a/yellowstone-grpc-geyser/config.json
+++ b/yellowstone-grpc-geyser/config.json
@@ -32,7 +32,9 @@
                 "max": 1,
                 "any": false,
                 "account_include_max": 10,
-                "account_include_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"]
+                "account_include_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],
+                "include_transactions": true,
+                "include_accounts" : false
             },
             "blocks_meta": {
                 "max": 1

--- a/yellowstone-grpc-geyser/config.json
+++ b/yellowstone-grpc-geyser/config.json
@@ -30,8 +30,8 @@
             },
             "blocks": {
                 "max": 1,
-                "any": false,
                 "account_include_max": 10,
+                "account_include_any": false,
                 "account_include_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],
                 "include_transactions": true,
                 "include_accounts" : false

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -213,9 +213,10 @@ impl Default for ConfigGrpcFiltersTransactions {
 pub struct ConfigGrpcFiltersBlocks {
     #[serde(deserialize_with = "deserialize_usize_str")]
     pub max: usize,
-    pub any: bool,
     #[serde(deserialize_with = "deserialize_usize_str")]
     pub account_include_max: usize,
+    #[serde(alias = "any")]
+    pub account_include_any: bool,
     #[serde(deserialize_with = "deserialize_pubkey_set")]
     pub account_include_reject: HashSet<Pubkey>,
     pub include_transactions: bool,
@@ -226,8 +227,8 @@ impl Default for ConfigGrpcFiltersBlocks {
     fn default() -> Self {
         Self {
             max: usize::MAX,
-            any: true,
             account_include_max: usize::MAX,
+            account_include_any: true,
             account_include_reject: HashSet::new(),
             include_transactions: true,
             include_accounts: true,

--- a/yellowstone-grpc-geyser/src/filters.rs
+++ b/yellowstone-grpc-geyser/src/filters.rs
@@ -558,7 +558,12 @@ impl FilterBlocks {
 
         let mut this = Self::default();
         for (name, filter) in configs {
-            ConfigGrpcFilters::check_any(filter.account_include.is_empty(), limit.any)?;
+            ConfigGrpcFilters::check_any(
+                filter.account_include.is_empty()
+                    && filter.include_transactions.is_none()
+                    && filter.include_accounts.is_none(),
+                limit.any,
+            )?;
             ConfigGrpcFilters::check_pubkey_max(
                 filter.account_include.len(),
                 limit.account_include_max,

--- a/yellowstone-grpc-geyser/src/filters.rs
+++ b/yellowstone-grpc-geyser/src/filters.rs
@@ -558,12 +558,7 @@ impl FilterBlocks {
 
         let mut this = Self::default();
         for (name, filter) in configs {
-            ConfigGrpcFilters::check_any(
-                filter.account_include.is_empty()
-                    && filter.include_transactions.is_none()
-                    && filter.include_accounts.is_none(),
-                limit.any,
-            )?;
+            ConfigGrpcFilters::check_any(filter.account_include.is_empty(), limit.account_include_any)?;
             ConfigGrpcFilters::check_pubkey_max(
                 filter.account_include.len(),
                 limit.account_include_max,


### PR DESCRIPTION
I change the filter check_any verification to allow block filter with no account defined but Tx or Account activated.
It allows to be notified for each full  block and its Tx and/or accounts.
We need it for the RPCv2.

I update the default config.json to add the mandatory block fields if block notification is activated.