### PR TITLE
fix: make it possible to build and run on macOS

### DIFF
--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -16,8 +16,10 @@ crate-type = ["cdylib", "rlib"]
 [[bin]]
 name = "config-check"
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 affinity = { workspace = true }
+
+[dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -117,6 +117,7 @@ fn parse_taskset(taskset: &str) -> Result<Vec<usize>, String> {
     let mut vec = set.into_iter().collect::<Vec<usize>>();
     vec.sort();
 
+    #[cfg(target_os = "linux")]
     if let Some(set_max_index) = vec.last().copied() {
         let max_index = affinity::get_thread_affinity()
             .map_err(|_err| "failed to get affinity".to_owned())?

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -87,6 +87,7 @@ impl GeyserPlugin for Plugin {
         if let Some(worker_threads) = config.tokio.worker_threads {
             builder.worker_threads(worker_threads);
         }
+        #[cfg(target_os = "linux")]
         if let Some(tokio_cpus) = config.tokio.affinity.clone() {
             builder.on_thread_start(move || {
                 affinity::set_thread_affinity(&tokio_cpus).expect("failed to set affinity")


### PR DESCRIPTION
Currently building and running Yellowstone gRPC on a mac is not possible due to `affinity` not supporting macOS. 
My use case is that I want to run a local Solana validator with Yellowstone enabled.
