### PR TITLE
Optional solana crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ tracing-subscriber = "0.3.17"
 uuid = "1.8.0"
 vergen = "9.0.0"
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "=1.16.0+solana.2.0.2" }
-yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "=1.15.0+solana.2.0.2" }
+yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "=1.15.0+solana.2.0.2", default-features = false }
 
 [profile.release]
 lto = true

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -29,4 +29,4 @@ solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 yellowstone-grpc-client = { workspace = true }
-yellowstone-grpc-proto = { workspace = true }
+yellowstone-grpc-proto = { workspace = true, default-features = true }

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tokio-stream = { workspace = true }
 tonic = { workspace = true, features = ["gzip", "tls", "tls-roots"] }
 tonic-health = { workspace = true }
-yellowstone-grpc-proto = { workspace = true }
+yellowstone-grpc-proto = { workspace = true, features = ["convert"] }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/yellowstone-grpc-proto/Cargo.toml
+++ b/yellowstone-grpc-proto/Cargo.toml
@@ -13,12 +13,16 @@ publish = true
 [dependencies]
 bincode = { workspace = true }
 prost = { workspace = true }
-solana-account-decoder = { workspace = true }
-solana-sdk = { workspace = true }
-solana-transaction-status = { workspace = true }
+solana-account-decoder = { workspace = true, optional = true }
+solana-sdk = { workspace = true, optional = true }
+solana-transaction-status = { workspace = true, optional = true }
 tonic = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }
 protobuf-src = { workspace = true }
 tonic-build = { workspace = true }
+
+[features]
+convert = ["dep:solana-account-decoder", "dep:solana-sdk", "dep:solana-transaction-status"]
+default = ["convert"]

--- a/yellowstone-grpc-proto/src/lib.rs
+++ b/yellowstone-grpc-proto/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
 
 pub use {prost, tonic};
 
+#[cfg(feature = "convert")]
 pub mod convert_to {
     use {
         super::prelude as proto,
@@ -265,6 +266,7 @@ pub mod convert_to {
     }
 }
 
+#[cfg(feature = "convert")]
 pub mod convert_from {
     use {
         super::prelude as proto,


### PR DESCRIPTION
### Changes
- Do to the recent version plucking in 2.x of Solana crates.
- Add `convert` feature to exclude some solana crates but they are still included by default.


```
error: failed to select a version for `solana-account-decoder`.
    ... required by package `yellowstone-grpc-proto v1.14.0`
    ... which satisfies dependency `yellowstone-grpc-proto = "^1.14.0"` of package `yellowstone-vixen v0.0.0 (/Users/kyleespinola/Code/rpcpool/yellowstone-vixen/crates/runtime)`
versions that meet the requirements `>=1.17.28, <1.18.0` are: 1.17.34, 1.17.33, 1.17.32, 1.17.31, 1.17.30, 1.17.29, 1.17.28

all possible versions conflict with previously selected packages.

  previously selected package `solana-zk-token-sdk v2.0.0`
    ... which satisfies dependency `solana-zk-token-sdk = "^2.0.0"` of package `spl-token-2022 v4.0.1`
    ... which satisfies dependency `spl-token-2022 = "^4.0.1"` of package `yellowstone-vixen-parsers v0.0.0 (/Users/kyleespinola/Code/rpcpool/yellowstone-vixen/crates/parsers)`

failed to select a version for `solana-account-decoder` which could resolve this conflict
```