### PR TITLE
Experimental perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ __pycache__/
 
 # Configs
 yellowstone-grpc-geyser/config-test.json
+
+# Local development files
+.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "6.0.0"
+version = "6.0.0-pr560+solana2.2.1"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "6.0.0"
+version = "6.0.0+solana2.2.1+pr560"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "6.0.0+solana2.2.1+pr560"
+version = "6.0.0-pr560+solana2.2.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -508,7 +508,7 @@ impl GrpcService {
     }
 
     async fn geyser_loop(
-        mut geyser_rx: crossbeam_channel::Receiver<Message>,
+        geyser_rx: crossbeam_channel::Receiver<Message>,
         blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
     ) {

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -12,10 +12,13 @@ use {
         pubkey::Pubkey,
     },
     std::{
-        collections::{BTreeMap, HashMap}, str::FromStr, sync::{
+        collections::{BTreeMap, HashMap},
+        str::FromStr,
+        sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
-        }, time::SystemTime
+        },
+        time::SystemTime,
     },
     tokio::{
         fs,
@@ -820,8 +823,8 @@ impl GrpcService {
                     }
                     let _ = tx.send(ReplayedResponse::Messages(replayed_messages));
                 }
-            }    
-            
+            }
+
             let elapsed = t.elapsed();
             let micro: u64 = elapsed.as_micros().try_into().unwrap_or(u64::MAX);
             metrics::observe_geyser_loop_duration(micro);
@@ -1093,7 +1096,8 @@ impl Geyser for GrpcService {
             None
         };
 
-        let x_subscription_id = request.metadata()
+        let x_subscription_id = request
+            .metadata()
             .get("x-subscription-id")
             .and_then(|ascii| ascii.to_str().ok())
             .map(String::from_str)

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -12,12 +12,16 @@ use {
         server::conn::auto::Builder as ServerBuilder,
     },
     log::{error, info},
-    prometheus::{Histogram, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder},
+    prometheus::{
+        Histogram, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+        Registry, TextEncoder,
+    },
     solana_sdk::clock::Slot,
     std::{
         collections::{hash_map::Entry as HashMapEntry, HashMap},
         convert::Infallible,
-        sync::{Arc, Once}, time::Duration,
+        sync::{Arc, Once},
+        time::Duration,
     },
     tokio::{
         net::TcpListener,

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -333,7 +333,7 @@ fn not_found_handler() -> http::Result<Response<BoxBody<Bytes, Infallible>>> {
 pub fn observe_filter_update_duration(subscription_id: impl AsRef<str>, duration: Duration) {
     let duration = duration.as_millis() as f64;
     FILTER_UPDATE_DURATION_VEC
-        .with_label_values(&[&subscription_id.as_ref()])
+        .with_label_values(&[subscription_id.as_ref()])
         .observe(duration);
 }
 

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -26,19 +26,36 @@ use {
     },
 };
 
+///
+/// Crossbean bounded channel is a implemented as a ring buffer with a fixed size.
+///
+/// The capacity of the channel is 2^23 "slots".
+///
+/// Each slot contains header + data
+/// header size is 64 bytes (AtomicUSize),
+/// WE NEED TO MAKE THE DATA ALLIGNED TO 64 BYTES TOO.
+/// SO MAKE SURE THE MESSAGE STRUCT NEVER EXCEED 64 BYTES!
+///
+/// By doing so, each "Slot" is 128 bytes (contiguous) which is equal to two cacheline for x86_64 CPU.
+/// Since Slot is 128 of contiguous memory, CPU can prefetch the next cachine (bytes 64..128)
+///
+/// 2^23 * 128 bytes ~ 1GB of pre-allocated channel capacity
+/// Since each slot is 128 bytes, we can 32 slots in a single OS page (4KB)
+const GEYSER_CHANNEL_SIZE: usize = 2 ^ 23;
+
 #[derive(Debug)]
 pub struct PluginInner {
     runtime: Runtime,
     snapshot_channel: Mutex<Option<crossbeam_channel::Sender<Box<Message>>>>,
     snapshot_channel_closed: AtomicBool,
-    grpc_channel: mpsc::UnboundedSender<Message>,
+    geyser_channel: crossbeam_channel::Sender<Message>,
     grpc_shutdown: Arc<Notify>,
     prometheus: PrometheusService,
 }
 
 impl PluginInner {
     fn send_message(&self, message: Message) {
-        if self.grpc_channel.send(message).is_ok() {
+        if self.geyser_channel.send(message).is_ok() {
             metrics::message_queue_size_inc();
         }
     }
@@ -86,6 +103,7 @@ impl GeyserPlugin for Plugin {
             .build()
             .map_err(|error| GeyserPluginError::Custom(Box::new(error)))?;
 
+        let (geyser_tx, geyser_rx) = crossbeam_channel::bounded(GEYSER_CHANNEL_SIZE);
         let (snapshot_channel, grpc_channel, grpc_shutdown, prometheus) =
             runtime.block_on(async move {
                 let (debug_client_tx, debug_client_rx) = mpsc::unbounded_channel();
@@ -94,6 +112,7 @@ impl GeyserPlugin for Plugin {
                     config.grpc,
                     config.debug_clients_http.then_some(debug_client_tx),
                     is_reload,
+                    geyser_rx,
                 )
                 .await
                 .map_err(|error| GeyserPluginError::Custom(format!("{error:?}").into()))?;
@@ -115,6 +134,7 @@ impl GeyserPlugin for Plugin {
             runtime,
             snapshot_channel: Mutex::new(snapshot_channel),
             snapshot_channel_closed: AtomicBool::new(false),
+            geyser_channel: geyser_tx,
             grpc_channel,
             grpc_shutdown,
             prometheus,
@@ -126,7 +146,7 @@ impl GeyserPlugin for Plugin {
     fn on_unload(&mut self) {
         if let Some(inner) = self.inner.take() {
             inner.grpc_shutdown.notify_one();
-            drop(inner.grpc_channel);
+            drop(inner.geyser_channel);
             inner.prometheus.shutdown();
             inner.runtime.shutdown_timeout(Duration::from_secs(30));
         }

--- a/yellowstone-grpc-proto/benches/encode.rs
+++ b/yellowstone-grpc-proto/benches/encode.rs
@@ -54,7 +54,6 @@ fn bench_account(c: &mut Criterion) {
             message: FilteredUpdateOneof::transaction(&MessageTransaction {
                 transaction,
                 slot: 42,
-                created_at: Timestamp::from(SystemTime::now()),
             }),
             created_at: Timestamp::from(SystemTime::now()),
         })

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -1109,7 +1109,6 @@ mod tests {
                 message::{Message, MessageTransaction, MessageTransactionInfo},
             },
         },
-        prost_types::Timestamp,
         solana_sdk::{
             hash::Hash,
             message::{v0::LoadedAddresses, Message as SolMessage, MessageHeader},
@@ -1118,11 +1117,7 @@ mod tests {
             transaction::{SanitizedTransaction, Transaction},
         },
         solana_transaction_status::TransactionStatusMeta,
-        std::{
-            collections::HashMap,
-            sync::Arc,
-            time::{Duration, SystemTime},
-        },
+        std::{collections::HashMap, sync::Arc, time::Duration},
     };
 
     fn create_filter_names() -> FilterNames {

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -75,24 +75,24 @@ pub enum FilterError {
 pub type FilterResult<T> = Result<T, FilterError>;
 
 macro_rules! filtered_updates_once_owned {
-    ($filters:ident, $message:expr, $created_at:expr) => {{
+    ($filters:ident, $message:expr) => {{
         let mut messages = FilteredUpdates::new();
         if !$filters.is_empty() {
-            messages.push(FilteredUpdate::new($filters, $message, $created_at));
+            messages.push(FilteredUpdate::new($filters, $message));
         }
         messages
     }};
 }
 
 macro_rules! filtered_updates_once_ref {
-    ($filters:ident, $message:expr, $created_at:expr) => {{
+    ($filters:ident, $message:expr) => {{
         let mut messages = FilteredUpdates::new();
         if !$filters.is_empty() {
             let mut message_filters = FilteredUpdateFilters::new();
             for filter in $filters {
                 message_filters.push(filter.clone());
             }
-            messages.push(FilteredUpdate::new(message_filters, $message, $created_at));
+            messages.push(FilteredUpdate::new(message_filters, $message));
         }
         messages
     }};
@@ -349,8 +349,7 @@ impl FilterAccounts {
         let filters = filter.get_filters();
         filtered_updates_once_owned!(
             filters,
-            FilteredUpdateOneof::account(message, accounts_data_slice.clone()),
-            message.created_at
+            FilteredUpdateOneof::account(message, accounts_data_slice.clone())
         )
     }
 }
@@ -653,11 +652,7 @@ impl FilterSlots {
                 }
             })
             .collect::<FilteredUpdateFilters>();
-        filtered_updates_once_owned!(
-            filters,
-            FilteredUpdateOneof::slot(message.clone()),
-            message.created_at
-        )
+        filtered_updates_once_owned!(filters, FilteredUpdateOneof::slot(message.clone()))
     }
 }
 
@@ -811,8 +806,7 @@ impl FilterTransactions {
                 FilterTransactionsType::TransactionStatus => {
                     FilteredUpdateOneof::transaction_status(message)
                 }
-            },
-            message.created_at
+            }
         )
     }
 }
@@ -840,11 +834,7 @@ impl FilterEntries {
 
     fn get_updates(&self, message: &Arc<MessageEntry>) -> FilteredUpdates {
         let filters = self.filters.as_slice();
-        filtered_updates_once_ref!(
-            filters,
-            FilteredUpdateOneof::entry(Arc::clone(message)),
-            message.created_at
-        )
+        filtered_updates_once_ref!(filters, FilteredUpdateOneof::entry(Arc::clone(message)))
     }
 }
 
@@ -972,7 +962,6 @@ impl FilterBlocks {
                     accounts,
                     entries,
                 })),
-                message.created_at,
             ));
         }
         updates
@@ -1004,8 +993,7 @@ impl FilterBlocksMeta {
         let filters = self.filters.as_slice();
         filtered_updates_once_ref!(
             filters,
-            FilteredUpdateOneof::block_meta(Arc::clone(message)),
-            message.created_at
+            FilteredUpdateOneof::block_meta(Arc::clone(message))
         )
     }
 }
@@ -1188,7 +1176,6 @@ mod tests {
                 account_keys,
             }),
             slot: 100,
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 

--- a/yellowstone-grpc-proto/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/message.rs
@@ -105,24 +105,16 @@ impl prost::Message for FilteredUpdate {
 }
 
 impl FilteredUpdate {
-    pub const fn new(
-        filters: FilteredUpdateFilters,
-        message: FilteredUpdateOneof,
-        created_at: Timestamp,
-    ) -> Self {
+    pub fn new(filters: FilteredUpdateFilters, message: FilteredUpdateOneof) -> Self {
         Self {
             filters,
             message,
-            created_at,
+            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
     pub fn new_empty(message: FilteredUpdateOneof) -> Self {
-        Self::new(
-            FilteredUpdateFilters::new(),
-            message,
-            Timestamp::from(SystemTime::now()),
-        )
+        Self::new(FilteredUpdateFilters::new(), message)
     }
 
     fn as_subscribe_update_account(
@@ -250,7 +242,7 @@ impl FilteredUpdate {
 
         let message = match update.update_oneof.ok_or("update should be defined")? {
             UpdateOneof::Account(msg) => {
-                let account = MessageAccount::from_update_oneof(msg, created_at)?;
+                let account = MessageAccount::from_update_oneof(msg)?;
                 FilteredUpdateOneof::Account(FilteredUpdateAccount {
                     account: account.account,
                     slot: account.slot,
@@ -263,7 +255,7 @@ impl FilteredUpdate {
                 FilteredUpdateOneof::Slot(FilteredUpdateSlot(slot))
             }
             UpdateOneof::Transaction(msg) => {
-                let tx = MessageTransaction::from_update_oneof(msg, created_at)?;
+                let tx = MessageTransaction::from_update_oneof(msg)?;
                 FilteredUpdateOneof::Transaction(FilteredUpdateTransaction {
                     transaction: tx.transaction,
                     slot: tx.slot,
@@ -300,11 +292,11 @@ impl FilteredUpdate {
             UpdateOneof::Ping(_) => FilteredUpdateOneof::Ping,
             UpdateOneof::Pong(msg) => FilteredUpdateOneof::Pong(msg),
             UpdateOneof::BlockMeta(msg) => {
-                let block_meta = MessageBlockMeta::from_update_oneof(msg, created_at);
+                let block_meta = MessageBlockMeta::from_update_oneof(msg);
                 FilteredUpdateOneof::BlockMeta(Arc::new(block_meta))
             }
             UpdateOneof::Entry(msg) => {
-                let entry = MessageEntry::from_update_oneof(&msg, created_at)?;
+                let entry = MessageEntry::from_update_oneof(&msg)?;
                 FilteredUpdateOneof::Entry(FilteredUpdateEntry(Arc::new(entry)))
             }
         };
@@ -1080,7 +1072,6 @@ pub mod tests {
                             account: Arc::clone(&account),
                             slot,
                             is_startup,
-                            created_at: Timestamp::from(SystemTime::now()),
                         };
                         vec.push((msg, data_slice));
                     }
@@ -1099,7 +1090,6 @@ pub mod tests {
                 hash: Hash::new_from_array([98; 32]),
                 executed_transaction_count: 32,
                 starting_transaction_index: 1000,
-                created_at: Timestamp::from(SystemTime::now()),
             },
             MessageEntry {
                 slot: 299888121,
@@ -1108,7 +1098,6 @@ pub mod tests {
                 hash: Hash::new_from_array([42; 32]),
                 executed_transaction_count: 32,
                 starting_transaction_index: 1000,
-                created_at: Timestamp::from(SystemTime::now()),
             },
         ]
         .into_iter()
@@ -1198,7 +1187,6 @@ pub mod tests {
                         executed_transaction_count: transactions.len() as u64,
                         entries_count: entries.len() as u64,
                     },
-                    created_at: Timestamp::from(SystemTime::now()),
                 };
                 let mut block_meta2 = block_meta1.clone();
                 block_meta2.rewards =
@@ -1280,7 +1268,6 @@ pub mod tests {
                             parent,
                             status,
                             dead_error: None,
-                            created_at: Timestamp::from(SystemTime::now()),
                         }),
                     )
                 }
@@ -1291,7 +1278,6 @@ pub mod tests {
                         parent,
                         status: SlotStatus::Dead,
                         dead_error: Some("123".to_owned()),
-                        created_at: Timestamp::from(SystemTime::now()),
                     }),
                 )
             }
@@ -1304,7 +1290,6 @@ pub mod tests {
             let msg = MessageTransaction {
                 transaction,
                 slot: 42,
-                created_at: Timestamp::from(SystemTime::now()),
             };
             encode_decode_cmp(&["123"], FilteredUpdateOneof::transaction(&msg));
             encode_decode_cmp(&["123"], FilteredUpdateOneof::transaction_status(&msg));

--- a/yellowstone-grpc-proto/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/message.rs
@@ -251,7 +251,7 @@ impl FilteredUpdate {
                 })
             }
             UpdateOneof::Slot(msg) => {
-                let slot = MessageSlot::from_update_oneof(&msg, created_at)?;
+                let slot = MessageSlot::from_update_oneof(&msg)?;
                 FilteredUpdateOneof::Slot(FilteredUpdateSlot(slot))
             }
             UpdateOneof::Transaction(msg) => {
@@ -279,7 +279,7 @@ impl FilteredUpdate {
                 })
             }
             UpdateOneof::Block(msg) => {
-                let block = MessageBlock::from_update_oneof(msg, created_at)?;
+                let block = MessageBlock::from_update_oneof(msg)?;
                 FilteredUpdateOneof::Block(Box::new(FilteredUpdateBlock {
                     meta: block.meta,
                     transactions: block.transactions,

--- a/yellowstone-grpc-proto/src/plugin/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/message.rs
@@ -151,7 +151,6 @@ pub struct MessageSlot {
     pub parent: Option<Slot>,
     pub status: SlotStatus,
     pub dead_error: Option<String>,
-    pub created_at: Timestamp,
 }
 
 impl MessageSlot {
@@ -165,7 +164,6 @@ impl MessageSlot {
             } else {
                 None
             },
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
@@ -180,7 +178,6 @@ impl MessageSlot {
                 .map_err(|_| "failed to parse slot status")?
                 .into(),
             dead_error: msg.dead_error.clone(),
-            created_at,
         })
     }
 }
@@ -235,7 +232,6 @@ pub struct MessageAccount {
     pub account: Arc<MessageAccountInfo>,
     pub slot: Slot,
     pub is_startup: bool,
-    pub created_at: Timestamp,
 }
 
 impl MessageAccount {
@@ -244,21 +240,16 @@ impl MessageAccount {
             account: Arc::new(MessageAccountInfo::from_geyser(info)),
             slot,
             is_startup,
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
-    pub fn from_update_oneof(
-        msg: SubscribeUpdateAccount,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
+    pub fn from_update_oneof(msg: SubscribeUpdateAccount) -> FromUpdateOneofResult<Self> {
         Ok(Self {
             account: Arc::new(MessageAccountInfo::from_update_oneof(
                 msg.account.ok_or("account message should be defined")?,
             )?),
             slot: msg.slot,
             is_startup: msg.is_startup,
-            created_at,
         })
     }
 }
@@ -343,7 +334,6 @@ impl MessageTransactionInfo {
 pub struct MessageTransaction {
     pub transaction: Arc<MessageTransactionInfo>,
     pub slot: u64,
-    pub created_at: Timestamp,
 }
 
 impl MessageTransaction {
@@ -351,21 +341,16 @@ impl MessageTransaction {
         Self {
             transaction: Arc::new(MessageTransactionInfo::from_geyser(info)),
             slot,
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
-    pub fn from_update_oneof(
-        msg: SubscribeUpdateTransaction,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
+    pub fn from_update_oneof(msg: SubscribeUpdateTransaction) -> FromUpdateOneofResult<Self> {
         Ok(Self {
             transaction: Arc::new(MessageTransactionInfo::from_update_oneof(
                 msg.transaction
                     .ok_or("transaction message should be defined")?,
             )?),
             slot: msg.slot,
-            created_at,
         })
     }
 }
@@ -378,7 +363,6 @@ pub struct MessageEntry {
     pub hash: Hash,
     pub executed_transaction_count: u64,
     pub starting_transaction_index: u64,
-    pub created_at: Timestamp,
 }
 
 impl MessageEntry {
@@ -393,14 +377,10 @@ impl MessageEntry {
                 .starting_transaction_index
                 .try_into()
                 .expect("failed convert usize to u64"),
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
-    pub fn from_update_oneof(
-        msg: &SubscribeUpdateEntry,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
+    pub fn from_update_oneof(msg: &SubscribeUpdateEntry) -> FromUpdateOneofResult<Self> {
         Ok(Self {
             slot: msg.slot,
             index: msg.index as usize,
@@ -411,7 +391,6 @@ impl MessageEntry {
             ),
             executed_transaction_count: msg.executed_transaction_count,
             starting_transaction_index: msg.starting_transaction_index,
-            created_at,
         })
     }
 }
@@ -419,7 +398,6 @@ impl MessageEntry {
 #[derive(Debug, Clone, PartialEq)]
 pub struct MessageBlockMeta {
     pub block_meta: SubscribeUpdateBlockMeta,
-    pub created_at: Timestamp,
 }
 
 impl Deref for MessageBlockMeta {
@@ -453,18 +431,11 @@ impl MessageBlockMeta {
                 executed_transaction_count: info.executed_transaction_count,
                 entries_count: info.entry_count,
             },
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
-    pub const fn from_update_oneof(
-        block_meta: SubscribeUpdateBlockMeta,
-        created_at: Timestamp,
-    ) -> Self {
-        Self {
-            block_meta,
-            created_at,
-        }
+    pub const fn from_update_oneof(block_meta: SubscribeUpdateBlockMeta) -> Self {
+        Self { block_meta }
     }
 }
 
@@ -475,7 +446,6 @@ pub struct MessageBlock {
     pub updated_account_count: u64,
     pub accounts: Vec<Arc<MessageAccountInfo>>,
     pub entries: Vec<Arc<MessageEntry>>,
-    pub created_at: Timestamp,
 }
 
 impl MessageBlock {
@@ -491,7 +461,6 @@ impl MessageBlock {
             updated_account_count: accounts.len() as u64,
             accounts,
             entries,
-            created_at: Timestamp::from(SystemTime::now()),
         }
     }
 
@@ -512,7 +481,6 @@ impl MessageBlock {
                     executed_transaction_count: msg.executed_transaction_count,
                     entries_count: msg.entries_count,
                 },
-                created_at,
             }),
             transactions: msg
                 .transactions
@@ -528,14 +496,14 @@ impl MessageBlock {
             entries: msg
                 .entries
                 .iter()
-                .map(|entry| MessageEntry::from_update_oneof(entry, created_at).map(Arc::new))
+                .map(|entry| MessageEntry::from_update_oneof(entry).map(Arc::new))
                 .collect::<Result<Vec<_>, _>>()?,
-            created_at,
         })
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[repr(align(64))] // Message is currently 56 bytes in size, so aligning to 64 bytes so it fits in a cache line
 pub enum Message {
     Slot(MessageSlot),
     Account(MessageAccount),
@@ -562,12 +530,10 @@ impl Message {
         created_at: Timestamp,
     ) -> FromUpdateOneofResult<Self> {
         Ok(match oneof {
-            UpdateOneof::Account(msg) => {
-                Self::Account(MessageAccount::from_update_oneof(msg, created_at)?)
-            }
+            UpdateOneof::Account(msg) => Self::Account(MessageAccount::from_update_oneof(msg)?),
             UpdateOneof::Slot(msg) => Self::Slot(MessageSlot::from_update_oneof(&msg, created_at)?),
             UpdateOneof::Transaction(msg) => {
-                Self::Transaction(MessageTransaction::from_update_oneof(msg, created_at)?)
+                Self::Transaction(MessageTransaction::from_update_oneof(msg)?)
             }
             UpdateOneof::TransactionStatus(_) => {
                 return Err("TransactionStatus message is not supported")
@@ -577,11 +543,11 @@ impl Message {
             }
             UpdateOneof::Ping(_) => return Err("Ping message is not supported"),
             UpdateOneof::Pong(_) => return Err("Pong message is not supported"),
-            UpdateOneof::BlockMeta(msg) => Self::BlockMeta(Arc::new(
-                MessageBlockMeta::from_update_oneof(msg, created_at),
-            )),
+            UpdateOneof::BlockMeta(msg) => {
+                Self::BlockMeta(Arc::new(MessageBlockMeta::from_update_oneof(msg)))
+            }
             UpdateOneof::Entry(msg) => {
-                Self::Entry(Arc::new(MessageEntry::from_update_oneof(&msg, created_at)?))
+                Self::Entry(Arc::new(MessageEntry::from_update_oneof(&msg)?))
             }
         })
     }

--- a/yellowstone-grpc-proto/src/plugin/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/message.rs
@@ -13,7 +13,6 @@ use {
         ReplicaAccountInfoV3, ReplicaBlockInfoV4, ReplicaEntryInfoV2, ReplicaTransactionInfoV2,
         SlotStatus as GeyserSlotStatus,
     },
-    prost_types::Timestamp,
     solana_sdk::{
         clock::Slot,
         hash::{Hash, HASH_BYTES},
@@ -24,7 +23,6 @@ use {
         collections::HashSet,
         ops::{Deref, DerefMut},
         sync::Arc,
-        time::SystemTime,
     },
 };
 
@@ -167,10 +165,7 @@ impl MessageSlot {
         }
     }
 
-    pub fn from_update_oneof(
-        msg: &SubscribeUpdateSlot,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
+    pub fn from_update_oneof(msg: &SubscribeUpdateSlot) -> FromUpdateOneofResult<Self> {
         Ok(Self {
             slot: msg.slot,
             parent: msg.parent,
@@ -464,10 +459,7 @@ impl MessageBlock {
         }
     }
 
-    pub fn from_update_oneof(
-        msg: SubscribeUpdateBlock,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
+    pub fn from_update_oneof(msg: SubscribeUpdateBlock) -> FromUpdateOneofResult<Self> {
         Ok(Self {
             meta: Arc::new(MessageBlockMeta {
                 block_meta: SubscribeUpdateBlockMeta {
@@ -524,22 +516,17 @@ impl Message {
         }
     }
 
-    pub fn from_update_oneof(
-        oneof: UpdateOneof,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
+    pub fn from_update_oneof(oneof: UpdateOneof) -> FromUpdateOneofResult<Self> {
         Ok(match oneof {
             UpdateOneof::Account(msg) => Self::Account(MessageAccount::from_update_oneof(msg)?),
-            UpdateOneof::Slot(msg) => Self::Slot(MessageSlot::from_update_oneof(&msg, created_at)?),
+            UpdateOneof::Slot(msg) => Self::Slot(MessageSlot::from_update_oneof(&msg)?),
             UpdateOneof::Transaction(msg) => {
                 Self::Transaction(MessageTransaction::from_update_oneof(msg)?)
             }
             UpdateOneof::TransactionStatus(_) => {
                 return Err("TransactionStatus message is not supported")
             }
-            UpdateOneof::Block(msg) => {
-                Self::Block(Arc::new(MessageBlock::from_update_oneof(msg, created_at)?))
-            }
+            UpdateOneof::Block(msg) => Self::Block(Arc::new(MessageBlock::from_update_oneof(msg)?)),
             UpdateOneof::Ping(_) => return Err("Ping message is not supported"),
             UpdateOneof::Pong(_) => return Err("Pong message is not supported"),
             UpdateOneof::BlockMeta(msg) => {

--- a/yellowstone-grpc-proto/src/plugin/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/message.rs
@@ -503,7 +503,6 @@ impl MessageBlock {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-#[repr(align(64))] // Message is currently 56 bytes in size, so aligning to 64 bytes so it fits in a cache line
 pub enum Message {
     Slot(MessageSlot),
     Account(MessageAccount),


### PR DESCRIPTION
I removed all `timestamp` field from each `Message` variants.
Why? Because `Message` enum used to weight 72 bytes and the timestamp fields alone was 16 bytes.

When `Message` weights `72` bytes, the message cannot fit into one cache-line.
By removing the timestamp field, the `Message` enum size becomes `56` bytes.

This is really important because modern CPU memory fetching works in cache-line granularity. By making sure `Message` is `<= 64 bytes` we make sure that each `Message` does not need additional round-trip to memory.

Inside tight loops, when CPU pre-fetching kicks in, we will benefits from the fact that Latest Skylake Intel and AMD CPU can pre-fetch 128 bytes at a time (two cache-line).


Instead of using tokio's `mspc::UnboundedSender` in between the agave world and the `PluginInner`, I switched to a crossbeam.

Why?

Tokio's channel is fast but is implemented using linked-list of fixed size "arrays" of length `32` called `Block`.  
Here's a [link to tokio block capacity](https://github.com/tokio-rs/tokio/blob/0ec4d0db4d24af74cea40cf0ceed6b7a0a5ff183/tokio/src/sync/mpsc/mod.rs#L138)

The `Block` data is contiguous in-memory, not the linked list of `Block`.
Linked-list data structure creates higher chances of "cache-miss" inside the CPU.

Unlike Tokio, crossbeam `bounded` channel is a fixed array size of contiguous memory: minimising cache miss and maximising  OS page utilization.

Crossbeam `bounded` channel is an array of `Slot`, each slot is :
```rust
pub struct Slot<T> {
  header: AtomicUsize,
  data: UnsafeCell<MaybeUninit<T>>
}
```
the `data` field size is the same as `T` and has the same alignment as `T`.
As for `AtomicUsize`, its size is `8` bytes, making `Slot<Message>` weigh `64 bytes` total.
Perfectly fit in one cache-line exactly.

Since `Slot` are contiguous in physical memory, inside tight-loop we will be able to leverage `cache-prefetching` that is available in all modern CPU.

