### PR TITLE
fix(client): Include request in initial subscribe to gRPC endpoint to fix LB connection delay

### DIFF
--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -524,11 +524,7 @@ async fn geyser_subscribe(
     request: SubscribeRequest,
     resub: usize,
 ) -> anyhow::Result<()> {
-    let (mut subscribe_tx, mut stream) = client.subscribe().await?;
-    subscribe_tx
-        .send(request)
-        .await
-        .map_err(GeyserGrpcClientError::SubscribeSendError)?;
+    let (mut subscribe_tx, mut stream) = client.subscribe_with_request(Some(request)).await?;
 
     info!("stream opened");
     let mut counter = 0;

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -1,5 +1,3 @@
-use http::request;
-
 use {
     bytes::Bytes,
     futures::{


### PR DESCRIPTION
Some load balancers (eg. Cloudflare) expect a message to come through before passing a gRPC connection through to origin. Because the current subscribe method connects, and then sends a message, it causes a delay when connecting. This pr adds `subscribe_with_request` which pushes a request into the channel before sending the subscribe request. This resolves the LB issue