### PR TITLE
Expose TLS Config as part of the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2025-01-13
+
+- yellowstone-grpc-client-4.1.1
+
+### Fixes
+
+- client: re-export `ClientTlsConfig` ([#512](https://github.com/rpcpool/yellowstone-grpc/pull/512))
+
 ## 2025-01-07
 
 - @triton-one/yellowstone-grpc@2.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5960,7 +5960,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
     "examples/rust", # 4.3.0
-    "yellowstone-grpc-client", # 4.1.0
+    "yellowstone-grpc-client", # 4.1.1
     "yellowstone-grpc-geyser", # 4.2.2
     "yellowstone-grpc-proto", # 4.1.1
 ]

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "4.1.0"
+version = "4.1.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Simple Client"

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -1,4 +1,4 @@
-pub use tonic::service::Interceptor;
+pub use tonic::{service::Interceptor, transport::ClientTlsConfig};
 use {
     bytes::Bytes,
     futures::{
@@ -11,7 +11,7 @@ use {
         codec::{CompressionEncoding, Streaming},
         metadata::{errors::InvalidMetadataValue, AsciiMetadataValue, MetadataValue},
         service::interceptor::InterceptedService,
-        transport::channel::{Channel, ClientTlsConfig, Endpoint},
+        transport::channel::{Channel, Endpoint},
         Request, Response, Status,
     },
     tonic_health::pb::{health_client::HealthClient, HealthCheckRequest, HealthCheckResponse},


### PR DESCRIPTION
I am getting:
```
Error: tonic::transport::Error(Transport, ConnectError(HttpsUriWithoutTlsSupport(())))
```
When using the latest gRPC client against an https endpoint. To fix this I need to specify a ClientTLSConfig, but I cannot because it's not exposed as part of the yellowstone-grpc-client.

Relevant issue:
https://github.com/hyperium/tonic/issues/1817

Note:
For some reason, I do not get this error when using the 1.15 client. Only 2.0.0 and above.