### PR TITLE
fix(slot_messages): handle lower write_version by dropping messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,9 +2966,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -693,6 +693,10 @@ impl GrpcService {
                                     // We can replace the message, but in this case we will lose the order
                                     slot_messages.messages[entry.1] = None;
                                     *entry = (write_version, msg_index);
+                                } else {
+                                    // If the new write_version is lower than the latest one, we need to drop this message
+                                    // because we would have more than 1 image in slot_messages.messages
+                                    slot_messages.messages[msg_index] = None;
                                 }
                             } else {
                                 slot_messages.accounts_dedup.insert(msg.account.pubkey, (write_version, msg_index));


### PR DESCRIPTION
This PR fixes an edge case in account update deduplication for `slot_messages.messages`.

### Background

Yellowstone gRPC saves account updates into `slot_messages.messages`.
The intent is to keep only the latest (highest `write_version`) account update per pubkey within a slot.
Deduplication is tracked via `slot_messages.accounts_dedup`.

### Problem

Previously, when an account update arrived out of order (with a `write_version` **lower** than the highest seen so far), the code failed to discard it.
Because messages are appended to `slot_messages.messages` **before** deduplication logic runs, this resulted in multiple updates being saved for the same pubkey in a slot.

### Fix

Added an else branch to handle the case where the new update’s `write_version` is lower than the latest one.
The new (out-of-order) message is immediately dropped by marking its array entry as `None`.
This ensures only the latest `write_version` per pubkey survives.

### Impact

Prevents saving multiple account updates per pubkey in a slot.
Preserves intended deduplication semantics.