### PR TITLE
update renaming task in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'v1.16'
-      - 'v1.17'
-      - 'v1.18'
-      - 'v2.0'
-      - 'v2.1'
       - 'v2.2'
     tags:
       - 'v*'
@@ -107,11 +102,10 @@ jobs:
           mv target/release/client target/release/client-${{ matrix.os }}
           mv target/release/config-check target/release/config-check-${{ matrix.os }}
 
-      - name: Rename lib for ubuntu22 release
-        if: matrix.os == 'ubuntu-22.04'
+      - name: Add os version to release name
         run: |
-          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.tar.bz2 ${{ env.GEYSER_PLUGIN_NAME }}-release22-x86_64-unknown-linux-gnu.tar.bz2
-          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.yml ${{ env.GEYSER_PLUGIN_NAME }}-release22-x86_64-unknown-linux-gnu.yml
+          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.tar.bz2 ${{ env.GEYSER_PLUGIN_NAME }}-release-${{ matrix.os }}-x86_64-unknown-linux-gnu.tar.bz2
+          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.yml ${{ env.GEYSER_PLUGIN_NAME }}-release-${{ matrix.os }}-x86_64-unknown-linux-gnu.yml
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           echo "CI_TAG=$(ci/getTag.sh)" >> "$GITHUB_ENV"
           echo "CI_OS_NAME=linux" >> "$GITHUB_ENV"
+          echo "CI_OS_VERSION=$(echo "${{ matrix.os }}" | sed 's/ubuntu-//' | sed 's/\.04//')" >> "$GITHUB_ENV"
 
           SOLANA_VERSION="$(./ci/solana-version.sh)"
           echo "SOLANA_VERSION=$SOLANA_VERSION" >> "$GITHUB_ENV"
@@ -104,8 +105,8 @@ jobs:
 
       - name: Add os version to release name
         run: |
-          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.tar.bz2 ${{ env.GEYSER_PLUGIN_NAME }}-release-${{ matrix.os }}-x86_64-unknown-linux-gnu.tar.bz2
-          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.yml ${{ env.GEYSER_PLUGIN_NAME }}-release-${{ matrix.os }}-x86_64-unknown-linux-gnu.yml
+          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.tar.bz2 ${{ env.GEYSER_PLUGIN_NAME }}-release${{ env.CI_OS_VERSION }}-x86_64-unknown-linux-gnu.tar.bz2
+          mv ${{ env.GEYSER_PLUGIN_NAME }}-release-x86_64-unknown-linux-gnu.yml ${{ env.GEYSER_PLUGIN_NAME }}-release${{ env.CI_OS_VERSION }}-x86_64-unknown-linux-gnu.yml
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Right now ubuntu24 builds are getting named without ubuntu versions suffix (naming used by ubuntu20 builds)

make it generic so it will add version to any ubuntu version in use