### PR TITLE
add precommit hooks for signing + formatting checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ cd "$repo_root"
 # Ensure commit signing is enabled before allowing commit to continue.
 if [[ "$(git config --bool --get commit.gpgsign || true)" != "true" ]]; then
   echo "[pre-commit] ERROR: commit signing is not enabled."
-  echo "[pre-commit] Set it with: git config commit.gpgsign true"
+  echo "[pre-commit] Commit is the -S flag OR Set it with: git config commit.gpgsign true"
   exit 1
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Exit on command errors, undefined vars, and failed pipelines.
+set -euo pipefail
+
+# Resolve and switch to repository root so relative paths are stable.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Ensure commit signing is enabled before allowing commit to continue.
+if [[ "$(git config --bool --get commit.gpgsign || true)" != "true" ]]; then
+  echo "[pre-commit] ERROR: commit signing is not enabled."
+  echo "[pre-commit] Set it with: git config commit.gpgsign true"
+  exit 1
+fi
+
+# Run root workspace formatting check (warning only, does not block commit).
+if ! cargo fmt --all -- --check; then
+  echo "[pre-commit] WARNING: formatting check failed (cargo fmt --all -- --check)."
+  echo "[pre-commit] Run: cargo fmt --all"
+fi
+
+# If staged changes include files under napi, run formatting check there too.
+if git diff --cached --name-only -- 'yellowstone-grpc-client-nodejs/napi/**' | grep -q .; then
+  # Run the check in the napi crate directory (warning only).
+  if ! (
+    cd yellowstone-grpc-client-nodejs/napi
+    cargo fmt --all -- --check
+  ); then
+    echo "[pre-commit] WARNING: formatting check failed in yellowstone-grpc-client-nodejs/napi."
+    echo "[pre-commit] Run: (cd yellowstone-grpc-client-nodejs/napi && cargo fmt --all)"
+  fi
+fi

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ clean-napi:
 	rm -rf yellowstone-grpc-client-nodejs/napi/index.js
 	rm -rf yellowstone-grpc-client-nodejs/napi/index.d.ts
 
+install-hooks:
+	git config core.hooksPath .githooks
+
 solana-encoding-napi-clippy:
 	cd yellowstone-grpc-client-nodejs/napi && \
 		cargo clippy

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains a fully functional gRPC interface for Solana, built and maint
 
 It provides the ability to get slots, blocks, transactions, and account update notifications over a standardised path.
 
-For additional documentation,  please see: https://docs.triton.one/rpc-pool/grpc-subscriptions
+For additional documentation, please see: https://docs.triton.one/rpc-pool/grpc-subscriptions
 
 #### Known bugs
 
@@ -22,6 +22,19 @@ solana-validator --geyser-plugin-config yellowstone-grpc-geyser/config.json
 cargo-fmt && cargo run --bin config-check -- --config yellowstone-grpc-geyser/config.json
 ```
 
+### Pre-commit hooks
+
+Install repository hooks:
+
+```bash
+make install-hooks
+```
+
+The pre-commit hook will:
+
+- ensure commit signing is enabled (`commit.gpgsign=true`)
+- run `cargo fmt --all -- --check` and print a warning if formatting fails
+
 ### Block reconstruction
 
 Geyser interface on block update does not provide detailed information about transactions and account updates. To provide this information with a block message, we must collect all messages and expect a specified order. By default, if we failed to reconstruct full block, we log an error message and increase the `invalid_full_blocks_total` counter in prometheus metrics. If you want to panic on invalid reconstruction, change the option `block_fail_action` in config to `panic` (default value is `log`).
@@ -30,32 +43,32 @@ Geyser interface on block update does not provide detailed information about tra
 
 Please check [yellowstone-grpc-proto/proto/geyser.proto](yellowstone-grpc-proto/proto/geyser.proto) for details.
 
-   - `commitment` — commitment level: `processed` / `confirmed` / `finalized`
-   - `accounts_data_slice` — array of objects `{ offset: uint64, length: uint64 }`, allow to receive only required data from accounts
-   - `ping` — optional boolean field. Some cloud providers (like Cloudflare, Fly.io) close the stream if the client doesn't send anything during some time. You can send the same filter every N seconds as a workaround, but this would not be optimal since you need to keep this filter. Instead, you can send a subscribe request with `ping` field set to `true` and ignore the rest of the fields in the request. Since we sent a `Ping` message every 15s from the server, you can send a subscribe request with `ping` as a reply and receive a `Pong` message.
+- `commitment` — commitment level: `processed` / `confirmed` / `finalized`
+- `accounts_data_slice` — array of objects `{ offset: uint64, length: uint64 }`, allow to receive only required data from accounts
+- `ping` — optional boolean field. Some cloud providers (like Cloudflare, Fly.io) close the stream if the client doesn't send anything during some time. You can send the same filter every N seconds as a workaround, but this would not be optimal since you need to keep this filter. Instead, you can send a subscribe request with `ping` field set to `true` and ignore the rest of the fields in the request. Since we sent a `Ping` message every 15s from the server, you can send a subscribe request with `ping` as a reply and receive a `Pong` message.
 
 #### Slots
 
-   - `filter_by_commitment` — by default, slots are sent for all commitment levels, but with this filter, you can receive only the selected commitment level
+- `filter_by_commitment` — by default, slots are sent for all commitment levels, but with this filter, you can receive only the selected commitment level
 
 #### Account
 
 Accounts can be filtered by:
 
-   - `account` — account Pubkey, match to any Pubkey from the array
-   - `owner` — account owner Pubkey, match to any Pubkey from the array
-   - `filters` — same as `getProgramAccounts` filters, array of `dataSize` or `Memcmp` (bytes, base58, base64 are supported)
+- `account` — account Pubkey, match to any Pubkey from the array
+- `owner` — account owner Pubkey, match to any Pubkey from the array
+- `filters` — same as `getProgramAccounts` filters, array of `dataSize` or `Memcmp` (bytes, base58, base64 are supported)
 
 If all fields are empty, then all accounts are broadcast. Otherwise, fields work as logical `AND` and values in arrays as logical `OR` (except values in `filters` that works as logical `AND`).
 
 #### Transactions
 
-   - `vote` — enable/disable broadcast `vote` transactions
-   - `failed` — enable/disable broadcast `failed` transactions
-   - `signature` — match only specified transaction
-   - `account_include` — filter transactions that use any account from the list
-   - `account_exclude` — opposite to `account_include`
-   - `account_required` — require all accounts from the list to be used in the transaction
+- `vote` — enable/disable broadcast `vote` transactions
+- `failed` — enable/disable broadcast `failed` transactions
+- `signature` — match only specified transaction
+- `account_include` — filter transactions that use any account from the list
+- `account_exclude` — opposite to `account_include`
+- `account_required` — require all accounts from the list to be used in the transaction
 
 If all fields are empty, then all transactions are broadcast. Otherwise, fields work as logical `AND` and values in arrays as logical `OR`.
 
@@ -65,10 +78,10 @@ Currently, we do not have filters for the entries, all entries are broadcast.
 
 #### Blocks
 
-   - `account_include` — filter transactions and accounts that use any account from the list
-   - `include_transactions` — include all transactions
-   - `include_accounts` — include all accounts updates
-   - `include_entries` — include all entries
+- `account_include` — filter transactions and accounts that use any account from the list
+- `include_transactions` — include all transactions
+- `include_accounts` — include all accounts updates
+- `include_entries` — include all entries
 
 #### Blocks meta
 
@@ -135,15 +148,15 @@ It's possible to add limits for filters in the config. If the `filters` field is
 
 ### Examples
 
-   - [Go](examples/golang)
-   - [Rust](examples/rust)
-   - [TypeScript](examples/typescript)
+- [Go](examples/golang)
+- [Rust](examples/rust)
+- [TypeScript](examples/typescript)
 
 > [!NOTE]
 > Some load balancers will terminate gRPC connections if no messages are sent from the client for a period of time.
-In order to mitigate this, you need to send a message periodically. The `ping` field in the SubscribeRequest is used for this purpose.
-The gRPC server already sends pings to the client, so you can reply with a ping, and your connection will remain open.
-You can see in the rust example how to reply to the ping from the server with the client.
+> In order to mitigate this, you need to send a message periodically. The `ping` field in the SubscribeRequest is used for this purpose.
+> The gRPC server already sends pings to the client, so you can reply with a ping, and your connection will remain open.
+> You can see in the rust example how to reply to the ping from the server with the client.
 
 ### Projects based on Geyser gRPC
 


### PR DESCRIPTION
- Adds a repository pre-commit hook at pre-commit to enforce signed commits and run cargo formatting checks.
- Blocks commit when `commit.gpgsign` is not enabled (`true`).
- Runs `cargo fmt --all -- --check` at repo root and prints warnings (does not fail commit) when formatting is off.
- If staged files include `yellowstone-grpc-client-nodejs/napi/**`, runs an additional warning-only fmt check in that crate.
- Adds `install-hooks` target in Makefile to set `core.hooksPath` to .githooks.
- Documents setup/behavior in README.md, with minor Markdown formatting normalization in the same file.