### PR TITLE
version: bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,19 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+### Breaking
+
+## 2024-10-04
+
+- yellowstone-grpc-client-simple-2.0.0
+- yellowstone-grpc-client-2.0.0
+- yellowstone-grpc-geyser-2.0.0
+- yellowstone-grpc-proto-2.0.0
+
+### Features
+
 - solana: relax dependencies ([#430](https://github.com/rpcpool/yellowstone-grpc/pull/430))
 - tools: remove ([#431](https://github.com/rpcpool/yellowstone-grpc/pull/431))
-
-### Breaking
 
 ## 2024-09-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "1.16.2"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client-simple"
-version = "1.14.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "1.16.3"
+version = "2.0.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "1.15.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 resolver = "2"
 members = [
-    "examples/rust", # 1.14.1
-    "yellowstone-grpc-client", # 1.16.2
-    "yellowstone-grpc-geyser", # 1.16.3
-    "yellowstone-grpc-proto", # 1.15.0
+    "examples/rust", # 2.0.0
+    "yellowstone-grpc-client", # 2.0.0
+    "yellowstone-grpc-geyser", # 2.0.0
+    "yellowstone-grpc-proto", # 2.0.0
 ]
 
 [workspace.package]
@@ -14,6 +14,7 @@ homepage = "https://triton.one"
 repository = "https://github.com/rpcpool/yellowstone-grpc"
 license = "AGPL-3.0"
 keywords = ["solana"]
+publish = false
 
 [workspace.dependencies]
 agave-geyser-plugin-interface = "~2.0.10"
@@ -58,8 +59,8 @@ tonic = "0.12.1"
 tonic-build = "0.12.1"
 tonic-health = "0.12.1"
 vergen = "9.0.0"
-yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "1.16.2" }
-yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "1.15.0", default-features = false }
+yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "2.0.0" }
+yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "2.0.0", default-features = false }
 
 [workspace.lints.clippy]
 clone_on_ref_ptr = "deny"

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "yellowstone-grpc-client-simple"
-version = "1.14.1"
+version = "2.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 license = "Apache-2.0"
 keywords = { workspace = true }
-publish = false
+publish = { workspace = true }
 
 [[bin]]
 name = "client"

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "1.16.2"
+version = "2.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Simple Client"

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "1.16.3"
+version = "2.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
-publish = false
+publish = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/yellowstone-grpc-proto/Cargo.toml
+++ b/yellowstone-grpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-proto"
-version = "1.15.0"
+version = "2.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Protobuf Definitions"


### PR DESCRIPTION
Bump version for crates.io. We can not publish with solana change `~1.18`  -> `~2.0` without doing a major version bump in gRPC crates.