### PR TITLE
fixes lifetime capture issue for Rust edition 2024

### DIFF
--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -112,8 +112,8 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
         &mut self,
         request: Option<SubscribeRequest>,
     ) -> GeyserGrpcClientResult<(
-        impl Sink<SubscribeRequest, Error = mpsc::SendError>,
-        impl Stream<Item = Result<SubscribeUpdate, Status>>,
+        impl Sink<SubscribeRequest, Error = mpsc::SendError> + use<F>,
+        impl Stream<Item = Result<SubscribeUpdate, Status>> + use<F>,
     )> {
         let (mut subscribe_tx, subscribe_rx) = mpsc::unbounded();
         if let Some(request) = request {


### PR DESCRIPTION
this is the report from rust compiler (1.86):
> note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
> help: if you can modify this crate, add a precise capturing bound to avoid overcapturing: `+ use<F>`

this is the usage:
```rust
let fut_subscribe = timeout(
  subscribe_timeout,
  client.subscribe_with_request(Some(subscribe_filter_on_connect)),
);
```

disclaimer: I've just read 2 minutes about that issue so maybe what I'm proposing is totally wrong
