### PR TITLE
geyser: Add option to allow the injection of a root authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- geyser: Add option to allow the injection of a root authority ([#497](https://github.com/rpcpool/yellowstone-grpc/pull/497))
+- client: add `ca_certificate` option ([#497](https://github.com/rpcpool/yellowstone-grpc/pull/497))
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- geyser: Add option to allow the injection of a root authority ([#497](https://github.com/rpcpool/yellowstone-grpc/pull/497))
+
 ### Breaking
 
 ## 2024-12-15

--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -49,13 +49,13 @@ type BlocksMetaFilterMap = HashMap<String, SubscribeRequestFilterBlocksMeta>;
 #[derive(Debug, Clone, Parser)]
 #[clap(author, version, about)]
 struct Args {
-    /// Path of a certificate authority file
-    #[clap(long)]
-    ca_certificate: Option<PathBuf>,
-
     #[clap(short, long, default_value_t = String::from("http://127.0.0.1:10000"))]
     /// Service endpoint
     endpoint: String,
+
+    /// Path of a certificate authority file
+    #[clap(long)]
+    ca_certificate: Option<PathBuf>,
 
     #[clap(long)]
     x_token: Option<String>,
@@ -123,9 +123,9 @@ impl Args {
 
     async fn connect(&self) -> anyhow::Result<GeyserGrpcClient<impl Interceptor>> {
         let mut tls_config = ClientTlsConfig::new().with_native_roots();
-        if let Some(file_name) = &self.ca_certificate {
-            let contents = fs::read_to_string(file_name).await?;
-            tls_config = tls_config.ca_certificate(Certificate::from_pem(contents.as_bytes()));
+        if let Some(path) = &self.ca_certificate {
+            let bytes = fs::read(path).await?;
+            tls_config = tls_config.ca_certificate(Certificate::from_pem(bytes));
         }
         let mut builder = GeyserGrpcClient::build_from_shared(self.endpoint.clone())?
             .x_token(self.x_token.clone())?


### PR DESCRIPTION
The configuration file of the geyser plugin allows the addition of certificates but it is not currently possible to add a root authority in the Rust client.

https://github.com/rpcpool/yellowstone-grpc/blob/3192b5508d91b342a7e2a714df088efc72598558/yellowstone-grpc-geyser/config.json#L12-L15

For example, with the newly introduced parameter it is now possible to interact with self-made CAs.