### PR TITLE
fix: resolve Windows compilation issues for protobuf-src

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ prometheus = "0.13.2"
 prost = "~0.14.0"
 prost-types = "~0.14.0"
 prost_011 = { package = "prost", version = "0.11.9" }
-protobuf-src = "1.1.0"
 serde = "~1.0.145"
 serde_json = "~1.0.86"
 solana-account = "2"

--- a/yellowstone-grpc-proto/Cargo.toml
+++ b/yellowstone-grpc-proto/Cargo.toml
@@ -53,9 +53,11 @@ solana-transaction = { workspace = true, features = ["blake3"] }
 
 [build-dependencies]
 anyhow = { workspace = true }
-protobuf-src = { workspace = true }
 tonic-build = { workspace = true }
 tonic-prost-build = { workspace = true }
+
+[target.'cfg(not(windows))'.build-dependencies]
+protobuf-src = "1.1.0"
 
 [features]
 default = ["convert", "tonic", "tonic-compression"]

--- a/yellowstone-grpc-proto/build.rs
+++ b/yellowstone-grpc-proto/build.rs
@@ -4,6 +4,8 @@ use {
 };
 
 fn main() -> anyhow::Result<()> {
+    // Windows compilation issues for protobuf-src
+    #[cfg(not(windows))]
     std::env::set_var("PROTOC", protobuf_src::protoc());
 
     // build protos


### PR DESCRIPTION
Windows users now need to:
1. Manually download protoc binary from official releases
2. Set PROTOC environment variable pointing to the executable