### PR TITLE
feat(geyser): optimize account processing latency and add monitoring metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2025-11-05
+
+- yellowstone-grpc-geyser-10.2.0
+
+### Features
+
+- geyser: optimize account processing latency by removing 10ms timeout and reducing batch size to 8 for better CPU cache alignment
+- geyser: add histogram metrics for account processing visibility (account_message_creation_duration_us, account_geyser_loop_update_duration_us)
+
 ## 2025-10-25
 
 - yellowstone-grpc-client-simple-10.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "10.1.1"
+version = "10.2.0"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "10.1.1"
+version = "10.2.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -115,6 +115,22 @@ lazy_static::lazy_static! {
         )
         .buckets(vec![5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 10000.0])
     ).unwrap();
+
+    static ref ACCOUNT_MESSAGE_CREATION_DURATION_US: Histogram = Histogram::with_opts(
+        HistogramOpts::new(
+            "account_message_creation_duration_us",
+            "Duration of account message creation"
+        )
+        .buckets(vec![0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 10000.0])
+    ).unwrap();
+
+    static ref ACCOUNT_GEYSER_LOOP_UPDATE_DURATION_US: Histogram = Histogram::with_opts(
+        HistogramOpts::new(
+            "account_geyser_loop_update_duration_us",
+            "Duration of account geyser loop update"
+        )
+        .buckets(vec![0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 10000.0])
+    ).unwrap();
 }
 
 #[derive(Debug)]
@@ -266,6 +282,8 @@ impl PrometheusService {
             register!(GRPC_SUBSCRIBER_SEND_BANDWIDTH_LOAD);
             register!(GRPC_SUBCRIBER_RX_LOAD);
             register!(GRPC_SUBSCRIBER_QUEUE_SIZE);
+            register!(ACCOUNT_MESSAGE_CREATION_DURATION_US);
+            register!(ACCOUNT_GEYSER_LOOP_UPDATE_DURATION_US);
 
             VERSION
                 .with_label_values(&[
@@ -476,4 +494,12 @@ pub fn set_subscriber_queue_size<S: AsRef<str>>(subscriber_id: S, size: u64) {
     GRPC_SUBSCRIBER_QUEUE_SIZE
         .with_label_values(&[subscriber_id.as_ref()])
         .set(size as i64);
+}
+
+pub fn observe_account_message_creation_duration(duration: std::time::Duration) {
+    ACCOUNT_MESSAGE_CREATION_DURATION_US.observe(duration.as_micros() as f64);
+}
+
+pub fn observe_account_geyser_loop_update_duration(duration: std::time::Duration) {
+    ACCOUNT_GEYSER_LOOP_UPDATE_DURATION_US.observe(duration.as_micros() as f64);
 }

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -15,7 +15,7 @@ use {
             atomic::{AtomicBool, Ordering},
             Arc, Mutex,
         },
-        time::Duration,
+        time::{Duration, Instant},
     },
     tokio::{
         runtime::{Builder, Runtime},
@@ -194,8 +194,10 @@ impl GeyserPlugin for Plugin {
                     }
                 }
             } else {
+                let start = Instant::now();
                 let message =
                     Message::Account(MessageAccount::from_geyser(account, slot, is_startup));
+                metrics::observe_account_message_creation_duration(start.elapsed());
                 inner.send_message(message);
             }
 


### PR DESCRIPTION
## Summary

  Optimizes account processing for lower latency and better observability.

  ## Changes

  - **Remove 10ms timeout**: Account updates arrive rapidly and the timeout was rarely used. Messages
  now send immediately when batches are ready.

  - **Reduce batch size from 31 to 8**: Power-of-2 sizing for better CPU cache alignment and lower
  latency.

  - **Add metrics for visibility**:
    - `account_message_creation_duration_us`: Measures the time it takes to create the message and serialize with protobuf.
    - `account_geyser_loop_update_duration_us`: Time it takes from receiving and creating the message to send on the geyser_loop.
