### PR TITLE
fixes openssl link problem (on mac os)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,6 +2438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.6+3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2454,7 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/yellowstone-grpc-tools/Cargo.toml
+++ b/yellowstone-grpc-tools/Cargo.toml
@@ -23,7 +23,7 @@ hyper = { version = "0.14.27", features = ["server"] }
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 prometheus = "0.13.2"
-rdkafka = { version = "0.34.0", features = ["ssl", "sasl"] }
+rdkafka = { version = "0.34.0", features = ["ssl-vendored", "sasl"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 serde_yaml = "0.9.25"

--- a/yellowstone-grpc-tools/Cargo.toml
+++ b/yellowstone-grpc-tools/Cargo.toml
@@ -36,10 +36,10 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 yellowstone-grpc-client = { path = "../yellowstone-grpc-client" }
 yellowstone-grpc-proto = { path = "../yellowstone-grpc-proto" }
 
-[target.'cfg(not(all(target_os = "macos", target_arch = "arm")))'.dependencies]
+[target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
 rdkafka = { version = "0.34.0", features = ["ssl", "sasl"] }
 
-[target.'cfg(all(target_os = "macos", target_arch = "arm"))'.dependencies]
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 rdkafka = { version = "0.34.0", features = ["ssl-vendored", "sasl"] }
 
 [build-dependencies]

--- a/yellowstone-grpc-tools/Cargo.toml
+++ b/yellowstone-grpc-tools/Cargo.toml
@@ -23,7 +23,6 @@ hyper = { version = "0.14.27", features = ["server"] }
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 prometheus = "0.13.2"
-rdkafka = { version = "0.34.0", features = ["ssl-vendored", "sasl"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 serde_yaml = "0.9.25"
@@ -36,6 +35,12 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 yellowstone-grpc-client = { path = "../yellowstone-grpc-client" }
 yellowstone-grpc-proto = { path = "../yellowstone-grpc-proto" }
+
+[target.'cfg(not(all(target_os = "macos", target_arch = "arm")))'.dependencies]
+rdkafka = { version = "0.34.0", features = ["ssl", "sasl"] }
+
+[target.'cfg(all(target_os = "macos", target_arch = "arm"))'.dependencies]
+rdkafka = { version = "0.34.0", features = ["ssl-vendored", "sasl"] }
 
 [build-dependencies]
 anyhow = "1.0.62"


### PR DESCRIPTION
### Problem
building the _rdkafka_ crate fails on mac per default configuration

>   _mkltmpuU0ERk.c:2:10: fatal error: 'openssl/ssl.h' file not found
  #include <openssl/ssl.h>
           ^~~~~~~~~~~~~~~
  1 error generated.



see https://github.com/fede1024/rust-rdkafka/issues/491

### Proposed solution:
ssl -> ssl-vendored

