### PR TITLE
group solana deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5064,7 +5064,6 @@ dependencies = [
  "solana-clock",
  "solana-logger",
  "solana-pubkey",
- "solana-transaction-status",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ publish = false
 
 [workspace.dependencies]
 affinity = "0.1.2"
-agave-geyser-plugin-interface = "3.0.0"
 anyhow = "1.0.98"
 backoff = "0.4.0"
 base64 = "0.22.1"
@@ -55,23 +54,7 @@ prost_011 = { package = "prost", version = "0.11.9" }
 protobuf-src = "1.1.0"
 serde = "1.0.145"
 serde_json = "1.0.86"
-solana-account = "3.0.0"
-solana-account-decoder = "3.0.0"
-solana-clock = "3.0.0"
-solana-hash = "3.0.0"
-solana-keypair = "3.0.1"
-solana-logger = "3.0.0"
-solana-message = { version = "3.0.1", features = ["bincode", "blake3"] }
-solana-pubkey = "3.0.0"
-solana-signature = "3.1.0"
-solana-signer = "3.0.0"
-solana-storage-proto = "3.0.0"
-solana-transaction = "3.0.1"
-solana-transaction-context = "3.0.0"
-solana-transaction-error = "3.0.0"
-solana-transaction-status = "3.0.0"
 smallvec = "1.15.1"
-spl-token-2022-interface = "2.0.0"
 thiserror = "2.0.16"
 tokio = "1.47.1"
 tokio-stream = "0.1.17"
@@ -82,6 +65,31 @@ tonic-prost = "0.14.0"
 tonic-prost-build = "0.14.0"
 tonic-health = "0.14.0"
 vergen = "9.0.6"
+
+# Agave Monorepo
+agave-geyser-plugin-interface = "3.0.0"
+solana-account-decoder = "3.0.0"
+solana-logger = "3.0.0"
+solana-storage-proto = "3.0.0"
+solana-transaction-context = "3.0.0"
+solana-transaction-status = "3.0.0"
+
+# Solana SDK
+solana-account = "3.0.0"
+solana-clock = "3.0.0"
+solana-hash = "3.0.0"
+solana-keypair = "3.0.1"
+solana-message = { version = "3.0.1", features = ["bincode", "blake3"] }
+solana-pubkey = "3.0.0"
+solana-signature = "3.1.0"
+solana-signer = "3.0.0"
+solana-transaction = "3.0.1"
+solana-transaction-error = "3.0.0"
+
+# Solana Misc
+spl-token-2022-interface = "2.0.0"
+
+# Yellowstone
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "10.1.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "10.1.0", default-features = false }
 

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -26,12 +26,19 @@ indicatif = { workspace = true }
 log = { workspace = true }
 maplit = { workspace = true }
 serde_json = { workspace = true }
-solana-hash = { workspace = true }
-solana-pubkey = { workspace = true }
-solana-signature = { workspace = true }
 solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
 tonic = { workspace = true, features = ["zstd", "gzip", "tls-native-roots", "tls-ring"] }
+
+# Agave Monorepo
+# empty
+
+# Solana SDK
+solana-hash = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
+
+# Yellowstone
 yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true, features = ["plugin"] }
 

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -21,6 +21,8 @@ futures = { workspace = true }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["tls-native-roots"] }
 tonic-health = { workspace = true }
+
+# Yellowstone
 yellowstone-grpc-proto = { workspace = true, features = ["tonic", "tonic-compression"] }
 
 [dev-dependencies]

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -18,7 +18,6 @@ name = "config-check"
 
 [dependencies]
 affinity = { workspace = true }
-agave-geyser-plugin-interface = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -39,16 +38,22 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-solana-clock = { workspace = true }
-solana-logger = { workspace = true }
-solana-pubkey = { workspace = true }
-solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tokio-util = { workspace = true, features = ["rt"]}
 tokio-stream = { workspace = true }
 tonic = { workspace = true, features = ["gzip", "zstd", "tls-native-roots"] }
 tonic-health = { workspace = true }
+
+# Agave Monorepo
+agave-geyser-plugin-interface = { workspace = true }
+solana-logger = { workspace = true }
+
+# Solana SDK
+solana-clock = { workspace = true }
+solana-pubkey = { workspace = true }
+
+# Yellowstone
 yellowstone-grpc-proto = { workspace = true, features = ["convert", "plugin", "tonic", "account-data-as-bytes"] }
 
 [build-dependencies]

--- a/yellowstone-grpc-proto/Cargo.toml
+++ b/yellowstone-grpc-proto/Cargo.toml
@@ -16,7 +16,6 @@ harness = false
 required-features = ["plugin-bench"]
 
 [dependencies]
-agave-geyser-plugin-interface = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
 bs58 = { workspace = true, optional = true }
@@ -25,23 +24,30 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 prost_011 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-solana-account = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+tonic = { workspace = true, optional = true }
+tonic-prost = { workspace = true, optional = true }
+
+# Agave Monorepo
+agave-geyser-plugin-interface = { workspace = true, optional = true }
 solana-account-decoder = { workspace = true, optional = true }
+solana-storage-proto = { workspace = true, optional = true }
+solana-transaction-status = { workspace = true, optional = true }
+solana-transaction-context = { workspace = true, optional = true }
+
+# Solana SDK
+solana-account = { workspace = true, optional = true }
 solana-clock = { workspace = true, optional = true }
 solana-hash = { workspace = true, optional = true }
 solana-message = { workspace = true, optional = true }
 solana-pubkey = { workspace = true, optional = true }
 solana-signature = { workspace = true, optional = true }
-solana-storage-proto = { workspace = true, optional = true }
 solana-transaction = { workspace = true, optional = true }
-solana-transaction-context = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true, optional = true }
-solana-transaction-status = { workspace = true, optional = true }
-smallvec = { workspace = true, optional = true }
+
+# Solana Misc
 spl-token-2022-interface = { workspace = true, optional = true }
-thiserror = { workspace = true, optional = true }
-tonic = { workspace = true, optional = true }
-tonic-prost = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Motivation: When updating Solana dependencies the Monorepo version sometimes diverges from solana-sdk and maybe others which makes it harder to choose the right version.

Group solana dependencies in _Cargo.toml_ to make clear which dependencies are pulled from Anza monorepo vs solana-sdk.

