### PR TITLE
fix: continue to snapshot subscribe once filter received

### DIFF
--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1163,6 +1163,7 @@ impl GrpcService {
                         prom::update_subscriptions(&endpoint, Some(&filter), Some(&filter_new));
                         filter = filter_new;
                         info!("client #{id}: filter updated");
+                        break;
                     }
                     Some(None) => {
                         is_alive = false;


### PR DESCRIPTION
## Issue
When filters are received the loop continue which prevents connection from moving to next loop to receive messages.

## Fix
Break after receive filters. Snapshot only supports applying the first filter set it receives. 