### PR TITLE
export typedefs

### DIFF
--- a/yellowstone-grpc-client-nodejs/package.json
+++ b/yellowstone-grpc-client-nodejs/package.json
@@ -46,7 +46,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   }
 }


### PR DESCRIPTION
Currently, the typedefs in the `@triton-one/yellowstone-grpc` npm package are inaccessible in some project configurations:

```
Could not find a declaration file for module '@triton-one/yellowstone-grpc'. '/project/node_modules/@triton-one/yellowstone-grpc/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/project/node_modules/@triton-one/yellowstone-grpc/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@triton-one/yellowstone-grpc' library may need to update its package.json or typings.
```

This PR adds the typedefs to the export section in package.json.