### PR TITLE
Pre-encode transaction content to reduce serialization overhead

### DIFF
--- a/yellowstone-grpc-proto/src/plugin/filter/encoder.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/encoder.rs
@@ -1,0 +1,58 @@
+use bytes::Bytes;
+
+use crate::plugin::message::MessageTransactionInfo;
+
+pub struct TransactionEncoder;
+
+impl TransactionEncoder {
+    pub fn pre_encode(tx: &mut MessageTransactionInfo) {
+        let len = Self::encoded_len(tx);
+        let mut buf = Vec::with_capacity(len);
+        Self::encode_raw(tx, &mut buf);
+        tx.pre_encoded = Some(Bytes::from(buf));
+    }
+
+    fn encode_raw(tx: &MessageTransactionInfo, buf: &mut impl bytes::BufMut) {
+        use prost::encoding::{encode_key, encode_varint, message, WireType};
+
+        let index = tx.index as u64;
+
+        encode_key(1u32, WireType::LengthDelimited, buf);
+        encode_varint(tx.signature.as_ref().len() as u64, buf);
+        buf.put_slice(tx.signature.as_ref());
+
+        if tx.is_vote {
+            prost::encoding::bool::encode(2u32, &tx.is_vote, buf);
+        }
+
+        message::encode(3u32, &tx.transaction, buf);
+        message::encode(4u32, &tx.meta, buf);
+
+        if index != 0u64 {
+            prost::encoding::uint64::encode(5u32, &index, buf);
+        }
+    }
+
+    pub fn encoded_len(tx: &MessageTransactionInfo) -> usize {
+        use prost::encoding::{encoded_len_varint, key_len, message};
+
+        let index = tx.index as u64;
+        let sig_len = tx.signature.as_ref().len();
+
+        key_len(1u32)
+            + encoded_len_varint(sig_len as u64)
+            + sig_len
+            + if tx.is_vote {
+                prost::encoding::bool::encoded_len(2u32, &tx.is_vote)
+            } else {
+                0
+            }
+            + message::encoded_len(3u32, &tx.transaction)
+            + message::encoded_len(4u32, &tx.meta)
+            + if index != 0u64 {
+                prost::encoding::uint64::encoded_len(5u32, &index)
+            } else {
+                0
+            }
+    }
+}

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -1196,6 +1196,7 @@ mod tests {
                 meta,
                 index: 1,
                 account_keys,
+                pre_encoded: None,
             }),
             slot: 100,
             created_at: Timestamp::from(SystemTime::now()),

--- a/yellowstone-grpc-proto/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/message.rs
@@ -288,6 +288,7 @@ impl FilteredUpdate {
                         },
                         index: msg.index as usize,
                         account_keys: HashSet::new(),
+                        pre_encoded: None,
                     }),
                     slot: msg.slot,
                 })
@@ -661,6 +662,15 @@ impl prost::Message for FilteredUpdateTransaction {
 
 impl FilteredUpdateTransaction {
     fn tx_encode_raw(tag: u32, tx: &MessageTransactionInfo, buf: &mut impl BufMut) {
+        // try to use pre-encoded bytes (fast path)
+        if let Some(pre_encoded) = tx.get_pre_encoded() {
+            encode_key(tag, WireType::LengthDelimited, buf);
+            encode_varint(pre_encoded.len() as u64, buf);
+            buf.put_slice(pre_encoded);
+            return;
+        }
+
+        // fallback: encode from scratch
         encode_key(tag, WireType::LengthDelimited, buf);
         encode_varint(Self::tx_encoded_len(tx) as u64, buf);
 
@@ -678,6 +688,11 @@ impl FilteredUpdateTransaction {
     }
 
     fn tx_encoded_len(tx: &MessageTransactionInfo) -> usize {
+        // try to use pre-encoded length (fast path)
+        if let Some(pre_encoded) = tx.get_pre_encoded() {
+            return pre_encoded.len();
+        }
+
         let index = tx.index as u64;
 
         prost_bytes_encoded_len(1u32, tx.signature.as_ref())
@@ -990,7 +1005,10 @@ pub mod tests {
             convert_to,
             geyser::{SubscribeUpdate, SubscribeUpdateBlockMeta},
             plugin::{
-                filter::{name::FilterName, FilterAccountsDataSlice},
+                filter::{
+                    encoder::TransactionEncoder, message::FilteredUpdateTransaction,
+                    name::FilterName, FilterAccountsDataSlice,
+                },
                 message::{
                     MessageAccount, MessageAccountInfo, MessageBlockMeta, MessageEntry,
                     MessageSlot, MessageTransaction, MessageTransactionInfo, SlotStatus,
@@ -1171,6 +1189,7 @@ pub mod tests {
                             meta: convert_to::create_transaction_meta(&tx.meta),
                             index,
                             account_keys: HashSet::new(),
+                            pre_encoded: None,
                         }
                     })
                     .map(Arc::new)
@@ -1292,6 +1311,68 @@ pub mod tests {
                 )
             }
         }
+    }
+
+    #[test]
+    fn test_pre_encoded_matches_manual_encoding() {
+        // Get real transactions from fixtures (these have pre_encoded: None)
+        for tx_arc in load_predefined_transactions() {
+            // Clone the transaction info
+            let mut tx_with_cache = MessageTransactionInfo {
+                signature: tx_arc.signature,
+                is_vote: tx_arc.is_vote,
+                transaction: tx_arc.transaction.clone(),
+                meta: tx_arc.meta.clone(),
+                index: tx_arc.index,
+                account_keys: tx_arc.account_keys.clone(),
+                pre_encoded: None,
+            };
+
+            // Create version without cache (fallback path)
+            let tx_without_cache = MessageTransactionInfo {
+                signature: tx_arc.signature,
+                is_vote: tx_arc.is_vote,
+                transaction: tx_arc.transaction.clone(),
+                meta: tx_arc.meta.clone(),
+                index: tx_arc.index,
+                account_keys: tx_arc.account_keys.clone(),
+                pre_encoded: None,
+            };
+
+            // Pre-encode one of them
+            TransactionEncoder::pre_encode(&mut tx_with_cache);
+
+            assert!(
+                tx_with_cache.pre_encoded.is_some(),
+                "pre_encode should populate the field"
+            );
+
+            // Wrap both in FilteredUpdateTransaction and encode via the public Message trait
+            let wrapped_cached = FilteredUpdateTransaction {
+                transaction: Arc::new(tx_with_cache),
+                slot: 42,
+            };
+            let wrapped_manual = FilteredUpdateTransaction {
+                transaction: Arc::new(tx_without_cache),
+                slot: 42,
+            };
+
+            // Encode both using prost::Message::encode_to_vec (public API)
+            let buf_cached = wrapped_cached.encode_to_vec();
+            let buf_manual = wrapped_manual.encode_to_vec();
+
+            // They must be identical
+            assert_eq!(
+                buf_cached, buf_manual,
+                "Pre-encoded bytes differ from manual encoding for tx {:?}",
+                tx_arc.signature
+            );
+        }
+
+        println!(
+            "Tested {} transactions - all match!",
+            load_predefined_transactions().len()
+        );
     }
 
     #[test]

--- a/yellowstone-grpc-proto/src/plugin/filter/mod.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/mod.rs
@@ -1,3 +1,4 @@
+pub mod encoder;
 #[allow(clippy::module_inception)]
 mod filter;
 pub mod limits;


### PR DESCRIPTION
Closes #STR-258
## Problem

Each connected client triggers independent encoding of the same transaction data. Prost's two-pass encoding (length calculation + byte writing) means N clients cause 2N full traversals of the transaction struct. Profiling on mainnet showed 12-15% CPU in encoding-related functions (`tx_encoded_len`, `put_slice`, `encode_varint`).

## Solution

Pre-encode transaction content once when `MessageTransactionInfo` is created. Store the bytes alongside the struct. When encoding for clients, copy the pre-computed bytes instead of re-encoding.

## Changes

- Add `pre_encoded: Option<Bytes>` field to `MessageTransactionInfo`
- Call `pre_encode()` in `from_geyser()` and `from_update_oneof()`
- Modify `tx_encode_raw()` to use pre-encoded bytes when available
- Modify `tx_encoded_len()` to return cached length when available
- Fallback to manual encoding when `pre_encoded` is `None` (tests, edge cases)

## Why this works

Transaction filters are gatekeepers, not transformers. A transaction either passes the filter (sent whole) or doesn't (dropped). The encoded bytes are identical for every client who receives the transaction. Only the small `filters` wrapper field differs per client.

## Testing

- `test_pre_encoded_matches_manual_encoding`: verifies pre-encoded bytes match
  manual encoding for 308 real transactions from fixtures
- All existing encode/decode round-trip tests pass

## Expected impact

| Metric | Before | After |
|--------|--------|-------|
| Encoding passes per tx | N × 2 | 1 + N copies |
| `tx_encoded_len` calls | N per tx | 1 per tx |

Actual CPU reduction to be measured via profiling.