### PR TITLE
geyser: string to u64 dserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
-## 2025-02-26
+## 2025-02-28
 
-- yellowstone-grpc-geyser-5.0.0
+- yellowstone-grpc-geyser-5.0.1
 
 ### Fixes
 
-- geyser: add `string` to `u64` deserializer for config param `replay_stored_slots` ([#541](https://github.com/rpcpool/yellowstone-grpc/pull/541))
+- geyser: deserialize config param `replay_stored_slots` from the `String` ([#541](https://github.com/rpcpool/yellowstone-grpc/pull/541))
 
 ## 2025-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2025-02-26
+
+- yellowstone-grpc-geyser-5.0.0
+
+### Fixes
+
+- geyser: add `string` to `u64` deserializer for config param `replay_stored_slots` ([#541](https://github.com/rpcpool/yellowstone-grpc/pull/541))
+
 ## 2025-02-06
 
 - @triton-one/yellowstone-grpc@3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5998,7 +5998,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "examples/rust", # 5.0.0
     "yellowstone-grpc-client", # 5.0.0
-    "yellowstone-grpc-geyser", # 5.0.0
+    "yellowstone-grpc-geyser", # 5.0.1
     "yellowstone-grpc-proto", # 5.0.0
 ]
 exclude = [

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "5.0.0"
+version = "5.0.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -3,7 +3,10 @@ use {
         GeyserPluginError, Result as PluginResult,
     },
     serde::{de, Deserialize, Deserializer},
-    std::{collections::HashSet, fs::read_to_string, net::SocketAddr, path::Path, time::Duration},
+    std::{
+        collections::HashSet, fmt, fs::read_to_string, net::SocketAddr, path::Path, str::FromStr,
+        time::Duration,
+    },
     tokio::sync::Semaphore,
     tonic::codec::CompressionEncoding,
     yellowstone_grpc_proto::plugin::filter::limits::FilterLimits,
@@ -141,32 +144,32 @@ pub struct ConfigGrpc {
     /// Limits the maximum size of a decoded message, default is 4MiB
     #[serde(
         default = "ConfigGrpc::max_decoding_message_size_default",
-        deserialize_with = "deserialize_usize_str"
+        deserialize_with = "deserialize_int_str"
     )]
     pub max_decoding_message_size: usize,
     /// Capacity of the channel used for accounts from snapshot,
     /// on reaching the limit Sender block validator startup.
     #[serde(
         default = "ConfigGrpc::snapshot_plugin_channel_capacity_default",
-        deserialize_with = "deserialize_usize_str_maybe"
+        deserialize_with = "deserialize_int_str_maybe"
     )]
     pub snapshot_plugin_channel_capacity: Option<usize>,
     /// Capacity of the client channel, applicable only with snapshot
     #[serde(
         default = "ConfigGrpc::snapshot_client_channel_capacity_default",
-        deserialize_with = "deserialize_usize_str"
+        deserialize_with = "deserialize_int_str"
     )]
     pub snapshot_client_channel_capacity: usize,
     /// Capacity of the channel per connection
     #[serde(
         default = "ConfigGrpc::channel_capacity_default",
-        deserialize_with = "deserialize_usize_str"
+        deserialize_with = "deserialize_int_str"
     )]
     pub channel_capacity: usize,
     /// Concurrency limit for unary requests
     #[serde(
         default = "ConfigGrpc::unary_concurrency_limit_default",
-        deserialize_with = "deserialize_usize_str"
+        deserialize_with = "deserialize_int_str"
     )]
     pub unary_concurrency_limit: usize,
     /// Enable/disable unary methods
@@ -192,7 +195,7 @@ pub struct ConfigGrpc {
     /// Number of slots stored for re-broadcast (replay)
     #[serde(
         default = "ConfigGrpc::default_replay_stored_slots",
-        deserialize_with = "deserialize_u64_str"
+        deserialize_with = "deserialize_int_str"
     )]
     pub replay_stored_slots: u64,
     #[serde(default)]
@@ -309,55 +312,39 @@ pub struct ConfigPrometheus {
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum ValueIntStr<'a> {
-    Int(usize),
+enum ValueIntStr<'a, T> {
+    Int(T),
     Str(&'a str),
 }
 
-fn deserialize_usize_str<'de, D>(deserializer: D) -> Result<usize, D::Error>
+fn deserialize_int_str<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: fmt::Display,
 {
-    match ValueIntStr::deserialize(deserializer)? {
+    match ValueIntStr::<T>::deserialize(deserializer)? {
         ValueIntStr::Int(value) => Ok(value),
         ValueIntStr::Str(value) => value
             .replace('_', "")
-            .parse::<usize>()
+            .parse::<T>()
             .map_err(de::Error::custom),
     }
 }
 
-fn deserialize_usize_str_maybe<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+fn deserialize_int_str_maybe<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     D: Deserializer<'de>,
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: fmt::Display,
 {
-    match Option::<ValueIntStr>::deserialize(deserializer)? {
+    match Option::<ValueIntStr<T>>::deserialize(deserializer)? {
         Some(ValueIntStr::Int(value)) => Ok(Some(value)),
         Some(ValueIntStr::Str(value)) => value
             .replace('_', "")
-            .parse::<usize>()
+            .parse::<T>()
             .map(Some)
             .map_err(de::Error::custom),
         None => Ok(None),
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum ValueU64Str<'a> {
-    Int(u64),
-    Str(&'a str),
-}
-
-fn deserialize_u64_str<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    match ValueU64Str::deserialize(deserializer)? {
-        ValueU64Str::Int(value) => Ok(value),
-        ValueU64Str::Str(value) => value
-            .replace('_', "")
-            .parse::<u64>()
-            .map_err(de::Error::custom),
     }
 }

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -190,7 +190,10 @@ pub struct ConfigGrpc {
     )]
     pub filter_names_cleanup_interval: Duration,
     /// Number of slots stored for re-broadcast (replay)
-    #[serde(default = "ConfigGrpc::default_replay_stored_slots", deserialize_with = "deserialize_u64_str")]
+    #[serde(
+        default = "ConfigGrpc::default_replay_stored_slots",
+        deserialize_with = "deserialize_u64_str"
+    )]
     pub replay_stored_slots: u64,
     #[serde(default)]
     pub server_http2_adaptive_window: Option<bool>,
@@ -358,4 +361,3 @@ where
             .map_err(de::Error::custom),
     }
 }
-


### PR DESCRIPTION
The param `replay_stored_slots` is of type `u64`. This PR adds a string to u64 deserializer to it.

fixes #542 