### PR TITLE
remove request sending port from subscriber_id label in metrics

### DIFF
--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1292,7 +1292,7 @@ impl Geyser for GrpcService {
             .metadata()
             .get("x-subscription-id")
             .and_then(|h| h.to_str().ok().map(|s| s.to_string()))
-            .or(request.remote_addr().map(|addr| addr.to_string()));
+            .or(request.remote_addr().map(|addr| addr.ip().to_string()));
 
         let config_filter_limits = Arc::clone(&self.config_filter_limits);
         let filter_names = Arc::clone(&self.filter_names);


### PR DESCRIPTION
Closes #648 