### PR TITLE
feat: increase default HTTP/2 window sizes to 32MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- client: set HTTP/2 stream and connection window sizes to 64MB by default to prevent flow control bottlenecks on high-throughput subscriptions
-- nodejs: increase default stream and connection window sizes from 4MB/8MB to 64MB
-- examples: add 64MB window size defaults to Go, Python, and Rust example clients
+- client: set HTTP/2 stream and connection window sizes to 32MB by default to prevent flow control bottlenecks on high-throughput subscriptions
+- nodejs: increase default stream and connection window sizes from 4MB/8MB to 32MB
+- examples: add 32MB window size defaults to Go, Python, and Rust example clients
 - docs: add system tuning section to README for TCP receive buffer configuration
 
 ## 2026-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2026-02-11
+
+- yellowstone-grpc-client-12.1.0
+- yellowstone-grpc-client-simple-12.1.0
+- @triton-one/yellowstone-grpc-5.1.0
+
+### Features
+
+- client: set HTTP/2 stream and connection window sizes to 64MB by default to prevent flow control bottlenecks on high-throughput subscriptions
+- nodejs: increase default stream and connection window sizes from 4MB/8MB to 64MB
+- examples: add 64MB window size defaults to Go, Python, and Rust example clients
+- docs: add system tuning section to README for TCP receive buffer configuration
+
 ## 2026-02-06
 
 - yellowstone-grpc-client-12.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,7 +5105,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "12.0.0"
+version = "12.1.0"
 dependencies = [
  "bytes",
  "futures",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client-simple"
-version = "12.0.0"
+version = "12.1.0"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ solana-transaction-error = "3.0.0"
 spl-token-2022-interface = "2.0.0"
 
 # Yellowstone
-yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "12.0.0" }
+yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "12.1.0" }
 yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "12.0.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.0.0", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ For high-throughput subscriptions, increase the Linux TCP receive buffer sizes. 
 Apply immediately:
 
 ```bash
-sudo sysctl -w net.core.rmem_max=67108864 net.ipv4.tcp_rmem="4096 87380 67108864"
+sudo sysctl -w net.core.rmem_max=33554432 net.ipv4.tcp_rmem="4096 87380 33554432"
 ```
 
 To persist across reboots, add to `/etc/sysctl.conf`:
 
 ```
-net.core.rmem_max=67108864
-net.ipv4.tcp_rmem=4096 87380 67108864
+net.core.rmem_max=33554432
+net.ipv4.tcp_rmem=4096 87380 33554432
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -133,6 +133,23 @@ It's possible to add limits for filters in the config. If the `filters` field is
 
 #### GetVersion
 
+### System Tuning
+
+For high-throughput subscriptions, increase the Linux TCP receive buffer sizes. This can improve bandwidth by 5x+ on high-latency connections.
+
+Apply immediately:
+
+```bash
+sudo sysctl -w net.core.rmem_max=67108864 net.ipv4.tcp_rmem="4096 87380 67108864"
+```
+
+To persist across reboots, add to `/etc/sysctl.conf`:
+
+```
+net.core.rmem_max=67108864
+net.ipv4.tcp_rmem=4096 87380 67108864
+```
+
 ### Examples
 
    - [Go](examples/golang)

--- a/examples/golang/cmd/grpc-client/main.go
+++ b/examples/golang/cmd/grpc-client/main.go
@@ -104,6 +104,8 @@ func grpc_connect(address string, plaintext bool) *grpc.ClientConn {
 	}
 
 	opts = append(opts, grpc.WithKeepaliveParams(kacp))
+	opts = append(opts, grpc.WithInitialWindowSize(64*1024*1024))     // 64MB stream window
+	opts = append(opts, grpc.WithInitialConnWindowSize(64*1024*1024)) // 64MB connection window
 
 	log.Println("Starting grpc client, connecting to", address)
 	conn, err := grpc.Dial(address, opts...)

--- a/examples/golang/cmd/grpc-client/main.go
+++ b/examples/golang/cmd/grpc-client/main.go
@@ -104,8 +104,8 @@ func grpc_connect(address string, plaintext bool) *grpc.ClientConn {
 	}
 
 	opts = append(opts, grpc.WithKeepaliveParams(kacp))
-	opts = append(opts, grpc.WithInitialWindowSize(64*1024*1024))     // 64MB stream window
-	opts = append(opts, grpc.WithInitialConnWindowSize(64*1024*1024)) // 64MB connection window
+	opts = append(opts, grpc.WithInitialWindowSize(32*1024*1024))     // 32MB stream window
+	opts = append(opts, grpc.WithInitialConnWindowSize(32*1024*1024)) // 32MB connection window
 
 	log.Println("Starting grpc client, connecting to", address)
 	conn, err := grpc.Dial(address, opts...)

--- a/examples/python/helloworld_geyser.py
+++ b/examples/python/helloworld_geyser.py
@@ -47,7 +47,12 @@ def helloworld_geyser(rpc_fqdn, x_token):
     # Combined creds will store the channel creds aswell as the call credentials
     combined_creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
 
-    with grpc.secure_channel(rpc_fqdn, credentials=combined_creds) as channel:
+    channel_options = [
+        ('grpc.max_receive_message_length', 1024 * 1024 * 1024),     # 1GB
+        ('grpc.initial_window_size', 32 * 1024 * 1024),              # 32MB stream window
+        ('grpc.initial_connection_window_size', 32 * 1024 * 1024),   # 32MB connection window
+    ]
+    with grpc.secure_channel(rpc_fqdn, credentials=combined_creds, options=channel_options) as channel:
         stub = geyser_pb2_grpc.GeyserStub(channel)
         response = stub.GetSlot(geyser_pb2.GetSlotRequest())
         print(response)

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client-simple"
-version = "12.0.0"
+version = "12.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -97,13 +97,13 @@ struct Args {
     #[clap(long)]
     http2_keep_alive_interval_ms: Option<u64>,
 
-    /// Sets the max connection-level flow control for HTTP2, default is 64MB
-    #[clap(long, default_value_t = 64 * 1024 * 1024)]
-    initial_connection_window_size: u32,
+    /// Sets the max connection-level flow control for HTTP2. Library default is 32MB if not specified.
+    #[clap(long)]
+    initial_connection_window_size: Option<u32>,
 
-    /// Sets the SETTINGS_INITIAL_WINDOW_SIZE option for HTTP2 stream-level flow control, default is 64MB
-    #[clap(long, default_value_t = 64 * 1024 * 1024)]
-    initial_stream_window_size: u32,
+    /// Sets the SETTINGS_INITIAL_WINDOW_SIZE option for HTTP2 stream-level flow control. Library default is 32MB if not specified.
+    #[clap(long)]
+    initial_stream_window_size: Option<u32>,
 
     ///Set http2 KEEP_ALIVE_TIMEOUT. Uses hyper’s default otherwise.
     #[clap(long)]
@@ -180,8 +180,12 @@ impl Args {
         if let Some(duration) = self.http2_keep_alive_interval_ms {
             builder = builder.http2_keep_alive_interval(Duration::from_millis(duration));
         }
-        builder = builder.initial_connection_window_size(self.initial_connection_window_size);
-        builder = builder.initial_stream_window_size(self.initial_stream_window_size);
+        if let Some(sz) = self.initial_connection_window_size {
+            builder = builder.initial_connection_window_size(sz);
+        }
+        if let Some(sz) = self.initial_stream_window_size {
+            builder = builder.initial_stream_window_size(sz);
+        }
         if let Some(duration) = self.keep_alive_timeout_ms {
             builder = builder.keep_alive_timeout(Duration::from_millis(duration));
         }

--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -97,13 +97,13 @@ struct Args {
     #[clap(long)]
     http2_keep_alive_interval_ms: Option<u64>,
 
-    /// Sets the max connection-level flow control for HTTP2, default is 65,535
-    #[clap(long)]
-    initial_connection_window_size: Option<u32>,
+    /// Sets the max connection-level flow control for HTTP2, default is 64MB
+    #[clap(long, default_value_t = 64 * 1024 * 1024)]
+    initial_connection_window_size: u32,
 
-    ///Sets the SETTINGS_INITIAL_WINDOW_SIZE option for HTTP2 stream-level flow control, default is 65,535
-    #[clap(long)]
-    initial_stream_window_size: Option<u32>,
+    /// Sets the SETTINGS_INITIAL_WINDOW_SIZE option for HTTP2 stream-level flow control, default is 64MB
+    #[clap(long, default_value_t = 64 * 1024 * 1024)]
+    initial_stream_window_size: u32,
 
     ///Set http2 KEEP_ALIVE_TIMEOUT. Uses hyper’s default otherwise.
     #[clap(long)]
@@ -180,12 +180,8 @@ impl Args {
         if let Some(duration) = self.http2_keep_alive_interval_ms {
             builder = builder.http2_keep_alive_interval(Duration::from_millis(duration));
         }
-        if let Some(sz) = self.initial_connection_window_size {
-            builder = builder.initial_connection_window_size(sz);
-        }
-        if let Some(sz) = self.initial_stream_window_size {
-            builder = builder.initial_stream_window_size(sz);
-        }
+        builder = builder.initial_connection_window_size(self.initial_connection_window_size);
+        builder = builder.initial_stream_window_size(self.initial_stream_window_size);
         if let Some(duration) = self.keep_alive_timeout_ms {
             builder = builder.keep_alive_timeout(Duration::from_millis(duration));
         }

--- a/yellowstone-grpc-client-nodejs/napi/package.json
+++ b/yellowstone-grpc-client-nodejs/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yellowstone-grpc-napi",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Yellowstone gRPC NAPI bindings",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
@@ -56,8 +56,8 @@ impl Default for JsChannelOptions {
   /// JsChannelOptions {
   ///   grpc_connect_timeout: Duration::from_secs(10),
   ///   grpc_timeout: Some(Duration::from_secs(30)),
-  ///   grpc_initial_connection_window_size: Some(64 * 1024 * 1024), // 64MB
-  ///   grpc_initial_stream_window_size: Some(64 * 1024 * 1024),     // 64MB
+  ///   grpc_initial_connection_window_size: Some(32 * 1024 * 1024), // 32MB
+  ///   grpc_initial_stream_window_size: Some(32 * 1024 * 1024),     // 32MB
   ///   grpc_max_decoding_message_size: Some(1 * 1024 * 1024 * 1024), // 1GB
   ///   grpc_max_encoding_message_size: Some(32 * 1024 * 1024),     // 32MB
   ///   grpc_http2_adaptive_window: Some(true),
@@ -75,8 +75,8 @@ impl Default for JsChannelOptions {
     Self {
       grpc_connect_timeout: Some(10_000),
       grpc_timeout: Some(30_000),
-      grpc_initial_connection_window_size: Some(64 * 1024 * 1024), // 64MB
-      grpc_initial_stream_window_size: Some(64 * 1024 * 1024),     // 64MB
+      grpc_initial_connection_window_size: Some(32 * 1024 * 1024), // 32MB
+      grpc_initial_stream_window_size: Some(32 * 1024 * 1024),     // 32MB
       grpc_max_decoding_message_size: Some(1024 * 1024 * 1024),   // 1GB
       grpc_max_encoding_message_size: Some(32 * 1024 * 1024),     // 32MB
       grpc_http2_adaptive_window: Some(true),

--- a/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
@@ -56,8 +56,8 @@ impl Default for JsChannelOptions {
   /// JsChannelOptions {
   ///   grpc_connect_timeout: Duration::from_secs(10),
   ///   grpc_timeout: Some(Duration::from_secs(30)),
-  ///   grpc_initial_connection_window_size: Some(8 * 1024 * 1024), // 8MB
-  ///   grpc_initial_stream_window_size: Some(4 * 1024 * 1024),     // 4MB
+  ///   grpc_initial_connection_window_size: Some(64 * 1024 * 1024), // 64MB
+  ///   grpc_initial_stream_window_size: Some(64 * 1024 * 1024),     // 64MB
   ///   grpc_max_decoding_message_size: Some(1 * 1024 * 1024 * 1024), // 1GB
   ///   grpc_max_encoding_message_size: Some(32 * 1024 * 1024),     // 32MB
   ///   grpc_http2_adaptive_window: Some(true),
@@ -75,8 +75,8 @@ impl Default for JsChannelOptions {
     Self {
       grpc_connect_timeout: Some(10_000),
       grpc_timeout: Some(30_000),
-      grpc_initial_connection_window_size: Some(8 * 1024 * 1024), // 8MB
-      grpc_initial_stream_window_size: Some(4 * 1024 * 1024),     // 4MB
+      grpc_initial_connection_window_size: Some(64 * 1024 * 1024), // 64MB
+      grpc_initial_stream_window_size: Some(64 * 1024 * 1024),     // 64MB
       grpc_max_decoding_message_size: Some(1024 * 1024 * 1024),   // 1GB
       grpc_max_encoding_message_size: Some(32 * 1024 * 1024),     // 32MB
       grpc_http2_adaptive_window: Some(true),

--- a/yellowstone-grpc-client-nodejs/package.json
+++ b/yellowstone-grpc-client-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triton-one/yellowstone-grpc",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "license": "Apache-2.0",
   "author": "Triton One",
   "description": "Yellowstone gRPC Geyser Node.js Client",

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "12.0.0"
+version = "12.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Simple Client"

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -229,10 +229,14 @@ pub struct GeyserGrpcBuilder {
 }
 
 impl GeyserGrpcBuilder {
-    // Create new builder
-    const fn new(endpoint: Endpoint) -> Self {
+    // Create new builder with optimized HTTP/2 flow control defaults.
+    // Sets stream and connection window sizes to 64MB to prevent
+    // flow control bottlenecks on high-throughput subscriptions.
+    fn new(endpoint: Endpoint) -> Self {
         Self {
-            endpoint,
+            endpoint: endpoint
+                .initial_stream_window_size(64 * 1024 * 1024) // 64MB
+                .initial_connection_window_size(64 * 1024 * 1024), // 64MB
             x_token: None,
             x_request_snapshot: false,
             send_compressed: None,

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -229,14 +229,9 @@ pub struct GeyserGrpcBuilder {
 }
 
 impl GeyserGrpcBuilder {
-    // Create new builder with optimized HTTP/2 flow control defaults.
-    // Sets stream and connection window sizes to 64MB to prevent
-    // flow control bottlenecks on high-throughput subscriptions.
     fn new(endpoint: Endpoint) -> Self {
         Self {
-            endpoint: endpoint
-                .initial_stream_window_size(64 * 1024 * 1024) // 64MB
-                .initial_connection_window_size(64 * 1024 * 1024), // 64MB
+            endpoint,
             x_token: None,
             x_request_snapshot: false,
             send_compressed: None,
@@ -246,12 +241,23 @@ impl GeyserGrpcBuilder {
         }
     }
 
+    /// Apply optimized HTTP/2 flow control defaults (32MB stream + connection window).
+    fn with_default_window_sizes(endpoint: Endpoint) -> Endpoint {
+        endpoint
+            .initial_stream_window_size(32 * 1024 * 1024)
+            .initial_connection_window_size(32 * 1024 * 1024)
+    }
+
     pub fn from_shared(endpoint: impl Into<Bytes>) -> GeyserGrpcBuilderResult<Self> {
-        Ok(Self::new(Endpoint::from_shared(endpoint)?))
+        Ok(Self::new(Self::with_default_window_sizes(
+            Endpoint::from_shared(endpoint)?,
+        )))
     }
 
     pub fn from_static(endpoint: &'static str) -> Self {
-        Self::new(Endpoint::from_static(endpoint))
+        Self::new(Self::with_default_window_sizes(
+            Endpoint::from_static(endpoint),
+        ))
     }
 
     // Create client


### PR DESCRIPTION
## Summary

Increase the default HTTP/2 stream and connection window sizes to 32MB across all clients to improve throughput on high-latency connections, and document recommended OS-level TCP tuning in the README.

### Motivation

Benchmarking over an intercontinental connection (Pittsburgh, PA → Frankfurt, Germany) showed that HTTP/2 flow control window sizes are a major throughput bottleneck. Increasing the window size to 32MB provides optimal throughput without excessive memory overhead.

#### Throughput benchmark: HTTP/2 window size vs TCP buffer size

Measured using LaserStream replay (subscribing to all accounts, slots, transactions, transaction statuses, entries, and blocks meta from `current_slot - 300`) over a Pittsburgh-to-Frankfurt intercontinental connection, 5 seconds per configuration:

| TCP Buffer ↓ \ Window → | hyper default | 64KB | 4MB | 8MB | 16MB | 32MB | 64MB |
|---|---|---|---|---|---|---|---|
| **4MB** | 14.67 MB/s | 0.33 MB/s | 28.25 MB/s | 26.77 MB/s | 28.19 MB/s | 26.73 MB/s | 28.29 MB/s |
| **8MB** | 14.48 MB/s | 0.31 MB/s | 28.72 MB/s | 52.44 MB/s | 55.13 MB/s | 52.42 MB/s | 52.59 MB/s |
| **16MB** | 14.68 MB/s | 0.55 MB/s | 28.63 MB/s | 55.90 MB/s | 102.48 MB/s | 94.11 MB/s | 101.99 MB/s |
| **32MB** | 14.66 MB/s | 0.55 MB/s | 28.68 MB/s | 55.97 MB/s | 99.51 MB/s | **118.38 MB/s** | **124.47 MB/s** |
| **64MB** | 14.57 MB/s | 0.54 MB/s | 28.79 MB/s | 54.81 MB/s | 100.43 MB/s | 100.74 MB/s | 102.22 MB/s |

Key findings:
- **hyper default** caps at ~14.6 MB/s regardless of TCP buffer size. Hyper's default starts at the HTTP/2 spec value (65535 bytes) but uses adaptive flow control that grows the window dynamically — explaining why it performs ~30x better than an explicit 64KB setting
- **Explicit 64KB** (~0.5 MB/s) hard-locks the window at 65535 bytes with no adaptation, confirming flow control is the bottleneck
- **Sweet spot is 32MB TCP + 32-64MB window** at ~118-124 MB/s
- 64MB TCP buffer performs *worse* than 32MB (likely buffer bloat / memory pressure)
- Throughput roughly doubles at each window size step: 4MB→8MB→16MB, then plateaus
- 32MB window provides 8x improvement over hyper's default with minimal memory overhead

### Changes

**Rust client library** (`yellowstone-grpc-client`):
- `initial_stream_window_size`: unset (hyper default) → 32MB
- `initial_connection_window_size`: unset (hyper default) → 32MB
- Defaults applied in `from_shared()`/`from_static()`, not in `new()`, so clients that construct the builder with a pre-configured `Endpoint` are not overridden

**Node.js client** (`yellowstone-grpc-client-nodejs`):
- `grpc_initial_connection_window_size`: 8MB → 32MB
- `grpc_initial_stream_window_size`: 4MB → 32MB

**Rust example client**:
- `--initial-stream-window-size` and `--initial-connection-window-size` are now optional
- If not specified, uses library default (32MB). Previously always overrode with 64MB.

**Go example client**:
- `grpc.WithInitialWindowSize(32MB)` and `grpc.WithInitialConnWindowSize(32MB)`

**Python example client**:
- Added `grpc.initial_window_size` and `grpc.initial_connection_window_size` (32MB)
- Previously unset, using gRPC-Python's default

**README**:
- Updated "System Tuning" section with recommended `sysctl` settings for 32MB TCP receive buffers

### Trade-offs

32MB window sizes allow the sender to push ~32MB of data before waiting for flow control ACKs, which is critical on high-latency links. The memory overhead (~32MB worst case per stream) is negligible for most use cases. The benchmarks show diminishing returns above 32MB, making it the optimal default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)