### PR TITLE
Expose TLS Config as part of the client

### DIFF
--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -1,4 +1,6 @@
 pub use tonic::service::Interceptor;
+// Exposed publicly so client can configure TLS
+pub use tonic::transport::ClientTlsConfig;
 use {
     bytes::Bytes,
     futures::{
@@ -11,7 +13,7 @@ use {
         codec::{CompressionEncoding, Streaming},
         metadata::{errors::InvalidMetadataValue, AsciiMetadataValue},
         service::interceptor::InterceptedService,
-        transport::channel::{Channel, ClientTlsConfig, Endpoint},
+        transport::channel::{Channel, Endpoint},
         Request, Response, Status,
     },
     tonic_health::pb::{health_client::HealthClient, HealthCheckRequest, HealthCheckResponse},


### PR DESCRIPTION
I am getting:
```
Error: tonic::transport::Error(Transport, ConnectError(HttpsUriWithoutTlsSupport(())))
```

When using the latest gRPC client against an https endpoint. To fix this I need to specify a ClientTLSConfig, but I cannot because it's not exposed as part of the yellowstone-grpc-client. 

Relevant issue:
https://github.com/hyperium/tonic/issues/1817

Note:
For some reason, I do not get this error when using the 1.15 client. Only 2.0.0 and above.