### PR TITLE
geyser: add option `channel_capacity_filters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- geyser: add option `channel_capacity_filters` ([#432](https://github.com/rpcpool/yellowstone-grpc/pull/432))
+
 ### Breaking
 
 ## 2024-10-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- geyser: add option `channel_capacity_filters` ([#432](https://github.com/rpcpool/yellowstone-grpc/pull/432))
+- geyser: add option `channel_capacity_filters` ([#435](https://github.com/rpcpool/yellowstone-grpc/pull/435))
 
 ### Breaking
 

--- a/yellowstone-grpc-geyser/config.json
+++ b/yellowstone-grpc-geyser/config.json
@@ -21,6 +21,7 @@
         "snapshot_plugin_channel_capacity": null,
         "snapshot_client_channel_capacity": "50_000_000",
         "channel_capacity": "100_000",
+        "channel_capacity_filters": 10,
         "unary_concurrency_limit": 100,
         "unary_disabled": false,
         "x_token": null,

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -96,6 +96,12 @@ pub struct ConfigGrpc {
         deserialize_with = "deserialize_usize_str"
     )]
     pub channel_capacity: usize,
+    /// Capacity of the channel with new filters
+    #[serde(
+        default = "ConfigGrpc::channel_capacity_filters_default",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub channel_capacity_filters: usize,
     /// Concurrency limit for unary requests
     #[serde(
         default = "ConfigGrpc::unary_concurrency_limit_default",
@@ -127,6 +133,10 @@ impl ConfigGrpc {
 
     const fn channel_capacity_default() -> usize {
         250_000
+    }
+
+    const fn channel_capacity_filters_default() -> usize {
+        10
     }
 
     const fn unary_concurrency_limit_default() -> usize {


### PR DESCRIPTION
@Arrowana I think the plugin cased oom because we use unbounded channel for filters

client to reproduce an issue: https://github.com/rpcpool/yellowstone-grpc/commit/cf7793eedee9e4dea0cba4b37b539c22cffdc9aa