### PR TITLE
geyser: update solana =1.16.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,22 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+### Fixes
+
+### Breaking
+
+## 2023-10-02
+
+- yellowstone-grpc-client-1.10.0+solana.1.16.14
+- yellowstone-grpc-geyser-1.8.0+solana.1.16.14
+- yellowstone-grpc-kafka-1.0.0-rc.0+solana.1.16.14
+- yellowstone-grpc-proto-1.9.0+solana.1.16.14
+
+### Features
+
 - geyser: add optional TLS to gRPC server config ([#183](https://github.com/rpcpool/yellowstone-grpc/pull/183)).
 - client: add timeout options to rust ([#187](https://github.com/rpcpool/yellowstone-grpc/pull/187)).
+- geyser: update solana =1.16.14 ([#188](https://github.com/rpcpool/yellowstone-grpc/pull/188)).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380584cb468a1eb2ea79495c0c574ca09a11bf6796093b97a48a94cd98fe5b30"
+checksum = "f0ada16ccd5ca6884ae28b716211c4f09d22225a9ebde14eccd4f605cc321e42"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -3046,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcdcbe2a61849b7692ac9eb6ad567ea4f333c36272d5d12de554aa2f60fa792"
+checksum = "248b435722d18100b70bb8f09fd38b8a8c46031a0de86f6b31768f64cf4092c5"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3067,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44cd8bbbc468503ca8d337c91a6f6049ced080be31854d866a25974f1b90619"
+checksum = "e0622d8798d060c84883572483f214b0d5c1640450e4322483cfe2e72823a6d7"
 dependencies = [
  "bincode",
  "chrono",
@@ -3081,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea8be57163366de9ffee3652cd42ea02fd5cca672408722f1426eb0d234a330"
+checksum = "0e74d294241df12a73a229e38a819e810d54234da494c3d43f8a1a828631047d"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -3114,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4121f91307234cec8c8d8cd2d7ec171881c07db2222335e8c840d555ebe89cc"
+checksum = "4dabde7fbd88a68eb083ae9d6d5f6855b7ba1bfc45d200c786b1b448ac49da5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8bcaf5e09940bebbc0342257ac695e4bb6e4a996c68f223de16d2649c7b32a"
+checksum = "908cad0de1330b6b05d6cb6a9f5004df22a9fe46529d6bf6839835ba345ef966"
 dependencies = [
  "log",
  "solana-sdk",
@@ -3138,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f590904a129707c5bf6b9f2e198e49ce8984e802dad26babd2c406a4e898b0ce"
+checksum = "24dc0037a389d782c8de3c6f509b74efa1d60523ef9e5561cefe41f1a354fee0"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -3149,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26976359ec46d158ce2880d5a31bca4b08e971d29d03c25e9ba80f9a3d42b28e"
+checksum = "19563c27f12801e0e65b42d0f216db1d910dfeaad88d8f1335dd6369697eda60"
 dependencies = [
  "log",
  "solana-sdk",
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d97a86ca9bc1c33b77f98502ef0ec133823ebbb813fc60e10c6cf6377bbbdf2"
+checksum = "7f74c557e821c7ff48c9b4ef4ab3a296918d7fb745e3f2e820ebdb38e8e3555b"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -3173,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ac28d05adeff2212cdec76dfacc6eb631d69d065b1b83c063a1fab505d5e62"
+checksum = "3a2faeb9c89b354b547a229e3b39fa8fd6d11c78362ba8580f0c4721739725b6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3187,6 +3187,7 @@ dependencies = [
  "bitflags",
  "blake3",
  "borsh 0.10.3",
+ "borsh 0.9.3",
  "bs58",
  "bv",
  "bytemuck",
@@ -3227,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cb661d9fe32ec33ba8df554827becd5bcc1758392194420899771344177fb1"
+checksum = "9f65907a405764cda63be89335ffd2138ade18f065e5cae09d20adab7fb09502"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -3255,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa2d54c0e9109d1bf9edafbd86d645217776df783814397f79c3929cf4316ba"
+checksum = "57f4046d0d487e3d79be809ff29c63c1484793956e6ccbc5d3307b0aafbf989d"
 dependencies = [
  "assert_matches",
  "base64 0.21.2",
@@ -3308,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa991e6d6ae7c57ef9fc56f964b22f3bae6ba6c144ccb07b0fe07e06a3efc47c"
+checksum = "760fdfd4b7edb02fd9173a6dcec899ffae06ac21b66b65f8c7c5f3d17b12fa64"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -3321,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5331f3dfa4a8228dd69b6954859d6aafdd3234b24802690c1f7446bc37df6d"
+checksum = "8bdf7379a72c051d7879f1c36cfdab5fed0653a2a613718bc5d343e44e603401"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -3347,12 +3348,11 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.1"
+version = "1.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aa69c3f19df466a68a26f009e9dc39de671bf022c66fbbfab2d1c021b62a97"
+checksum = "3bdec366a15133a70a8dfc4f027b5d0f508bd7cb46af11971076c9ebaf9ede2d"
 dependencies = [
  "aes-gcm-siv",
- "arrayref",
  "base64 0.21.2",
  "bincode",
  "bytemuck",
@@ -3377,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae90c406f0a2d4a15f08d16c8b64f37997a57611fec0a89f1277854166996e8"
+checksum = "17d4ba1e58947346e360fabde0697029d36ba83c42f669199b16a8931313cf29"
 dependencies = [
  "byteorder",
  "combine",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "1.9.0+solana.1.16.1"
+version = "1.10.0+solana.1.16.14"
 dependencies = [
  "bytes",
  "futures",
@@ -4480,10 +4480,11 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client-simple"
-version = "1.9.0+solana.1.16.1"
+version = "1.9.0+solana.1.16.14"
 dependencies = [
  "anyhow",
  "backoff",
+ "bincode",
  "bs58",
  "chrono",
  "clap",
@@ -4500,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "1.7.1+solana.1.16.1"
+version = "1.8.0+solana.1.16.14"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -4531,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-kafka"
-version = "1.0.0-rc.0+solana.1.16.1"
+version = "1.0.0-rc.0+solana.1.16.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4559,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "1.9.0+solana.1.16.1"
+version = "1.9.0+solana.1.16.14"
 dependencies = [
  "anyhow",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
-    "examples/rust", # 1.9.0+solana.1.16.1
-    "yellowstone-grpc-client", # 1.9.0+solana.1.16.1
-    "yellowstone-grpc-geyser", # 1.7.1+solana.1.16.1
-    "yellowstone-grpc-kafka", # 1.0.0+solana.1.16.1
-    "yellowstone-grpc-proto", # 1.9.0+solana.1.16.1
+    "examples/rust", # 1.9.0+solana.1.16.14
+    "yellowstone-grpc-client", # 1.10.0+solana.1.16.14
+    "yellowstone-grpc-geyser", # 1.8.0+solana.1.16.14
+    "yellowstone-grpc-kafka", # 1.0.0+solana.1.16.14
+    "yellowstone-grpc-proto", # 1.9.0+solana.1.16.14
 ]
 
 [profile.release]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client-simple"
-version = "1.9.0+solana.1.16.1"
+version = "1.9.0+solana.1.16.14"
 authors = ["Triton One"]
 edition = "2021"
 publish = false
@@ -11,6 +11,7 @@ name = "client"
 [dependencies]
 anyhow = "1.0.62"
 backoff = { version = "0.4.0", features = ["tokio"] }
+bincode = "1.3.3"
 bs58 = "0.4.0"
 chrono = "0.4.26"
 clap = { version = "4.3.0", features = ["cargo", "derive"] }
@@ -19,7 +20,7 @@ futures = "0.3.24"
 hex = "0.4.3"
 log = { version = "0.4.14", features = ["std"] }
 maplit = "1.0.2"
-solana-sdk = "=1.16.1"
+solana-sdk = "=1.16.14"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time"] }
 yellowstone-grpc-client = { path = "../../yellowstone-grpc-client" }
 yellowstone-grpc-proto = { path = "../../yellowstone-grpc-proto" }

--- a/examples/rust/src/bin/tx-blocktime.rs
+++ b/examples/rust/src/bin/tx-blocktime.rs
@@ -114,7 +114,8 @@ async fn main() -> anyhow::Result<()> {
                 match msg.update_oneof {
                     Some(UpdateOneof::Transaction(tx)) => {
                         let entry = messages.entry(tx.slot).or_default();
-                        let sig = Signature::new(tx.transaction.unwrap().signature.as_slice())
+                        let sig = Signature::try_from(tx.transaction.unwrap().signature.as_slice())
+                            .expect("valid signature")
                             .to_string();
                         if let Some(timestamp) = entry.0 {
                             info!("received txn {} at {}", sig, timestamp);

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "1.9.0+solana.1.16.1"
+version = "1.10.0+solana.1.16.14"
 authors = ["Triton One"]
 edition = "2021"
 description = "Yellowstone gRPC Geyser Simple Client"
@@ -16,7 +16,7 @@ http = "0.2.8"
 thiserror = "1.0"
 tonic = { version = "0.9.2", features = ["gzip", "tls", "tls-roots"] }
 tonic-health = "0.9.2"
-yellowstone-grpc-proto = { path = "../yellowstone-grpc-proto", version = "1.9.0+solana.1.16.1" }
+yellowstone-grpc-proto = { path = "../yellowstone-grpc-proto", version = "1.9.0+solana.1.16.14" }
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["macros"] }

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "1.7.1+solana.1.16.1"
+version = "1.8.0+solana.1.16.14"
 authors = ["Triton One"]
 edition = "2021"
 description = "Yellowstone gRPC Geyser Plugin"
@@ -25,10 +25,10 @@ log = "0.4.17"
 prometheus = "0.13.2"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
-solana-geyser-plugin-interface = "=1.16.1"
-solana-logger = "=1.16.1"
-solana-sdk = "=1.16.1"
-solana-transaction-status = "=1.16.1"
+solana-geyser-plugin-interface = "=1.16.14"
+solana-logger = "=1.16.14"
+solana-sdk = "=1.16.14"
+solana-transaction-status = "=1.16.14"
 spl-token-2022 = "0.7.0"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time", "fs"] }
 tokio-stream = "0.1.11"

--- a/yellowstone-grpc-kafka/Cargo.toml
+++ b/yellowstone-grpc-kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-kafka"
-version = "1.0.0-rc.0+solana.1.16.1"
+version = "1.0.0-rc.0+solana.1.16.14"
 authors = ["Triton One"]
 edition = "2021"
 description = "Yellowstone gRPC Kafka Producer/Dedup/Consumer"

--- a/yellowstone-grpc-proto/Cargo.toml
+++ b/yellowstone-grpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-proto"
-version = "1.9.0+solana.1.16.1"
+version = "1.9.0+solana.1.16.14"
 authors = ["Triton One"]
 edition = "2021"
 description = "Yellowstone gRPC Geyser Protobuf Definitions"


### PR DESCRIPTION
Use gRPC 1.16.1 with validator 1.16.14 produce incorrect `failed` status.

https://docs.rs/solana-sdk/1.16.1/solana_sdk/transaction/enum.TransactionError.html
vs
https://docs.rs/solana-sdk/1.16.14/solana_sdk/transaction/enum.TransactionError.html

35 variants vs 36, as result deserialization is not correct