### PR TITLE
geyser: add metric `subscriptions_total`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- geyser: add metric `subscriptions_total` ([#355](https://github.com/rpcpool/yellowstone-grpc/pull/355))
+
 ### Breaking
 
 ## 2024-06-02

--- a/yellowstone-grpc-geyser/src/filters.rs
+++ b/yellowstone-grpc-geyser/src/filters.rs
@@ -96,6 +96,31 @@ impl Filter {
         Ok(vec)
     }
 
+    pub fn get_metrics(&self) -> [(&'static str, usize); 8] {
+        [
+            ("accounts", self.accounts.filters.len()),
+            ("slots", self.slots.filters.len()),
+            ("transactions", self.transactions.filters.len()),
+            (
+                "transactions_status",
+                self.transactions_status.filters.len(),
+            ),
+            ("entry", self.entry.filters.len()),
+            ("blocks", self.blocks.filters.len()),
+            ("blocks_meta", self.blocks_meta.filters.len()),
+            (
+                "all",
+                self.accounts.filters.len()
+                    + self.slots.filters.len()
+                    + self.transactions.filters.len()
+                    + self.transactions_status.filters.len()
+                    + self.entry.filters.len()
+                    + self.blocks.filters.len()
+                    + self.blocks_meta.filters.len(),
+            ),
+        ]
+    }
+
     pub const fn get_commitment_level(&self) -> CommitmentLevel {
         self.commitment
     }

--- a/yellowstone-grpc-geyser/src/prom.rs
+++ b/yellowstone-grpc-geyser/src/prom.rs
@@ -49,7 +49,12 @@ lazy_static::lazy_static! {
     ).unwrap();
 
     pub static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
-        "connections_total", "Total number of connections to GRPC service"
+        "connections_total", "Total number of connections to gRPC service"
+    ).unwrap();
+
+    static ref SUBSCRIPTIONS_TOTAL: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("subscritpions_total", "Total number of subscriptions to gRPC service"),
+        &["subscription"]
     ).unwrap();
 }
 
@@ -181,6 +186,7 @@ impl PrometheusService {
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
             register!(CONNECTIONS_TOTAL);
+            register!(SUBSCRIPTIONS_TOTAL);
 
             VERSION
                 .with_label_values(&[
@@ -297,4 +303,20 @@ pub fn update_invalid_blocks(reason: impl AsRef<str>) {
         .with_label_values(&[reason.as_ref()])
         .inc();
     INVALID_FULL_BLOCKS.with_label_values(&["all"]).inc();
+}
+
+pub fn update_subscriptions(old: Option<&Filter>, new: Option<&Filter>) {
+    for (multiplier, filter) in [(-1, old), (1, new)] {
+        if let Some(filter) = filter {
+            SUBSCRIPTIONS_TOTAL
+                .with_label_values(&["grpc_total"])
+                .add(multiplier);
+
+            for (name, value) in filter.get_metrics() {
+                SUBSCRIPTIONS_TOTAL
+                    .with_label_values(&[name])
+                    .add((value as i64) * multiplier);
+            }
+        }
+    }
 }


### PR DESCRIPTION
```
# HELP subscritpions_total Total number of subscriptions to gRPC service
# TYPE subscritpions_total gauge
subscritpions_total{subscription="accounts"} 0
subscritpions_total{subscription="all"} 2
subscritpions_total{subscription="blocks"} 0
subscritpions_total{subscription="blocks_meta"} 1
subscritpions_total{subscription="entry"} 0
subscritpions_total{subscription="grpc_total"} 1
subscritpions_total{subscription="slots"} 1
subscritpions_total{subscription="transactions"} 0
subscritpions_total{subscription="transactions_status"} 0
```