### PR TITLE
fix: Reset metrics on plugin unload

### DIFF
--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -477,3 +477,28 @@ pub fn set_subscriber_queue_size<S: AsRef<str>>(subscriber_id: S, size: u64) {
         .with_label_values(&[subscriber_id.as_ref()])
         .set(size as i64);
 }
+
+/// Reset all metrics on plugin unload to prevent metric accumulation across plugin lifecycle
+pub fn reset_metrics() {
+    // Reset gauge metrics to 0
+    CONNECTIONS_TOTAL.set(0);
+    MESSAGE_QUEUE_SIZE.set(0);
+
+    // Reset gauge vectors (clears all label combinations)
+    SUBSCRIPTIONS_TOTAL.reset();
+    SLOT_STATUS.reset();
+    SLOT_STATUS_PLUGIN.reset();
+    INVALID_FULL_BLOCKS.reset();
+    GRPC_SUBSCRIBER_SEND_BANDWIDTH_LOAD.reset();
+    GRPC_SUBSCRIBER_QUEUE_SIZE.reset();
+    GRPC_SUBCRIBER_RX_LOAD.reset();
+
+    // Reset counter vectors (clears all label combinations)
+    MISSED_STATUS_MESSAGE.reset();
+    GRPC_MESSAGE_SENT.reset();
+    GRPC_BYTES_SENT.reset();
+
+    // Note: VERSION and GEYSER_ACCOUNT_UPDATE_RECEIVED are intentionally not reset
+    // - VERSION contains build info set once on startup
+    // - GEYSER_ACCOUNT_UPDATE_RECEIVED is a Histogram which doesn't support reset()
+}

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -79,6 +79,9 @@ impl GeyserPlugin for Plugin {
 
         log::info!("loading plugin: {}", self.name());
 
+        // Reset metrics to prevent accumulation across plugin reload cycles
+        metrics::reset_metrics();
+
         // Create inner
         let mut builder = Builder::new_multi_thread();
         if let Some(worker_threads) = config.tokio.worker_threads {


### PR DESCRIPTION
Fixes #639

Metrics accumulate across plugin reload cycles because they're stored in static variables that persist for the process lifetime.

Added reset_metrics() function that clears gauges and counters when the plugin is unloaded.