### PR TITLE
Pre-encode account content to reduce serialization overhead

### DIFF
--- a/yellowstone-grpc-proto/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/message.rs
@@ -43,7 +43,7 @@ pub const fn prost_field_encoded_len(tag: u32, len: usize) -> usize {
 }
 
 #[inline]
-fn prost_bytes_encode_raw(tag: u32, value: &[u8], buf: &mut impl BufMut) {
+pub fn prost_bytes_encode_raw(tag: u32, value: &[u8], buf: &mut impl BufMut) {
     encode_key(tag, WireType::LengthDelimited, buf);
     encode_varint(value.len() as u64, buf);
     buf.put(value);
@@ -491,6 +491,17 @@ impl FilteredUpdateAccount {
         data_slice: &FilterAccountsDataSlice,
         buf: &mut impl BufMut,
     ) {
+        // use pre-encoded if: no slicing and pre-encoded exists
+        if data_slice.as_ref().is_empty() {
+            if let Some(pre_encoded) = account.get_pre_encoded() {
+                encode_key(tag, WireType::LengthDelimited, buf);
+                encode_varint(pre_encoded.len() as u64, buf);
+                buf.put_slice(pre_encoded);
+                return;
+            }
+        }
+
+        // fallback: slice-aware encoding
         encode_key(tag, WireType::LengthDelimited, buf);
         encode_varint(Self::account_encoded_len(account, data_slice) as u64, buf);
 
@@ -518,6 +529,14 @@ impl FilteredUpdateAccount {
         account: &MessageAccountInfo,
         data_slice: &FilterAccountsDataSlice,
     ) -> usize {
+        // use pre-encoded length if: no slicing and pre-encoded exists
+        if data_slice.as_ref().is_empty() {
+            if let Some(pre_encoded) = account.get_pre_encoded() {
+                return pre_encoded.len();
+            }
+        }
+
+        // fallback: calculate with slicing
         let data_len = data_slice.get_slice_len(&account.data);
 
         prost_bytes_encoded_len(1u32, account.pubkey.as_ref())
@@ -1006,8 +1025,10 @@ pub mod tests {
             geyser::{SubscribeUpdate, SubscribeUpdateBlockMeta},
             plugin::{
                 filter::{
-                    encoder::TransactionEncoder, message::FilteredUpdateTransaction,
-                    name::FilterName, FilterAccountsDataSlice,
+                    encoder::{AccountEncoder, TransactionEncoder},
+                    message::{FilteredUpdateAccount, FilteredUpdateTransaction},
+                    name::FilterName,
+                    FilterAccountsDataSlice,
                 },
                 message::{
                     MessageAccount, MessageAccountInfo, MessageBlockMeta, MessageEntry,
@@ -1082,6 +1103,7 @@ pub mod tests {
                                     data: Bytes::from(data.clone()),
                                     write_version,
                                     txn_signature,
+                                    pre_encoded: None,
                                 }));
                             }
                         }
@@ -1266,6 +1288,88 @@ pub mod tests {
                 .map(|msg| msg.as_subscribe_update()),
             Ok(update)
         );
+    }
+
+    #[test]
+    fn test_account_pre_encoded_matches_manual_encoding() {
+        use {bytes::Bytes, solana_pubkey::Pubkey, solana_signature::Signature};
+
+        // Test various account configurations
+        let pubkeys = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let owners = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let data_samples = [
+            vec![],
+            vec![1, 2, 3, 4],
+            vec![0u8; 1000], // larger account data
+        ];
+
+        for pubkey in &pubkeys {
+            for owner in &owners {
+                for lamports in [0u64, 100, 1_000_000] {
+                    for executable in [false, true] {
+                        for rent_epoch in [0u64, 100] {
+                            for write_version in [0u64, 42] {
+                                for data in &data_samples {
+                                    for txn_signature in [None, Some(Signature::from([0u8; 64]))] {
+                                        // Create account WITH pre-encoding
+                                        let mut account_with = MessageAccountInfo {
+                                            pubkey: *pubkey,
+                                            lamports,
+                                            owner: *owner,
+                                            executable,
+                                            rent_epoch,
+                                            data: Bytes::from(data.clone()),
+                                            write_version,
+                                            txn_signature,
+                                            pre_encoded: None,
+                                        };
+                                        AccountEncoder::pre_encode(&mut account_with);
+
+                                        // Create account WITHOUT pre-encoding (fallback path)
+                                        let account_without = MessageAccountInfo {
+                                            pubkey: *pubkey,
+                                            lamports,
+                                            owner: *owner,
+                                            executable,
+                                            rent_epoch,
+                                            data: Bytes::from(data.clone()),
+                                            write_version,
+                                            txn_signature,
+                                            pre_encoded: None,
+                                        };
+
+                                        // Encode both using FilteredUpdateAccount (no slicing)
+                                        let data_slice = FilterAccountsDataSlice::default();
+
+                                        let mut buf_with = Vec::new();
+                                        FilteredUpdateAccount::account_encode_raw(
+                                            1u32,
+                                            &account_with,
+                                            &data_slice,
+                                            &mut buf_with,
+                                        );
+
+                                        let mut buf_without = Vec::new();
+                                        FilteredUpdateAccount::account_encode_raw(
+                                            1u32,
+                                            &account_without,
+                                            &data_slice,
+                                            &mut buf_without,
+                                        );
+
+                                        // Must be identical
+                                        assert_eq!(
+                                            buf_with, buf_without,
+                                            "pre-encoded bytes don't match manual encoding"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #STR-287
<html><head></head><body><h2>Pre-encode account content to reduce serialization overhead</h2>
<h3>Problem</h3>
<p>Each connected client triggers independent encoding of the same account data. Prost's two-pass encoding (length calculation + byte writing) means N clients cause 2N full traversals of the account struct. Accounts are 3x more frequent than transactions (~6k accounts vs ~2k transactions per slot), making this a significant source of encoding overhead.</p>
<h3>Solution</h3>
<p>Pre-encode account content once when <code>MessageAccountInfo</code> is created. Store the bytes alongside the struct. When encoding for clients <strong>without data slicing</strong>, copy the pre-computed bytes instead of re-encoding.</p>
<h3>Changes</h3>
<ul>
<li>Add <code>pre_encoded: Option&lt;Bytes&gt;</code> field to <code>MessageAccountInfo</code></li>
<li>Call <code>pre_encode()</code> in <code>from_geyser()</code> and <code>from_update_oneof()</code></li>
<li>Modify <code>account_encode_raw()</code> to use pre-encoded bytes when <code>data_slice.is_empty()</code></li>
<li>Modify <code>account_encoded_len()</code> to return cached length when applicable</li>
<li>Fallback to manual encoding when:
<ul>
<li><code>pre_encoded</code> is <code>None</code> (tests, edge cases)</li>
<li>Client requests data slicing (slice-aware encoding required)</li>
</ul>
</li>
</ul>
<h3>Why this works</h3>
<p>For clients requesting full account data (no slicing), the encoded bytes are identical. We can share pre-computed bytes across these clients. Clients with data slicing need custom byte ranges, so they fall back to the existing slice-aware encoding path.</p>
<pre><code class="rust">// In account_encode_raw:
if data_slice.as_ref().is_empty() {
    if let Some(pre_encoded) = account.get_pre_encoded() {
        // Fast path: copy pre-encoded bytes
        buf.put_slice(pre_encoded);
        return;
    }
}
// Slow path: slice-aware encoding
</code></pre>
<h3>Testing</h3>
<ul>
<li><code>test_account_pre_encoded_matches_manual_encoding</code>: verifies pre-encoded bytes match manual encoding across various account configurations (different lamports, data sizes, executability, signatures)</li>
<li>All existing encode/decode round-trip tests pass</li>
</ul>
<h3>Expected impact</h3>
<p>For clients without data slicing:</p>

Metric | Before | After
-- | -- | --
Encoding passes per account | N × 2 | 1 + N copies
account_encoded_len calls | N per account | 1 per account


<p>Clients with data slicing: no change (existing behavior preserved).</p>