### PR TITLE
adding fs in tokio features to support fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- geyser: add `fs` feature to `tokio` dependencies in the plugin ([#184](https://github.com/rpcpool/yellowstone-grpc/pull/184)).
+
 ### Breaking
 
 ## 2023-08-28

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -30,7 +30,7 @@ solana-logger = "=1.16.1"
 solana-sdk = "=1.16.1"
 solana-transaction-status = "=1.16.1"
 spl-token-2022 = "0.7.0"
-tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time", "fs"] }
 tokio-stream = "0.1.11"
 tonic = { version = "0.9.2", features = ["gzip", "tls", "tls-roots"] }
 tonic-health = "0.9.2"


### PR DESCRIPTION
Currently with newer versions of tokio does not compile because it requires feauture flag fs enabled in Cargo.toml