### PR TITLE
geyser: fix getLatestBlockhash unary method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- geyser: fix getLatestBlockhash unary method ([#349](https://github.com/rpcpool/yellowstone-grpc/pull/349))
+
 ### Features
 
 ### Breaking

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1385,13 +1385,14 @@ impl Geyser for GrpcService {
             blocks_meta
                 .get_block(
                     |block| {
-                        block.block_height.map(|last_valid_block_height| {
-                            GetLatestBlockhashResponse {
+                        block
+                            .block_height
+                            .map(|block_height| GetLatestBlockhashResponse {
                                 slot: block.slot,
                                 blockhash: block.blockhash.clone(),
-                                last_valid_block_height,
-                            }
-                        })
+                                last_valid_block_height: block_height
+                                    + MAX_RECENT_BLOCKHASHES as u64,
+                            })
                     },
                     request.get_ref().commitment,
                 )


### PR DESCRIPTION
Closes #348 