### PR TITLE
fix: Slot update message now handles levels missing from CommitmentLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2025-03-17
+
+- yellowstone-grpc-client-simple-6.0.1
+
+### Fixes
+
+- client: fix `SlotStatus` ([#557](https://github.com/rpcpool/yellowstone-grpc/pull/557))
+
 ## 2025-03-10
 
 - @triton-one/yellowstone-grpc@4.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client-simple"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
-    "examples/rust", # 6.0.0
+    "examples/rust", # 6.0.1
     "yellowstone-grpc-client", # 6.0.0
     "yellowstone-grpc-geyser", # 6.0.0
     "yellowstone-grpc-proto", # 6.0.0

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client-simple"
-version = "6.0.0"
+version = "6.0.1"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -21,6 +21,7 @@ use {
     yellowstone_grpc_client::{GeyserGrpcClient, GeyserGrpcClientError, Interceptor},
     yellowstone_grpc_proto::{
         convert_from,
+        geyser::SlotStatus,
         plugin::filter::message::FilteredUpdate,
         prelude::{
             subscribe_request_filter_accounts_filter::Filter as AccountsFilterOneof,
@@ -777,7 +778,7 @@ async fn geyser_subscribe(
                         print_update("account", created_at, &filters, value);
                     }
                     Some(UpdateOneof::Slot(msg)) => {
-                        let status = CommitmentLevel::try_from(msg.status)
+                        let status = SlotStatus::try_from(msg.status)
                             .context("failed to decode commitment")?;
                         print_update(
                             "slot",


### PR DESCRIPTION
In the Rust example, subscribing to slot updates sometimes misses updates with certain commitment levels.  This leads to errors and unnecessary reconnections, a process that repeats continuously. This issue should be fixed.