### PR TITLE
Str 404 lv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5313,6 +5322,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 name = "yellowstone-grpc-client"
 version = "12.3.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "futures",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ publish = false
 [workspace.dependencies]
 affinity = "0.1.2"
 anyhow = "1.0.98"
+arc-swap = "1.0.0"
 backoff = "0.4.0"
 base64 = "0.22.1"
 bincode = "1.3.3"

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -16,6 +16,7 @@ account-data-as-bytes = [
 ]
 
 [dependencies]
+arc-swap = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 hyper-util = { workspace = true }

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -11,7 +11,6 @@ use {
         stream::Stream,
     },
     std::{
-        ops::Sub,
         path::PathBuf,
         sync::{Arc, Mutex},
         time::Duration,
@@ -39,6 +38,7 @@ use {
 };
 
 #[derive(Debug, Clone)]
+/// Interceptor that injects optional auth and snapshot metadata into requests.
 pub struct InterceptorXToken {
     pub x_token: Option<AsciiMetadataValue>,
     pub x_request_snapshot: bool,
@@ -71,6 +71,7 @@ pub enum GeyserGrpcClientError {
 pub type GeyserGrpcClientResult<T> = Result<T, GeyserGrpcClientError>;
 
 #[derive(Clone)]
+/// Configuration for automatic subscribe reconnect behavior.
 pub struct ReconnectConfig {
     pub backoff: Backoff,
     pub x_request_snapshot: bool,
@@ -107,6 +108,7 @@ impl ReconnectConfig {
 }
 
 #[derive(Clone)]
+/// High-level gRPC client exposing unary RPCs and streaming subscribe APIs.
 pub struct GeyserGrpcClient {
     pub health: HealthClient<InterceptedService<Channel, InterceptorXToken>>,
     pub geyser: GeyserClient<InterceptedService<Channel, InterceptorXToken>>,
@@ -127,10 +129,12 @@ impl GeyserGrpcClient {
     }
 }
 
+/// A stream of subscribe updates with automatic reconnect and deduplication.
 pub struct GeyserStream {
     inner: AutoReconnect<Streaming<SubscribeUpdate>, TonicGrpcConnector>,
 }
 
+/// A stream of deshred updates returned by `subscribe_deshred*` APIs.
 pub struct SubscribeDeshredStream {
     inner: Streaming<SubscribeUpdateDeshred>,
 }
@@ -157,6 +161,11 @@ impl Stream for GeyserStream {
     }
 }
 
+/// User-facing sink for subscribe requests on a bidirectional stream.
+///
+/// The inner sender is swappable so reconnect logic can replace the active
+/// request channel while keeping this sink instance alive.
+#[derive(Clone)]
 pub struct SubscribeRequestSink {
     inner: Arc<Mutex<mpsc::Sender<SubscribeRequest>>>,
     shared: Arc<ArcSwap<SubscribeRequest>>,
@@ -164,6 +173,7 @@ pub struct SubscribeRequestSink {
 
 #[derive(Debug, thiserror::Error)]
 #[error("{inner}")]
+/// Error emitted by `SubscribeRequestSink` operations.
 pub struct SubscribeRequestSinkError {
     inner: mpsc::SendError,
 }
@@ -175,13 +185,10 @@ impl From<mpsc::SendError> for SubscribeRequestSinkError {
 }
 
 impl Sink<SubscribeRequest> for SubscribeRequestSink {
-    // TODO: this is bad API design, because it leaks implementation details of the sink. We should ideally hide the fact that we're using an mpsc channel under the hood, but tonic's streaming API requires us to return a Sink for sending requests,
-    // so we have to wrap it like this to be able to update the shared state on each request.
-    // But for the time being, in order to not break the existing API, we'll just return the same error types.
     type Error = SubscribeRequestSinkError;
 
     fn poll_ready(
-        mut self: std::pin::Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         let mut inner = self
@@ -194,7 +201,7 @@ impl Sink<SubscribeRequest> for SubscribeRequestSink {
     }
 
     fn start_send(
-        mut self: std::pin::Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         item: SubscribeRequest,
     ) -> Result<(), Self::Error> {
         let mut inner = self
@@ -209,7 +216,7 @@ impl Sink<SubscribeRequest> for SubscribeRequestSink {
     }
 
     fn poll_flush(
-        mut self: std::pin::Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         let mut inner = self
@@ -220,7 +227,7 @@ impl Sink<SubscribeRequest> for SubscribeRequestSink {
     }
 
     fn poll_close(
-        mut self: std::pin::Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         let mut inner = self
@@ -452,6 +459,7 @@ pub enum GeyserGrpcBuilderError {
 pub type GeyserGrpcBuilderResult<T> = Result<T, GeyserGrpcBuilderError>;
 
 #[derive(Debug)]
+/// Builder for constructing a configured `GeyserGrpcClient`.
 pub struct GeyserGrpcBuilder {
     pub endpoint: Endpoint,
     pub x_token: Option<AsciiMetadataValue>,

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -1,8 +1,10 @@
 mod stream;
 
+use std::ops::Sub;
+
 pub use tonic::{service::Interceptor, transport::ClientTlsConfig};
 use {
-    crate::stream::{AutoReconnect, Backoff, DedupConfig},
+    crate::stream::Backoff,
     bytes::Bytes,
     futures::{
         channel::mpsc,
@@ -58,15 +60,15 @@ pub enum GeyserGrpcClientError {
     TonicStatus(#[from] Status),
     #[error("Failed to send subscribe request: {0}")]
     SubscribeSendError(#[from] mpsc::SendError),
+    #[error("gRPC transport error: {0}")]
+    TransportError(#[from] tonic::transport::Error),
 }
 
 pub type GeyserGrpcClientResult<T> = Result<T, GeyserGrpcClientError>;
 
 #[derive(Clone)]
 pub(crate) struct ReconnectConfig {
-    pub endpoint: Endpoint,
     pub backoff: Backoff,
-    pub x_token: Option<AsciiMetadataValue>,
     pub x_request_snapshot: bool,
     pub send_compressed: Option<CompressionEncoding>,
     pub accept_compressed: Option<CompressionEncoding>,
@@ -74,14 +76,27 @@ pub(crate) struct ReconnectConfig {
     pub max_encoding_message_size: Option<usize>,
 }
 
+impl ReconnectConfig {
+    pub(crate) fn no_reconnect() -> Self {
+        Self {
+            backoff: Backoff::new(Duration::from_millis(0), Duration::from_millis(0), 1.0, 0),
+            x_request_snapshot: false,
+            send_compressed: None,
+            accept_compressed: None,
+            max_decoding_message_size: None,
+            max_encoding_message_size: None,
+        }
+    }
+}
+
 #[derive(Clone)]
-pub struct GeyserGrpcClient<F> {
-    pub health: HealthClient<InterceptedService<Channel, F>>,
-    pub geyser: GeyserClient<InterceptedService<Channel, F>>,
+pub struct GeyserGrpcClient {
+    pub health: HealthClient<InterceptedService<Channel, InterceptorXToken>>,
+    pub geyser: GeyserClient<InterceptedService<Channel, InterceptorXToken>>,
     reconnect_config: Option<ReconnectConfig>,
 }
 
-impl GeyserGrpcClient<()> {
+impl GeyserGrpcClient {
     pub fn build_from_shared(
         endpoint: impl Into<Bytes>,
     ) -> GeyserGrpcBuilderResult<GeyserGrpcBuilder> {
@@ -93,10 +108,30 @@ impl GeyserGrpcClient<()> {
     }
 }
 
-impl<F: Interceptor> GeyserGrpcClient<F> {
+pub struct GeyserStream {
+    inner: Streaming<SubscribeUpdate>,
+}
+
+pub struct SubscribeDeshredStream {
+    inner: Streaming<SubscribeUpdateDeshred>,
+}
+
+impl Stream for GeyserStream {
+    type Item = Result<SubscribeUpdate, Status>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+
+impl GeyserGrpcClient {
     pub const fn new(
-        health: HealthClient<InterceptedService<Channel, F>>,
-        geyser: GeyserClient<InterceptedService<Channel, F>>,
+        health: HealthClient<InterceptedService<Channel, InterceptorXToken>>,
+        geyser: GeyserClient<InterceptedService<Channel, InterceptorXToken>>,
     ) -> Self {
         Self {
             health,
@@ -134,12 +169,12 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
         self.subscribe_with_request(None).await
     }
 
-    pub async fn subscribe_with_request(
+    pub(crate) async fn subscribe_raw(
         &mut self,
         request: Option<SubscribeRequest>,
     ) -> GeyserGrpcClientResult<(
-        impl Sink<SubscribeRequest, Error = mpsc::SendError> + use<F>,
-        impl Stream<Item = Result<SubscribeUpdate, Status>> + use<F>,
+        impl Sink<SubscribeRequest, Error = mpsc::SendError>,
+        Streaming<SubscribeUpdate>,
     )> {
         let (mut subscribe_tx, subscribe_rx) = mpsc::unbounded();
         if let Some(request) = request {
@@ -153,20 +188,23 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
         Ok((subscribe_tx, response.into_inner()))
     }
 
+    pub async fn subscribe_with_request(
+        &mut self,
+        request: Option<SubscribeRequest>,
+    ) -> GeyserGrpcClientResult<(
+        impl Sink<SubscribeRequest, Error = mpsc::SendError>,
+        GeyserStream,
+    )> {
+        self.subscribe_raw(request).await.map(|(sink, stream)| (sink, GeyserStream { inner: stream }))
+    }
+
     pub async fn subscribe_once(
         &mut self,
         request: SubscribeRequest,
-    ) -> GeyserGrpcClientResult<impl Stream<Item = Result<SubscribeUpdate, Status>>>
-    where
-        F: 'static,
+    ) -> GeyserGrpcClientResult<GeyserStream>
     {
         let (_sink, stream) = self.subscribe_with_request(Some(request.clone())).await?;
-
-        if let Some(config) = self.reconnect_config.take() {
-            Ok(AutoReconnect::new(stream.boxed(), request, DedupConfig::default(), config).boxed())
-        } else {
-            Ok(stream.boxed())
-        }
+        Ok(stream)
     }
 
     // Subscribe Deshred
@@ -174,7 +212,7 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
         &mut self,
     ) -> GeyserGrpcClientResult<(
         impl Sink<SubscribeDeshredRequest, Error = mpsc::SendError>,
-        impl Stream<Item = Result<SubscribeUpdateDeshred, Status>>,
+        SubscribeDeshredStream,
     )> {
         self.subscribe_deshred_with_request(None).await
     }
@@ -183,8 +221,8 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
         &mut self,
         request: Option<SubscribeDeshredRequest>,
     ) -> GeyserGrpcClientResult<(
-        impl Sink<SubscribeDeshredRequest, Error = mpsc::SendError> + use<F>,
-        impl Stream<Item = Result<SubscribeUpdateDeshred, Status>> + use<F>,
+        impl Sink<SubscribeDeshredRequest, Error = mpsc::SendError>,
+        SubscribeDeshredStream,
     )> {
         let (mut subscribe_tx, subscribe_rx) = mpsc::unbounded();
         if let Some(request) = request {
@@ -195,13 +233,13 @@ impl<F: Interceptor> GeyserGrpcClient<F> {
         }
         let response: Response<Streaming<SubscribeUpdateDeshred>> =
             self.geyser.subscribe_deshred(subscribe_rx).await?;
-        Ok((subscribe_tx, response.into_inner()))
+        Ok((subscribe_tx, SubscribeDeshredStream { inner: response.into_inner() }))
     }
 
     pub async fn subscribe_deshred_once(
         &mut self,
         request: SubscribeDeshredRequest,
-    ) -> GeyserGrpcClientResult<impl Stream<Item = Result<SubscribeUpdateDeshred, Status>>> {
+    ) -> GeyserGrpcClientResult<SubscribeDeshredStream> {
         self.subscribe_deshred_with_request(Some(request))
             .await
             .map(|(_sink, stream)| stream)
@@ -326,12 +364,10 @@ impl GeyserGrpcBuilder {
     fn build(
         self,
         channel: Channel,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient<impl Interceptor + Clone>> {
+    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
         let reconnect_config = if self.auto_reconnect {
             Some(ReconnectConfig {
-                endpoint: self.endpoint.clone(),
                 backoff: Backoff::default(),
-                x_token: self.x_token.clone(),
                 x_request_snapshot: self.x_request_snapshot,
                 send_compressed: self.send_compressed,
                 accept_compressed: self.accept_compressed,
@@ -370,14 +406,14 @@ impl GeyserGrpcBuilder {
 
     pub async fn connect(
         self,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient<impl Interceptor + Clone>> {
+    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
         let channel = self.endpoint.connect().await?;
         self.build(channel)
     }
 
     pub fn connect_lazy(
         self,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient<impl Interceptor + Clone>> {
+    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
         let channel = self.endpoint.connect_lazy();
         self.build(channel)
     }
@@ -390,7 +426,7 @@ impl GeyserGrpcBuilder {
     pub async fn connect_uds(
         self,
         path: impl Into<PathBuf>,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient<impl Interceptor + Clone>> {
+    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
         let path = path.into();
 
         // tonic needs an Endpoint to hang config off of, but the URI is ignored

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -1,17 +1,21 @@
 mod stream;
 
-use std::ops::Sub;
-
 pub use tonic::{service::Interceptor, transport::ClientTlsConfig};
 use {
-    crate::stream::Backoff,
+    crate::stream::{AutoReconnect, Backoff, DedupState, DedupStream, TonicGrpcConnector},
+    arc_swap::ArcSwap,
     bytes::Bytes,
     futures::{
         channel::mpsc,
         sink::{Sink, SinkExt},
-        stream::{Stream, StreamExt},
+        stream::Stream,
     },
-    std::{path::PathBuf, time::Duration},
+    std::{
+        ops::Sub,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+        time::Duration,
+    },
     tokio::net::UnixStream,
     tonic::{
         codec::{CompressionEncoding, Streaming},
@@ -67,7 +71,7 @@ pub enum GeyserGrpcClientError {
 pub type GeyserGrpcClientResult<T> = Result<T, GeyserGrpcClientError>;
 
 #[derive(Clone)]
-pub(crate) struct ReconnectConfig {
+pub struct ReconnectConfig {
     pub backoff: Backoff,
     pub x_request_snapshot: bool,
     pub send_compressed: Option<CompressionEncoding>,
@@ -76,8 +80,21 @@ pub(crate) struct ReconnectConfig {
     pub max_encoding_message_size: Option<usize>,
 }
 
+impl Default for ReconnectConfig {
+    fn default() -> Self {
+        Self {
+            backoff: Backoff::default(),
+            x_request_snapshot: false,
+            send_compressed: None,
+            accept_compressed: None,
+            max_decoding_message_size: None,
+            max_encoding_message_size: None,
+        }
+    }
+}
+
 impl ReconnectConfig {
-    pub(crate) fn no_reconnect() -> Self {
+    pub fn no_reconnect() -> Self {
         Self {
             backoff: Backoff::new(Duration::from_millis(0), Duration::from_millis(0), 1.0, 0),
             x_request_snapshot: false,
@@ -93,7 +110,9 @@ impl ReconnectConfig {
 pub struct GeyserGrpcClient {
     pub health: HealthClient<InterceptedService<Channel, InterceptorXToken>>,
     pub geyser: GeyserClient<InterceptedService<Channel, InterceptorXToken>>,
-    reconnect_config: Option<ReconnectConfig>,
+    reconnect_config: ReconnectConfig,
+    reconnect_endpoint: Option<Endpoint>,
+    reconnect_x_token: Option<AsciiMetadataValue>,
 }
 
 impl GeyserGrpcClient {
@@ -109,11 +128,22 @@ impl GeyserGrpcClient {
 }
 
 pub struct GeyserStream {
-    inner: Streaming<SubscribeUpdate>,
+    inner: AutoReconnect<Streaming<SubscribeUpdate>, TonicGrpcConnector>,
 }
 
 pub struct SubscribeDeshredStream {
     inner: Streaming<SubscribeUpdateDeshred>,
+}
+
+impl Stream for SubscribeDeshredStream {
+    type Item = Result<SubscribeUpdateDeshred, Status>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::pin::Pin::new(&mut self.inner).poll_next(cx)
+    }
 }
 
 impl Stream for GeyserStream {
@@ -123,20 +153,95 @@ impl Stream for GeyserStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.inner.poll_next_unpin(cx)
+        std::pin::Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 
+pub struct SubscribeRequestSink {
+    inner: Arc<Mutex<mpsc::Sender<SubscribeRequest>>>,
+    shared: Arc<ArcSwap<SubscribeRequest>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{inner}")]
+pub struct SubscribeRequestSinkError {
+    inner: mpsc::SendError,
+}
+
+impl From<mpsc::SendError> for SubscribeRequestSinkError {
+    fn from(err: mpsc::SendError) -> Self {
+        Self { inner: err }
+    }
+}
+
+impl Sink<SubscribeRequest> for SubscribeRequestSink {
+    // TODO: this is bad API design, because it leaks implementation details of the sink. We should ideally hide the fact that we're using an mpsc channel under the hood, but tonic's streaming API requires us to return a Sink for sending requests,
+    // so we have to wrap it like this to be able to update the shared state on each request.
+    // But for the time being, in order to not break the existing API, we'll just return the same error types.
+    type Error = SubscribeRequestSinkError;
+
+    fn poll_ready(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("subscribe request sink mutex poisoned");
+        std::pin::Pin::new(&mut *inner)
+            .poll_ready(cx)
+            .map_err(Into::into)
+    }
+
+    fn start_send(
+        mut self: std::pin::Pin<&mut Self>,
+        item: SubscribeRequest,
+    ) -> Result<(), Self::Error> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("subscribe request sink mutex poisoned");
+        inner
+            .start_send_unpin(item.clone())
+            .map_err(SubscribeRequestSinkError::from)?;
+        self.shared.store(Arc::new(item));
+        Ok(())
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("subscribe request sink mutex poisoned");
+        inner.poll_flush_unpin(cx).map_err(Into::into)
+    }
+
+    fn poll_close(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("subscribe request sink mutex poisoned");
+        inner.poll_close_unpin(cx).map_err(Into::into)
+    }
+}
 
 impl GeyserGrpcClient {
-    pub const fn new(
+    pub fn new(
         health: HealthClient<InterceptedService<Channel, InterceptorXToken>>,
         geyser: GeyserClient<InterceptedService<Channel, InterceptorXToken>>,
     ) -> Self {
         Self {
             health,
             geyser,
-            reconnect_config: None,
+            reconnect_config: ReconnectConfig::no_reconnect(),
+            reconnect_endpoint: None,
+            reconnect_x_token: None,
         }
     }
 
@@ -162,22 +267,16 @@ impl GeyserGrpcClient {
     // Subscribe
     pub async fn subscribe(
         &mut self,
-    ) -> GeyserGrpcClientResult<(
-        impl Sink<SubscribeRequest, Error = mpsc::SendError>,
-        impl Stream<Item = Result<SubscribeUpdate, Status>>,
-    )> {
+    ) -> GeyserGrpcClientResult<(SubscribeRequestSink, GeyserStream)> {
         self.subscribe_with_request(None).await
     }
 
     pub(crate) async fn subscribe_raw(
         &mut self,
         request: Option<SubscribeRequest>,
-    ) -> GeyserGrpcClientResult<(
-        impl Sink<SubscribeRequest, Error = mpsc::SendError>,
-        Streaming<SubscribeUpdate>,
-    )> {
-        let (mut subscribe_tx, subscribe_rx) = mpsc::unbounded();
-        if let Some(request) = request {
+    ) -> GeyserGrpcClientResult<(SubscribeRequestSink, Streaming<SubscribeUpdate>)> {
+        let (mut subscribe_tx, subscribe_rx) = mpsc::channel(1000);
+        if let Some(request) = request.clone() {
             subscribe_tx
                 .send(request)
                 .await
@@ -185,24 +284,46 @@ impl GeyserGrpcClient {
         }
         let response: Response<Streaming<SubscribeUpdate>> =
             self.geyser.subscribe(subscribe_rx).await?;
-        Ok((subscribe_tx, response.into_inner()))
+        let sink = SubscribeRequestSink {
+            inner: Arc::new(Mutex::new(subscribe_tx)),
+            shared: Arc::new(ArcSwap::new(Arc::new(request.unwrap_or_default()))),
+        };
+        Ok((sink, response.into_inner()))
     }
 
     pub async fn subscribe_with_request(
         &mut self,
         request: Option<SubscribeRequest>,
-    ) -> GeyserGrpcClientResult<(
-        impl Sink<SubscribeRequest, Error = mpsc::SendError>,
-        GeyserStream,
-    )> {
-        self.subscribe_raw(request).await.map(|(sink, stream)| (sink, GeyserStream { inner: stream }))
+    ) -> GeyserGrpcClientResult<(SubscribeRequestSink, GeyserStream)> {
+        let reconnect_config = self.reconnect_config.clone();
+        let endpoint = self
+            .reconnect_endpoint
+            .clone()
+            .unwrap_or_else(|| Endpoint::from_static("http://127.0.0.1:0"));
+        let reconnect_x_token = self.reconnect_x_token.clone();
+
+        self.subscribe_raw(request.clone())
+            .await
+            .map(|(sink, stream)| {
+                let connector = TonicGrpcConnector::new(
+                    endpoint,
+                    reconnect_config.clone(),
+                    reconnect_x_token,
+                    sink.inner.clone(),
+                );
+                let inner = AutoReconnect::new(
+                    DedupStream::new(stream, DedupState::default()),
+                    connector,
+                    sink.shared.clone(),
+                );
+                (sink, GeyserStream { inner })
+            })
     }
 
     pub async fn subscribe_once(
         &mut self,
         request: SubscribeRequest,
-    ) -> GeyserGrpcClientResult<GeyserStream>
-    {
+    ) -> GeyserGrpcClientResult<GeyserStream> {
         let (_sink, stream) = self.subscribe_with_request(Some(request.clone())).await?;
         Ok(stream)
     }
@@ -233,7 +354,12 @@ impl GeyserGrpcClient {
         }
         let response: Response<Streaming<SubscribeUpdateDeshred>> =
             self.geyser.subscribe_deshred(subscribe_rx).await?;
-        Ok((subscribe_tx, SubscribeDeshredStream { inner: response.into_inner() }))
+        Ok((
+            subscribe_tx,
+            SubscribeDeshredStream {
+                inner: response.into_inner(),
+            },
+        ))
     }
 
     pub async fn subscribe_deshred_once(
@@ -361,21 +487,19 @@ impl GeyserGrpcBuilder {
     }
 
     // Create client
-    fn build(
-        self,
-        channel: Channel,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
+    fn build(self, channel: Channel) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
+        let reconnect_x_token = self.x_token.clone();
         let reconnect_config = if self.auto_reconnect {
-            Some(ReconnectConfig {
+            ReconnectConfig {
                 backoff: Backoff::default(),
                 x_request_snapshot: self.x_request_snapshot,
                 send_compressed: self.send_compressed,
                 accept_compressed: self.accept_compressed,
                 max_decoding_message_size: self.max_decoding_message_size,
                 max_encoding_message_size: self.max_encoding_message_size,
-            })
+            }
         } else {
-            None
+            ReconnectConfig::no_reconnect()
         };
 
         let interceptor = InterceptorXToken {
@@ -401,19 +525,17 @@ impl GeyserGrpcBuilder {
             health: HealthClient::with_interceptor(channel, interceptor),
             geyser,
             reconnect_config,
+            reconnect_endpoint: Some(self.endpoint),
+            reconnect_x_token,
         })
     }
 
-    pub async fn connect(
-        self,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
+    pub async fn connect(self) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
         let channel = self.endpoint.connect().await?;
         self.build(channel)
     }
 
-    pub fn connect_lazy(
-        self,
-    ) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
+    pub fn connect_lazy(self) -> GeyserGrpcBuilderResult<GeyserGrpcClient> {
         let channel = self.endpoint.connect_lazy();
         self.build(channel)
     }
@@ -587,7 +709,12 @@ impl GeyserGrpcBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::GeyserGrpcClient;
+    use {
+        super::{GeyserGrpcClient, SubscribeRequest, SubscribeRequestSink},
+        arc_swap::ArcSwap,
+        futures::{channel::mpsc, FutureExt, SinkExt, StreamExt},
+        std::sync::{Arc, Mutex},
+    };
 
     #[tokio::test]
     async fn test_channel_https_success() {
@@ -655,5 +782,48 @@ mod tests {
             "Err(TonicError(tonic::transport::Error(InvalidUri, InvalidUri(InvalidFormat))))"
                 .to_owned()
         );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_request_sink_uses_swapped_sender() {
+        let (tx1, mut rx1) = mpsc::channel(8);
+        let (tx2, mut rx2) = mpsc::channel(8);
+
+        let shared = Arc::new(ArcSwap::new(Arc::new(SubscribeRequest::default())));
+        let mut sink = SubscribeRequestSink {
+            inner: Arc::new(Mutex::new(tx1)),
+            shared: shared.clone(),
+        };
+
+        let mut req1 = SubscribeRequest::default();
+        req1.from_slot = Some(11);
+        sink.send(req1).await.expect("first send must succeed");
+
+        let first = rx1
+            .next()
+            .await
+            .expect("first receiver should get first request");
+        assert_eq!(first.from_slot, Some(11));
+
+        *sink
+            .inner
+            .lock()
+            .expect("subscribe request sink mutex poisoned") = tx2;
+
+        let mut req2 = SubscribeRequest::default();
+        req2.from_slot = Some(22);
+        sink.send(req2).await.expect("second send must succeed");
+
+        let second = rx2
+            .next()
+            .await
+            .expect("second receiver should get second request");
+        assert_eq!(second.from_slot, Some(22));
+
+        match rx1.next().now_or_never() {
+            None | Some(None) => {}
+            Some(Some(_)) => panic!("old receiver must not get requests after sender swap"),
+        }
+        assert_eq!(shared.load_full().from_slot, Some(22));
     }
 }

--- a/yellowstone-grpc-client/src/stream.rs
+++ b/yellowstone-grpc-client/src/stream.rs
@@ -1,16 +1,26 @@
 use {
-    crate::{GeyserGrpcClient, GeyserGrpcClientError, InterceptorXToken, ReconnectConfig},
-    futures::stream::{BoxStream, Stream, StreamExt},
+    crate::{GeyserGrpcClientError, InterceptorXToken, ReconnectConfig},
+    arc_swap::ArcSwap,
+    futures::{
+        channel::mpsc,
+        sink::SinkExt,
+        stream::{Stream, StreamExt},
+    },
     std::{
-        collections::{HashMap, HashSet, VecDeque}, future::Future, pin::Pin, sync::{Arc, Mutex}, task::{Context, Poll}, time::Duration
+        collections::{HashMap, HashSet, VecDeque},
+        future::Future,
+        pin::Pin,
+        sync::{Arc, Mutex},
+        task::{Context, Poll},
+        time::Duration,
     },
     tonic::{
-        Code, Status, Streaming, codec::CompressionEncoding, metadata::AsciiMetadataValue, transport::Endpoint
+        codec::CompressionEncoding, metadata::AsciiMetadataValue, transport::Endpoint, Code,
+        Status, Streaming,
     },
-    tonic_health::pb::health_client::HealthClient,
     yellowstone_grpc_proto::{
         geyser::geyser_client::GeyserClient,
-        prelude::{SubscribeRequest, SubscribeUpdate, subscribe_update::UpdateOneof},
+        prelude::{subscribe_update::UpdateOneof, SubscribeRequest, SubscribeUpdate},
     },
 };
 
@@ -18,7 +28,6 @@ use {
 /// Conservative buffer to account for late-arriving events
 /// and out-of-order delivery within a slot.
 const CHECKPOINT_SLOT_BUFFER: u64 = 2;
-
 
 pub struct DedupStream<S> {
     state: DedupState,
@@ -166,21 +175,62 @@ impl DedupState {
 type ConnectFuture<S> =
     Pin<Box<dyn Future<Output = Result<DedupStream<S>, GeyserGrpcClientError>> + Send + 'static>>;
 
-
-
 #[derive(Debug, Clone)]
 pub struct Backoff {
     pub initial_interval: Duration,
     pub max_interval: Duration,
     pub multiplier: f64,
     pub max_retries: u32,
-    current_interval: Duration,
-    attempts: u32,
 }
 
 pub(crate) enum ErrorCategory<E> {
     Retryable(E),
     Unrecoverable(E),
+}
+
+impl<E> ErrorCategory<E> {
+    fn is_retryable(&self) -> bool {
+        matches!(self, Self::Retryable(_))
+    }
+
+    fn into_inner(self) -> E {
+        match self {
+            Self::Retryable(e) | Self::Unrecoverable(e) => e,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BackoffInstance {
+    current_interval: Duration,
+    attempts: u32,
+    max_interval: Duration,
+    multiplier: f64,
+    max_retries: u32,
+}
+
+impl BackoffInstance {
+    fn new(config: &Backoff) -> Self {
+        Self {
+            current_interval: config.initial_interval,
+            attempts: 0,
+            max_interval: config.max_interval,
+            multiplier: config.multiplier,
+            max_retries: config.max_retries,
+        }
+    }
+
+    fn exhausted(&self) -> bool {
+        self.attempts >= self.max_retries
+    }
+
+    fn advance(&mut self) {
+        self.attempts += 1;
+        self.current_interval = self
+            .current_interval
+            .mul_f64(self.multiplier)
+            .min(self.max_interval);
+    }
 }
 
 impl Backoff {
@@ -211,64 +261,33 @@ impl Backoff {
             max_interval,
             multiplier,
             max_retries,
-            current_interval: initial_interval,
-            attempts: 0,
         }
     }
 
-    pub const fn reset(&mut self) {
-        self.current_interval = self.initial_interval;
-        self.attempts = 0;
+    fn instance(&self) -> BackoffInstance {
+        BackoffInstance::new(self)
     }
 
-    pub const fn exhausted(&self) -> bool {
-        self.attempts >= self.max_retries
-    }
-
-    fn advance(&mut self) {
-        self.attempts += 1;
-        self.current_interval = self
-            .current_interval
-            .mul_f64(self.multiplier)
-            .min(self.max_interval);
-    }
-
-    pub fn retry<F, Fut, T, E>(&self, mut operation: F) -> impl Future<Output = Result<T, E>>
+    pub(crate) fn retry<F, Fut, T, E>(&self, mut operation: F) -> impl Future<Output = Result<T, E>>
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = Result<T, ErrorCategory<E>>>,
     {
-        let mut this = self.clone();
+        let mut state = self.instance();
         async move {
-            this.reset();
-
             loop {
                 match operation().await {
-                    Ok(value) => {
-                        this.reset();
-                        return Ok(value);
-                    }
+                    Ok(value) => return Ok(value),
                     Err(error) => {
-                        if this.exhausted() {
-                            match error {
-                                ErrorCategory::Retryable(e) | ErrorCategory::Unrecoverable(e) => {
-                                    return Err(e);
-                                }
-                            }
-                        }
-                        match error {
-                            ErrorCategory::Unrecoverable(e) => return Err(e),
-                            ErrorCategory::Retryable(_) => {
-                                // continue to retry
-                            }
+                        if !error.is_retryable() || state.exhausted() {
+                            return Err(error.into_inner());
                         }
 
-                        tokio::time::sleep(this.current_interval).await;
-                        this.advance();
+                        tokio::time::sleep(state.current_interval).await;
+                        state.advance();
                     }
                 }
             }
-
         }
     }
 }
@@ -305,11 +324,18 @@ pub trait GrpcConnector: Clone + Send + Sync + 'static {
     type Stream: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static;
     type ConnectError: std::error::Error + Send + Sync + 'static;
     type ConnectFuture: Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static;
-    fn connect(&self, request: SubscribeRequest, from_slot: Option<u64>) -> Self::ConnectFuture;
+    fn connect(
+        &self,
+        request: Arc<SubscribeRequest>,
+        from_slot: Option<u64>,
+    ) -> Self::ConnectFuture;
+    fn backoff(&self) -> Backoff;
 }
 
 #[derive(Clone)]
 pub struct TonicGrpcConnector {
+    backoff: Backoff,
+    request_sink: Arc<Mutex<mpsc::Sender<SubscribeRequest>>>,
     endpoint: Endpoint,
     x_token: Option<AsciiMetadataValue>,
     x_request_snapshot: bool,
@@ -324,8 +350,11 @@ impl TonicGrpcConnector {
         endpoint: Endpoint,
         config: ReconnectConfig,
         x_token: Option<AsciiMetadataValue>,
+        request_sink: Arc<Mutex<mpsc::Sender<SubscribeRequest>>>,
     ) -> Self {
         Self {
+            backoff: config.backoff,
+            request_sink,
             endpoint,
             x_token,
             x_request_snapshot: config.x_request_snapshot,
@@ -343,18 +372,27 @@ impl GrpcConnector for TonicGrpcConnector {
     type ConnectFuture =
         Pin<Box<dyn Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static>>;
 
-    fn connect(&self, mut request: SubscribeRequest, from_slot: Option<u64>) -> Self::ConnectFuture {
+    fn connect(
+        &self,
+        request: Arc<SubscribeRequest>,
+        from_slot: Option<u64>,
+    ) -> Self::ConnectFuture {
         let endpoint = self.endpoint.clone();
+        let request_sink = self.request_sink.clone();
         let x_token = self.x_token.clone();
         let x_request_snapshot = self.x_request_snapshot;
         let send_compressed = self.send_compressed;
         let accept_compressed = self.accept_compressed;
         let max_decoding_message_size = self.max_decoding_message_size;
         let max_encoding_message_size = self.max_encoding_message_size;
+        let mut request = (*request).clone();
         request.from_slot = from_slot;
 
         Box::pin(async move {
-            let channel = endpoint.connect().await.map_err(GeyserGrpcClientError::TransportError)?;
+            let channel = endpoint
+                .connect()
+                .await
+                .map_err(GeyserGrpcClientError::TransportError)?;
 
             let interceptor = InterceptorXToken {
                 x_token,
@@ -375,23 +413,29 @@ impl GrpcConnector for TonicGrpcConnector {
                 geyser = geyser.max_encoding_message_size(limit);
             }
 
+            let (mut subscribe_tx, subscribe_rx) = mpsc::channel(1000);
+            subscribe_tx
+                .send(request)
+                .await
+                .map_err(GeyserGrpcClientError::SubscribeSendError)?;
+            let response = geyser.subscribe(subscribe_rx).await?;
 
-            let mut client =
-                GeyserGrpcClient::new(HealthClient::with_interceptor(channel, interceptor), geyser);
+            // Reconnect creates a new bidi request channel; swap sender so user-facing
+            // SubscribeRequestSink continues writing into the active stream.
+            *request_sink.lock().expect("request sink mutex poisoned") = subscribe_tx;
 
-            let (_sink, stream) = client.subscribe_raw(Some(request)).await?;
-            Ok(stream)
+            Ok(response.into_inner())
         })
+    }
+
+    fn backoff(&self) -> Backoff {
+        self.backoff.clone()
     }
 }
 
-
-pub struct AutoReconnect<GrpcStream, Connector> 
-{
-    request: SubscribeRequest,
+pub struct AutoReconnect<GrpcStream, Connector> {
+    request: Arc<ArcSwap<SubscribeRequest>>,
     last_checkpoint: Option<u64>,
-    // client config for rebuilding
-    config: ReconnectConfig,
     stop: bool,
     connector: Connector,
     inner_stream: Option<DedupStream<GrpcStream>>,
@@ -399,20 +443,18 @@ pub struct AutoReconnect<GrpcStream, Connector>
 }
 
 impl<S, Connector> AutoReconnect<S, Connector>
-    where
-        S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static,
-        Connector: GrpcConnector<Stream = S, ConnectError = GeyserGrpcClientError>,
+where
+    S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static,
+    Connector: GrpcConnector<Stream = S, ConnectError = GeyserGrpcClientError>,
 {
     pub(crate) fn new(
         stream: DedupStream<S>,
         connector: Connector,
-        request: SubscribeRequest,
-        config: ReconnectConfig,
+        request: Arc<ArcSwap<SubscribeRequest>>,
     ) -> Self {
         Self {
             request,
             last_checkpoint: None,
-            config,
             inner_stream: Some(stream),
             pending_connecting_task: None,
             stop: false,
@@ -420,9 +462,8 @@ impl<S, Connector> AutoReconnect<S, Connector>
         }
     }
 
-
     fn make_connection_future(&self, dedup_state: DedupState) -> ConnectFuture<S> {
-        let backoff = self.config.backoff.clone();
+        let backoff = self.connector.backoff();
         let connector = self.connector.clone();
         let request = self.request.clone();
         let from_slot = self.last_checkpoint;
@@ -433,13 +474,16 @@ impl<S, Connector> AutoReconnect<S, Connector>
             let from_slot = from_slot;
             let dedup_state = dedup_state.clone();
             async move {
-                let stream = connector.connect(request, from_slot).await.map_err(|e| {
-                    if is_recoverable_client_error(&e) {
-                        ErrorCategory::Retryable(e)
-                    } else {
-                        ErrorCategory::Unrecoverable(e)
-                    }
-                })?;
+                let stream = connector
+                    .connect(request.load_full(), from_slot)
+                    .await
+                    .map_err(|e| {
+                        if is_recoverable_client_error(&e) {
+                            ErrorCategory::Retryable(e)
+                        } else {
+                            ErrorCategory::Unrecoverable(e)
+                        }
+                    })?;
 
                 let dedup_state = dedup_state.take().expect("dedup_state must exists");
 
@@ -448,10 +492,7 @@ impl<S, Connector> AutoReconnect<S, Connector>
         });
         Box::pin(fut)
     }
-
 }
-
-
 
 fn is_recoverable_client_error(err: &GeyserGrpcClientError) -> bool {
     match err {
@@ -460,7 +501,6 @@ fn is_recoverable_client_error(err: &GeyserGrpcClientError) -> bool {
         _ => false,
     }
 }
-
 
 const fn is_recoverable_status_code(code: &Code) -> bool {
     matches!(
@@ -476,7 +516,6 @@ const fn is_recoverable_status_code(code: &Code) -> bool {
     )
 }
 
-
 impl<S, Connector> Stream for AutoReconnect<S, Connector>
 where
     S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static,
@@ -490,7 +529,6 @@ where
         }
         let me = self.get_mut();
         while !me.stop {
-
             if let Some(mut stream) = me.inner_stream.take() {
                 match Pin::new(&mut stream).poll_next(cx) {
                     Poll::Ready(Some(Ok(msg))) => {
@@ -501,19 +539,21 @@ where
                                 // arrive in random order — replaying from a couple slots
                                 // back guarantees we don't miss data. dedup handles
                                 // the duplicates this creates.
-                                me.last_checkpoint = Some(slot.saturating_sub(CHECKPOINT_SLOT_BUFFER));
+                                me.last_checkpoint =
+                                    Some(slot.saturating_sub(CHECKPOINT_SLOT_BUFFER));
                             }
                         }
                         me.inner_stream = Some(stream);
                         return Poll::Ready(Some(Ok(msg)));
                     }
-                    Poll::Ready(Some(Err(status))) if is_recoverable_status_code(&status.code()) => {
-                        if me.config.backoff.max_retries == 0 {
+                    Poll::Ready(Some(Err(status)))
+                        if is_recoverable_status_code(&status.code()) =>
+                    {
+                        if me.connector.backoff().max_retries == 0 {
                             me.stop = true;
                             return Poll::Ready(Some(Err(status)));
                         }
 
-                        // drop the stream, recover the dedup state and start reconnecting
                         let dedup_state = stream.state;
                         me.pending_connecting_task = Some(me.make_connection_future(dedup_state));
                     }
@@ -552,7 +592,10 @@ where
                     }
                 }
             }
-            assert!(me.inner_stream.is_some() || me.pending_connecting_task.is_some() || me.stop, "must have either an active stream, a pending connecting task, or be stopped");
+            assert!(
+                me.inner_stream.is_some() || me.pending_connecting_task.is_some() || me.stop,
+                "must have either an active stream, a pending connecting task, or be stopped"
+            );
         }
 
         Poll::Ready(None)
@@ -577,7 +620,10 @@ mod tests {
     use {
         super::*,
         futures::stream,
-        std::{collections::VecDeque, sync::{Arc, Mutex}},
+        std::{
+            collections::VecDeque,
+            sync::{Arc, Mutex},
+        },
         tonic::Code,
         yellowstone_grpc_proto::prelude::{
             subscribe_update::UpdateOneof, SubscribeUpdatePing, SubscribeUpdateSlot,
@@ -586,6 +632,7 @@ mod tests {
 
     #[derive(Clone)]
     struct MockGrpcConnector {
+        backoff: Backoff,
         plans: Arc<Mutex<VecDeque<ConnectPlan>>>,
         from_slot_calls: Arc<Mutex<Vec<Option<u64>>>>,
     }
@@ -596,20 +643,24 @@ mod tests {
     }
 
     impl MockGrpcConnector {
-        fn new(plans: Vec<ConnectPlan>) -> Self {
+        fn new(backoff: Backoff, plans: Vec<ConnectPlan>) -> Self {
             Self {
+                backoff,
                 plans: Arc::new(Mutex::new(plans.into())),
                 from_slot_calls: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
         fn calls(&self) -> Vec<Option<u64>> {
-            self.from_slot_calls.lock().expect("calls mutex poisoned").clone()
+            self.from_slot_calls
+                .lock()
+                .expect("calls mutex poisoned")
+                .clone()
         }
     }
 
     impl GrpcConnector for MockGrpcConnector {
-        type Stream = BoxStream<'static, Result<SubscribeUpdate, Status>>;
+        type Stream = futures::stream::BoxStream<'static, Result<SubscribeUpdate, Status>>;
         type ConnectError = GeyserGrpcClientError;
         type ConnectFuture = Pin<
             Box<dyn Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static>,
@@ -617,11 +668,13 @@ mod tests {
 
         fn connect(
             &self,
-            _request: SubscribeRequest,
+            _request: Arc<SubscribeRequest>,
             from_slot: Option<u64>,
         ) -> Self::ConnectFuture {
             let mut plans = self.plans.lock().expect("plans mutex poisoned");
-            let plan = plans.pop_front().expect("unexpected connect call without a test plan");
+            let plan = plans
+                .pop_front()
+                .expect("unexpected connect call without a test plan");
             drop(plans);
 
             self.from_slot_calls
@@ -630,7 +683,10 @@ mod tests {
                 .push(from_slot);
 
             if let Some(expected_from_slot) = plan.expected_from_slot {
-                assert_eq!(from_slot, expected_from_slot, "unexpected reconnect from_slot");
+                assert_eq!(
+                    from_slot, expected_from_slot,
+                    "unexpected reconnect from_slot"
+                );
             }
 
             Box::pin(async move {
@@ -640,22 +696,23 @@ mod tests {
                 }
             })
         }
+
+        fn backoff(&self) -> Backoff {
+            self.backoff.clone()
+        }
     }
 
-    fn reconnect_config_with_retries(max_retries: u32) -> ReconnectConfig {
-        ReconnectConfig {
-            backoff: Backoff::new(
-                Duration::from_millis(0),
-                Duration::from_millis(0),
-                1.0,
-                max_retries,
-            ),
-            x_request_snapshot: false,
-            send_compressed: None,
-            accept_compressed: None,
-            max_decoding_message_size: None,
-            max_encoding_message_size: None,
-        }
+    fn backoff_with_retries(max_retries: u32) -> Backoff {
+        Backoff::new(
+            Duration::from_millis(0),
+            Duration::from_millis(0),
+            1.0,
+            max_retries,
+        )
+    }
+
+    fn request_state(request: SubscribeRequest) -> Arc<ArcSwap<SubscribeRequest>> {
+        Arc::new(ArcSwap::new(Arc::new(request)))
     }
 
     #[test]
@@ -665,47 +722,48 @@ mod tests {
         assert_eq!(backoff.max_interval, Duration::from_secs(30));
         assert_eq!(backoff.multiplier, 2.0);
         assert_eq!(backoff.max_retries, 3);
-        assert!(!backoff.exhausted());
     }
 
     #[test]
-    fn test_backoff_exhaustion() {
-        let mut backoff = Backoff::new(Duration::from_millis(100), Duration::from_secs(1), 2.0, 3);
-        assert!(!backoff.exhausted());
-        backoff.attempts = 3;
-        assert!(backoff.exhausted());
+    fn test_backoff_instance_exhaustion() {
+        let backoff = Backoff::new(Duration::from_millis(100), Duration::from_secs(1), 2.0, 3);
+        let mut instance = backoff.instance();
+
+        assert!(!instance.exhausted());
+        instance.attempts = 3;
+        assert!(instance.exhausted());
     }
 
     #[test]
-    fn test_backoff_reset() {
-        let mut backoff = Backoff::new(Duration::from_millis(100), Duration::from_secs(1), 2.0, 3);
-        backoff.attempts = 2;
-        backoff.current_interval = Duration::from_secs(1);
-        backoff.reset();
-        assert_eq!(backoff.attempts, 0);
-        assert_eq!(backoff.current_interval, Duration::from_millis(100));
+    fn test_backoff_instance_starts_from_initial() {
+        let backoff = Backoff::new(Duration::from_millis(100), Duration::from_secs(1), 2.0, 3);
+        let instance = backoff.instance();
+        assert_eq!(instance.attempts, 0);
+        assert_eq!(instance.current_interval, Duration::from_millis(100));
     }
 
     #[test]
     fn test_backoff_advance() {
-        let mut backoff = Backoff::new(Duration::from_millis(100), Duration::from_secs(1), 2.0, 5);
-        assert_eq!(backoff.current_interval, Duration::from_millis(100));
+        let backoff = Backoff::new(Duration::from_millis(100), Duration::from_secs(1), 2.0, 5);
+        let mut instance = backoff.instance();
+        assert_eq!(instance.current_interval, Duration::from_millis(100));
 
-        backoff.advance();
-        assert_eq!(backoff.attempts, 1);
-        assert_eq!(backoff.current_interval, Duration::from_millis(200));
+        instance.advance();
+        assert_eq!(instance.attempts, 1);
+        assert_eq!(instance.current_interval, Duration::from_millis(200));
 
-        backoff.advance();
-        assert_eq!(backoff.attempts, 2);
-        assert_eq!(backoff.current_interval, Duration::from_millis(400));
+        instance.advance();
+        assert_eq!(instance.attempts, 2);
+        assert_eq!(instance.current_interval, Duration::from_millis(400));
     }
 
     #[test]
     fn test_backoff_advance_caps_at_max() {
-        let mut backoff = Backoff::new(Duration::from_millis(500), Duration::from_secs(1), 2.0, 10);
-        backoff.advance(); // 1s
-        backoff.advance(); // would be 2s, capped at 1s
-        assert_eq!(backoff.current_interval, Duration::from_secs(1));
+        let backoff = Backoff::new(Duration::from_millis(500), Duration::from_secs(1), 2.0, 10);
+        let mut instance = backoff.instance();
+        instance.advance(); // 1s
+        instance.advance(); // would be 2s, capped at 1s
+        assert_eq!(instance.current_interval, Duration::from_secs(1));
     }
 
     #[tokio::test]
@@ -729,8 +787,6 @@ mod tests {
 
         assert_eq!(result, Ok(42));
         assert_eq!(calls, 3);
-        assert_eq!(backoff.attempts, 0);
-        assert_eq!(backoff.current_interval, Duration::from_millis(0));
     }
 
     #[tokio::test]
@@ -747,7 +803,6 @@ mod tests {
 
         assert_eq!(result, Err("still failing"));
         assert_eq!(calls, 3);
-        assert_eq!(backoff.attempts, 0);
     }
 
     #[test]
@@ -889,16 +944,18 @@ mod tests {
     #[tokio::test]
     async fn test_autoreconnect_recovers_from_recoverable_stream_error() {
         let initial = stream::iter(vec![Err(Status::unavailable("disconnect"))]).boxed();
-        let connector = MockGrpcConnector::new(vec![ConnectPlan {
-            expected_from_slot: Some(None),
-            result: Ok(vec![Ok(make_slot_msg(42, 0))]),
-        }]);
+        let connector = MockGrpcConnector::new(
+            backoff_with_retries(1),
+            vec![ConnectPlan {
+                expected_from_slot: Some(None),
+                result: Ok(vec![Ok(make_slot_msg(42, 0))]),
+            }],
+        );
 
         let mut auto = AutoReconnect::new(
             DedupStream::new(initial, DedupState::default()),
             connector.clone(),
-            SubscribeRequest::default(),
-            reconnect_config_with_retries(1),
+            request_state(SubscribeRequest::default()),
         );
 
         let next = auto.next().await;
@@ -912,34 +969,38 @@ mod tests {
     #[tokio::test]
     async fn test_autoreconnect_no_reconnect_when_max_retries_zero() {
         let initial = stream::iter(vec![Err(Status::unavailable("disconnect"))]).boxed();
-        let connector = MockGrpcConnector::new(vec![]);
+        let connector = MockGrpcConnector::new(backoff_with_retries(0), vec![]);
 
         let mut auto = AutoReconnect::new(
             DedupStream::new(initial, DedupState::default()),
             connector.clone(),
-            SubscribeRequest::default(),
-            reconnect_config_with_retries(0),
+            request_state(SubscribeRequest::default()),
         );
 
         let first = auto.next().await.expect("expected one item");
         assert!(first.is_err());
-        assert_eq!(first.expect_err("expected recoverable error").code(), Code::Unavailable);
+        assert_eq!(
+            first.expect_err("expected recoverable error").code(),
+            Code::Unavailable
+        );
         assert_eq!(connector.calls().len(), 0);
     }
 
     #[tokio::test]
     async fn test_autoreconnect_passes_checkpoint_as_from_slot() {
         let initial = stream::iter(vec![Err(Status::unavailable("disconnect"))]).boxed();
-        let connector = MockGrpcConnector::new(vec![ConnectPlan {
-            expected_from_slot: Some(Some(77)),
-            result: Ok(vec![Ok(make_slot_msg(90, 0))]),
-        }]);
+        let connector = MockGrpcConnector::new(
+            backoff_with_retries(1),
+            vec![ConnectPlan {
+                expected_from_slot: Some(Some(77)),
+                result: Ok(vec![Ok(make_slot_msg(90, 0))]),
+            }],
+        );
 
         let mut auto = AutoReconnect::new(
             DedupStream::new(initial, DedupState::default()),
             connector.clone(),
-            SubscribeRequest::default(),
-            reconnect_config_with_retries(1),
+            request_state(SubscribeRequest::default()),
         );
         auto.last_checkpoint = Some(77);
 

--- a/yellowstone-grpc-client/src/stream.rs
+++ b/yellowstone-grpc-client/src/stream.rs
@@ -1,21 +1,16 @@
 use {
     crate::{GeyserGrpcClient, GeyserGrpcClientError, InterceptorXToken, ReconnectConfig},
     futures::stream::{BoxStream, Stream, StreamExt},
-    pin_project::pin_project,
     std::{
-        collections::{HashMap, HashSet, VecDeque},
-        future::Future,
-        pin::Pin,
-        task::{Context, Poll},
-        time::Duration,
+        collections::{HashMap, HashSet, VecDeque}, future::Future, pin::Pin, sync::{Arc, Mutex}, task::{Context, Poll}, time::Duration
     },
     tonic::{
-        codec::CompressionEncoding, metadata::AsciiMetadataValue, transport::Endpoint, Code, Status,
+        Code, Status, Streaming, codec::CompressionEncoding, metadata::AsciiMetadataValue, transport::Endpoint
     },
     tonic_health::pb::health_client::HealthClient,
     yellowstone_grpc_proto::{
         geyser::geyser_client::GeyserClient,
-        prelude::{subscribe_update::UpdateOneof, SubscribeRequest, SubscribeUpdate},
+        prelude::{SubscribeRequest, SubscribeUpdate, subscribe_update::UpdateOneof},
     },
 };
 
@@ -24,21 +19,9 @@ use {
 /// and out-of-order delivery within a slot.
 const CHECKPOINT_SLOT_BUFFER: u64 = 2;
 
-#[derive(Debug, Clone)]
-pub struct DedupConfig {
-    pub max_slot: usize,
-}
 
-impl Default for DedupConfig {
-    fn default() -> Self {
-        Self { max_slot: 100 }
-    }
-}
-
-#[pin_project]
 pub struct DedupStream<S> {
     state: DedupState,
-    #[pin]
     inner: S,
 }
 
@@ -54,7 +37,7 @@ impl<S> DedupStream<S> {
 
 impl<S> Stream for DedupStream<S>
 where
-    S: Stream<Item = Result<SubscribeUpdate, Status>>,
+    S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin,
 {
     type Item = Result<SubscribeUpdate, Status>;
 
@@ -62,9 +45,9 @@ where
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        let mut this = self.project();
+        let this = self.get_mut();
         loop {
-            match this.inner.as_mut().poll_next(cx) {
+            match this.inner.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(msg))) => {
                     if this.state.is_duplicate(&msg) {
                         continue;
@@ -90,19 +73,28 @@ enum DedupKey {
     Block,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct DedupState {
     seen_messages: HashMap<u64, HashSet<DedupKey>>, // slot -> message_key
     slot_order: VecDeque<u64>,
-    config: DedupConfig,
+    slot_retention: usize,
+}
+
+impl Default for DedupState {
+    fn default() -> Self {
+        Self {
+            seen_messages: Default::default(),
+            slot_order: Default::default(),
+            slot_retention: 1000, // default retention of 1000 slots
+        }
+    }
 }
 
 impl DedupState {
-    pub fn new(config: DedupConfig) -> Self {
+    pub fn with_slot_retention(slot_retention: usize) -> Self {
         Self {
-            seen_messages: HashMap::new(),
-            slot_order: VecDeque::new(),
-            config,
+            slot_retention: slot_retention,
+            ..Default::default()
         }
     }
 
@@ -156,7 +148,7 @@ impl DedupState {
     }
 
     pub fn prune(&mut self) {
-        while self.slot_order.len() > self.config.max_slot {
+        while self.slot_order.len() > self.slot_retention {
             if let Some(slot) = self.slot_order.pop_front() {
                 self.seen_messages.remove(&slot);
             }
@@ -171,23 +163,10 @@ impl DedupState {
 }
 
 /// A boxed future that resolves to a new raw stream or an error.
-type ConnectFuture =
-    Pin<Box<dyn Future<Output = Result<GeyserStream, GeyserGrpcClientError>> + Send>>;
+type ConnectFuture<S> =
+    Pin<Box<dyn Future<Output = Result<DedupStream<S>, GeyserGrpcClientError>> + Send + 'static>>;
 
-/// A boxed sleep timer for backoff between reconnect attempts.
-type SleepFuture = Pin<Box<tokio::time::Sleep>>;
 
-type GeyserStream = BoxStream<'static, Result<SubscribeUpdate, Status>>;
-
-pub enum ConnectionState {
-    Streaming(DedupStream<GeyserStream>),
-    /// Connection died — waiting for backoff timer before retrying.
-    /// Carries DedupState so it survives to the next connection.
-    Waiting(DedupState, SleepFuture),
-    /// Backoff done — async connect/subscribe in progress.
-    /// Carries DedupState to pass into the new DedupStream on success.
-    Connecting(DedupState, ConnectFuture),
-}
 
 #[derive(Debug, Clone)]
 pub struct Backoff {
@@ -199,9 +178,14 @@ pub struct Backoff {
     attempts: u32,
 }
 
+pub(crate) enum ErrorCategory<E> {
+    Retryable(E),
+    Unrecoverable(E),
+}
+
 impl Backoff {
     const fn default_initial_interval() -> Duration {
-        Duration::from_millis(500)
+        Duration::from_millis(10)
     }
 
     const fn default_max_interval() -> Duration {
@@ -213,7 +197,7 @@ impl Backoff {
     }
 
     const fn default_max_retries() -> u32 {
-        10
+        3
     }
 
     pub const fn new(
@@ -241,12 +225,51 @@ impl Backoff {
         self.attempts >= self.max_retries
     }
 
-    pub fn advance(&mut self) {
+    fn advance(&mut self) {
         self.attempts += 1;
         self.current_interval = self
             .current_interval
             .mul_f64(self.multiplier)
             .min(self.max_interval);
+    }
+
+    pub fn retry<F, Fut, T, E>(&self, mut operation: F) -> impl Future<Output = Result<T, E>>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, ErrorCategory<E>>>,
+    {
+        let mut this = self.clone();
+        async move {
+            this.reset();
+
+            loop {
+                match operation().await {
+                    Ok(value) => {
+                        this.reset();
+                        return Ok(value);
+                    }
+                    Err(error) => {
+                        if this.exhausted() {
+                            match error {
+                                ErrorCategory::Retryable(e) | ErrorCategory::Unrecoverable(e) => {
+                                    return Err(e);
+                                }
+                            }
+                        }
+                        match error {
+                            ErrorCategory::Unrecoverable(e) => return Err(e),
+                            ErrorCategory::Retryable(_) => {
+                                // continue to retry
+                            }
+                        }
+
+                        tokio::time::sleep(this.current_interval).await;
+                        this.advance();
+                    }
+                }
+            }
+
+        }
     }
 }
 
@@ -261,13 +284,33 @@ impl Default for Backoff {
     }
 }
 
-pub struct AutoReconnect {
-    state: ConnectionState,
-    backoff: Backoff,
+#[derive(Clone)]
+struct ConsumeOnce<T> {
+    inner: Arc<Mutex<Option<T>>>,
+}
+
+impl<T> ConsumeOnce<T> {
+    fn new(value: T) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Some(value))),
+        }
+    }
+
+    fn take(&self) -> Option<T> {
+        self.inner.lock().ok()?.take()
+    }
+}
+
+pub trait GrpcConnector: Clone + Send + Sync + 'static {
+    type Stream: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static;
+    type ConnectError: std::error::Error + Send + Sync + 'static;
+    type ConnectFuture: Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static;
+    fn connect(&self, request: SubscribeRequest, from_slot: Option<u64>) -> Self::ConnectFuture;
+}
+
+#[derive(Clone)]
+pub struct TonicGrpcConnector {
     endpoint: Endpoint,
-    request: SubscribeRequest,
-    last_checkpoint: Option<u64>,
-    // client config for rebuilding
     x_token: Option<AsciiMetadataValue>,
     x_request_snapshot: bool,
     send_compressed: Option<CompressionEncoding>,
@@ -276,23 +319,15 @@ pub struct AutoReconnect {
     max_encoding_message_size: Option<usize>,
 }
 
-impl AutoReconnect {
+impl TonicGrpcConnector {
     pub fn new(
-        stream: GeyserStream,
-        request: SubscribeRequest,
-        dedup_config: DedupConfig,
+        endpoint: Endpoint,
         config: ReconnectConfig,
+        x_token: Option<AsciiMetadataValue>,
     ) -> Self {
         Self {
-            state: ConnectionState::Streaming(DedupStream::new(
-                stream,
-                DedupState::new(dedup_config),
-            )),
-            backoff: config.backoff,
-            endpoint: config.endpoint,
-            request,
-            last_checkpoint: None,
-            x_token: config.x_token,
+            endpoint,
+            x_token,
             x_request_snapshot: config.x_request_snapshot,
             send_compressed: config.send_compressed,
             accept_compressed: config.accept_compressed,
@@ -300,23 +335,26 @@ impl AutoReconnect {
             max_encoding_message_size: config.max_encoding_message_size,
         }
     }
+}
 
-    pub fn make_connection_future(&self) -> ConnectFuture {
-        let endpoint = self.endpoint.clone(); // clone before the async block
+impl GrpcConnector for TonicGrpcConnector {
+    type Stream = Streaming<SubscribeUpdate>;
+    type ConnectError = GeyserGrpcClientError;
+    type ConnectFuture =
+        Pin<Box<dyn Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static>>;
+
+    fn connect(&self, mut request: SubscribeRequest, from_slot: Option<u64>) -> Self::ConnectFuture {
+        let endpoint = self.endpoint.clone();
         let x_token = self.x_token.clone();
         let x_request_snapshot = self.x_request_snapshot;
         let send_compressed = self.send_compressed;
         let accept_compressed = self.accept_compressed;
         let max_decoding_message_size = self.max_decoding_message_size;
         let max_encoding_message_size = self.max_encoding_message_size;
-        let mut request = self.request.clone();
-        request.from_slot = self.last_checkpoint;
+        request.from_slot = from_slot;
 
         Box::pin(async move {
-            let channel = endpoint
-                .connect()
-                .await
-                .map_err(|e| GeyserGrpcClientError::TonicStatus(Status::internal(e.to_string())))?;
+            let channel = endpoint.connect().await.map_err(GeyserGrpcClientError::TransportError)?;
 
             let interceptor = InterceptorXToken {
                 x_token,
@@ -337,17 +375,94 @@ impl AutoReconnect {
                 geyser = geyser.max_encoding_message_size(limit);
             }
 
+
             let mut client =
                 GeyserGrpcClient::new(HealthClient::with_interceptor(channel, interceptor), geyser);
 
-            let (_sink, stream) = client.subscribe_with_request(Some(request)).await?;
-
-            Ok(stream.boxed())
+            let (_sink, stream) = client.subscribe_raw(Some(request)).await?;
+            Ok(stream)
         })
     }
 }
 
-const fn should_reconnect(code: Code) -> bool {
+
+pub struct AutoReconnect<GrpcStream, Connector> 
+{
+    request: SubscribeRequest,
+    last_checkpoint: Option<u64>,
+    // client config for rebuilding
+    config: ReconnectConfig,
+    stop: bool,
+    connector: Connector,
+    inner_stream: Option<DedupStream<GrpcStream>>,
+    pending_connecting_task: Option<ConnectFuture<GrpcStream>>,
+}
+
+impl<S, Connector> AutoReconnect<S, Connector>
+    where
+        S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static,
+        Connector: GrpcConnector<Stream = S, ConnectError = GeyserGrpcClientError>,
+{
+    pub(crate) fn new(
+        stream: DedupStream<S>,
+        connector: Connector,
+        request: SubscribeRequest,
+        config: ReconnectConfig,
+    ) -> Self {
+        Self {
+            request,
+            last_checkpoint: None,
+            config,
+            inner_stream: Some(stream),
+            pending_connecting_task: None,
+            stop: false,
+            connector,
+        }
+    }
+
+
+    fn make_connection_future(&self, dedup_state: DedupState) -> ConnectFuture<S> {
+        let backoff = self.config.backoff.clone();
+        let connector = self.connector.clone();
+        let request = self.request.clone();
+        let from_slot = self.last_checkpoint;
+        let dedup_state = ConsumeOnce::new(dedup_state);
+        let fut = backoff.retry(move || {
+            let connector = connector.clone();
+            let request = request.clone();
+            let from_slot = from_slot;
+            let dedup_state = dedup_state.clone();
+            async move {
+                let stream = connector.connect(request, from_slot).await.map_err(|e| {
+                    if is_recoverable_client_error(&e) {
+                        ErrorCategory::Retryable(e)
+                    } else {
+                        ErrorCategory::Unrecoverable(e)
+                    }
+                })?;
+
+                let dedup_state = dedup_state.take().expect("dedup_state must exists");
+
+                Ok(DedupStream::new(stream, dedup_state))
+            }
+        });
+        Box::pin(fut)
+    }
+
+}
+
+
+
+fn is_recoverable_client_error(err: &GeyserGrpcClientError) -> bool {
+    match err {
+        GeyserGrpcClientError::TonicStatus(status) => is_recoverable_status_code(&status.code()),
+        GeyserGrpcClientError::TransportError(_) => true,
+        _ => false,
+    }
+}
+
+
+const fn is_recoverable_status_code(code: &Code) -> bool {
     matches!(
         code,
         Code::Cancelled
@@ -361,107 +476,86 @@ const fn should_reconnect(code: Code) -> bool {
     )
 }
 
-impl Stream for AutoReconnect {
+
+impl<S, Connector> Stream for AutoReconnect<S, Connector>
+where
+    S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static,
+    Connector: GrpcConnector<Stream = S, ConnectError = GeyserGrpcClientError> + Unpin,
+{
     type Item = Result<SubscribeUpdate, Status>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.stop {
+            return Poll::Ready(None);
+        }
         let me = self.get_mut();
+        while !me.stop {
 
-        let state = std::mem::replace(
-            &mut me.state,
-            ConnectionState::Waiting(
-                DedupState::default(),
-                Box::pin(tokio::time::sleep(Duration::from_secs(0))),
-            ),
-        );
-
-        match state {
-            ConnectionState::Streaming(mut stream) => match Pin::new(&mut stream).poll_next(cx) {
-                Poll::Ready(Some(Ok(msg))) => {
-                    me.backoff.reset();
-                    if let Some(UpdateOneof::BlockMeta(_)) = msg.update_oneof.as_ref() {
-                        if let Some(slot) = extract_slot(&msg) {
-                            // checkpoint a few slots behind the last fully built slot.
-                            // block_meta can arrive late and events within a slot
-                            // arrive in random order — replaying from a couple slots
-                            // back guarantees we don't miss data. dedup handles
-                            // the duplicates this creates.
-                            me.last_checkpoint = Some(slot.saturating_sub(CHECKPOINT_SLOT_BUFFER));
+            if let Some(mut stream) = me.inner_stream.take() {
+                match Pin::new(&mut stream).poll_next(cx) {
+                    Poll::Ready(Some(Ok(msg))) => {
+                        if let Some(UpdateOneof::BlockMeta(_)) = msg.update_oneof.as_ref() {
+                            if let Some(slot) = extract_slot(&msg) {
+                                // checkpoint a few slots behind the last fully built slot.
+                                // block_meta can arrive late and events within a slot
+                                // arrive in random order — replaying from a couple slots
+                                // back guarantees we don't miss data. dedup handles
+                                // the duplicates this creates.
+                                me.last_checkpoint = Some(slot.saturating_sub(CHECKPOINT_SLOT_BUFFER));
+                            }
                         }
+                        me.inner_stream = Some(stream);
+                        return Poll::Ready(Some(Ok(msg)));
                     }
-                    me.state = ConnectionState::Streaming(stream);
-                    Poll::Ready(Some(Ok(msg)))
-                }
-                Poll::Ready(Some(Err(status))) if should_reconnect(status.code()) => {
-                    log::warn!("stream error, reconnecting: {status}");
-                    let (dedup_state, _) = stream.into_parts();
-                    me.backoff.advance();
-                    me.state = ConnectionState::Waiting(
-                        dedup_state,
-                        Box::pin(tokio::time::sleep(me.backoff.current_interval)),
-                    );
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                }
-                Poll::Ready(Some(Err(status))) => Poll::Ready(Some(Err(status))),
-                Poll::Ready(None) => {
-                    log::info!("stream ended, reconnecting");
-                    let (dedup_state, _) = stream.into_parts();
-                    me.backoff.advance();
-                    me.state = ConnectionState::Waiting(
-                        dedup_state,
-                        Box::pin(tokio::time::sleep(me.backoff.current_interval)),
-                    );
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                }
-                Poll::Pending => {
-                    me.state = ConnectionState::Streaming(stream);
-                    Poll::Pending
-                }
-            },
-            ConnectionState::Waiting(dedup_state, mut sleep) => {
-                match Pin::new(&mut sleep).poll(cx) {
-                    Poll::Ready(()) => {
-                        let fut = me.make_connection_future();
-                        me.state = ConnectionState::Connecting(dedup_state, fut);
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
+                    Poll::Ready(Some(Err(status))) if is_recoverable_status_code(&status.code()) => {
+                        if me.config.backoff.max_retries == 0 {
+                            me.stop = true;
+                            return Poll::Ready(Some(Err(status)));
+                        }
+
+                        // drop the stream, recover the dedup state and start reconnecting
+                        let dedup_state = stream.state;
+                        me.pending_connecting_task = Some(me.make_connection_future(dedup_state));
+                    }
+                    Poll::Ready(Some(Err(e))) => {
+                        me.stop = true;
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                    Poll::Ready(None) => {
+                        me.stop = true;
+                        return Poll::Ready(None);
                     }
                     Poll::Pending => {
-                        me.state = ConnectionState::Waiting(dedup_state, sleep);
-                        Poll::Pending
+                        me.inner_stream = Some(stream);
+                        return Poll::Pending;
                     }
                 }
             }
-            ConnectionState::Connecting(dedup_state, mut fut) => match fut.as_mut().poll(cx) {
-                Poll::Ready(Ok(stream)) => {
-                    me.backoff.reset();
-                    me.state = ConnectionState::Streaming(DedupStream::new(stream, dedup_state));
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                }
-                Poll::Ready(Err(error)) => {
-                    log::error!("connect failed: {error}");
-                    if me.backoff.exhausted() {
-                        return Poll::Ready(Some(Err(Status::internal(
-                            "max reconnect retries exhausted",
-                        ))));
+
+            if let Some(mut fut) = me.pending_connecting_task.take() {
+                match fut.as_mut().poll(cx) {
+                    Poll::Ready(result) => match result {
+                        Ok(stream) => {
+                            // Next loop iteration it will be `poll_next`ed and we can detect if it fails immediately or not.
+                            me.inner_stream = Some(stream);
+                        }
+                        Err(error) => {
+                            me.stop = true;
+                            return Poll::Ready(Some(Err(Status::internal(format!(
+                                "reconnect failed: {error}",
+                            )))));
+                        }
+                    },
+                    Poll::Pending => {
+                        me.pending_connecting_task = Some(fut);
+                        return Poll::Pending;
                     }
-                    me.backoff.advance();
-                    me.state = ConnectionState::Waiting(
-                        dedup_state,
-                        Box::pin(tokio::time::sleep(me.backoff.current_interval)),
-                    );
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
                 }
-                Poll::Pending => {
-                    me.state = ConnectionState::Connecting(dedup_state, fut);
-                    Poll::Pending
-                }
-            },
+            }
+            assert!(me.inner_stream.is_some() || me.pending_connecting_task.is_some() || me.stop, "must have either an active stream, a pending connecting task, or be stopped");
         }
+
+        Poll::Ready(None)
     }
 }
 
@@ -482,19 +576,95 @@ pub(crate) fn extract_slot(msg: &SubscribeUpdate) -> Option<u64> {
 mod tests {
     use {
         super::*,
+        futures::stream,
+        std::{collections::VecDeque, sync::{Arc, Mutex}},
         tonic::Code,
         yellowstone_grpc_proto::prelude::{
             subscribe_update::UpdateOneof, SubscribeUpdatePing, SubscribeUpdateSlot,
         },
     };
 
+    #[derive(Clone)]
+    struct MockGrpcConnector {
+        plans: Arc<Mutex<VecDeque<ConnectPlan>>>,
+        from_slot_calls: Arc<Mutex<Vec<Option<u64>>>>,
+    }
+
+    struct ConnectPlan {
+        expected_from_slot: Option<Option<u64>>,
+        result: Result<Vec<Result<SubscribeUpdate, Status>>, GeyserGrpcClientError>,
+    }
+
+    impl MockGrpcConnector {
+        fn new(plans: Vec<ConnectPlan>) -> Self {
+            Self {
+                plans: Arc::new(Mutex::new(plans.into())),
+                from_slot_calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn calls(&self) -> Vec<Option<u64>> {
+            self.from_slot_calls.lock().expect("calls mutex poisoned").clone()
+        }
+    }
+
+    impl GrpcConnector for MockGrpcConnector {
+        type Stream = BoxStream<'static, Result<SubscribeUpdate, Status>>;
+        type ConnectError = GeyserGrpcClientError;
+        type ConnectFuture = Pin<
+            Box<dyn Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static>,
+        >;
+
+        fn connect(
+            &self,
+            _request: SubscribeRequest,
+            from_slot: Option<u64>,
+        ) -> Self::ConnectFuture {
+            let mut plans = self.plans.lock().expect("plans mutex poisoned");
+            let plan = plans.pop_front().expect("unexpected connect call without a test plan");
+            drop(plans);
+
+            self.from_slot_calls
+                .lock()
+                .expect("calls mutex poisoned")
+                .push(from_slot);
+
+            if let Some(expected_from_slot) = plan.expected_from_slot {
+                assert_eq!(from_slot, expected_from_slot, "unexpected reconnect from_slot");
+            }
+
+            Box::pin(async move {
+                match plan.result {
+                    Ok(items) => Ok(stream::iter(items).boxed()),
+                    Err(err) => Err(err),
+                }
+            })
+        }
+    }
+
+    fn reconnect_config_with_retries(max_retries: u32) -> ReconnectConfig {
+        ReconnectConfig {
+            backoff: Backoff::new(
+                Duration::from_millis(0),
+                Duration::from_millis(0),
+                1.0,
+                max_retries,
+            ),
+            x_request_snapshot: false,
+            send_compressed: None,
+            accept_compressed: None,
+            max_decoding_message_size: None,
+            max_encoding_message_size: None,
+        }
+    }
+
     #[test]
     fn test_backoff_default() {
         let backoff = Backoff::default();
-        assert_eq!(backoff.initial_interval, Duration::from_millis(500));
+        assert_eq!(backoff.initial_interval, Duration::from_millis(10));
         assert_eq!(backoff.max_interval, Duration::from_secs(30));
         assert_eq!(backoff.multiplier, 2.0);
-        assert_eq!(backoff.max_retries, 10);
+        assert_eq!(backoff.max_retries, 3);
         assert!(!backoff.exhausted());
     }
 
@@ -538,24 +708,66 @@ mod tests {
         assert_eq!(backoff.current_interval, Duration::from_secs(1));
     }
 
+    #[tokio::test]
+    async fn test_backoff_retry_eventually_succeeds() {
+        let backoff = Backoff::new(Duration::from_millis(0), Duration::from_millis(0), 2.0, 5);
+        let mut calls = 0;
+
+        let result = backoff
+            .retry(|| {
+                let current = calls;
+                calls += 1;
+                async move {
+                    if current < 2 {
+                        Err(ErrorCategory::Retryable("transient"))
+                    } else {
+                        Ok(42)
+                    }
+                }
+            })
+            .await;
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(calls, 3);
+        assert_eq!(backoff.attempts, 0);
+        assert_eq!(backoff.current_interval, Duration::from_millis(0));
+    }
+
+    #[tokio::test]
+    async fn test_backoff_retry_exhausted_returns_last_error() {
+        let backoff = Backoff::new(Duration::from_millis(0), Duration::from_millis(0), 2.0, 2);
+        let mut calls = 0;
+
+        let result = backoff
+            .retry(|| {
+                calls += 1;
+                async { Err::<(), _>(ErrorCategory::Retryable("still failing")) }
+            })
+            .await;
+
+        assert_eq!(result, Err("still failing"));
+        assert_eq!(calls, 3);
+        assert_eq!(backoff.attempts, 0);
+    }
+
     #[test]
     fn test_should_reconnect() {
-        assert!(should_reconnect(Code::Unavailable));
-        assert!(should_reconnect(Code::Internal));
-        assert!(should_reconnect(Code::Unknown));
-        assert!(should_reconnect(Code::Cancelled));
-        assert!(should_reconnect(Code::DeadlineExceeded));
-        assert!(should_reconnect(Code::ResourceExhausted));
-        assert!(should_reconnect(Code::Aborted));
-        assert!(should_reconnect(Code::DataLoss));
+        assert!(is_recoverable_status_code(&Code::Unavailable));
+        assert!(is_recoverable_status_code(&Code::Internal));
+        assert!(is_recoverable_status_code(&Code::Unknown));
+        assert!(is_recoverable_status_code(&Code::Cancelled));
+        assert!(is_recoverable_status_code(&Code::DeadlineExceeded));
+        assert!(is_recoverable_status_code(&Code::ResourceExhausted));
+        assert!(is_recoverable_status_code(&Code::Aborted));
+        assert!(is_recoverable_status_code(&Code::DataLoss));
 
-        assert!(!should_reconnect(Code::InvalidArgument));
-        assert!(!should_reconnect(Code::NotFound));
-        assert!(!should_reconnect(Code::PermissionDenied));
-        assert!(!should_reconnect(Code::Unauthenticated));
-        assert!(!should_reconnect(Code::Unimplemented));
-        assert!(!should_reconnect(Code::FailedPrecondition));
-        assert!(!should_reconnect(Code::OutOfRange));
+        assert!(!is_recoverable_status_code(&Code::InvalidArgument));
+        assert!(!is_recoverable_status_code(&Code::NotFound));
+        assert!(!is_recoverable_status_code(&Code::PermissionDenied));
+        assert!(!is_recoverable_status_code(&Code::Unauthenticated));
+        assert!(!is_recoverable_status_code(&Code::Unimplemented));
+        assert!(!is_recoverable_status_code(&Code::FailedPrecondition));
+        assert!(!is_recoverable_status_code(&Code::OutOfRange));
     }
 
     #[test]
@@ -662,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_dedup_prune() {
-        let mut dedup = DedupState::new(DedupConfig { max_slot: 3 });
+        let mut dedup = DedupState::with_slot_retention(3);
 
         dedup.record(&make_slot_msg(100, 0));
         dedup.record(&make_slot_msg(101, 0));
@@ -672,5 +884,71 @@ mod tests {
         dedup.record(&make_slot_msg(103, 0));
         assert!(!dedup.is_duplicate(&make_slot_msg(100, 0)));
         assert!(dedup.is_duplicate(&make_slot_msg(101, 0)));
+    }
+
+    #[tokio::test]
+    async fn test_autoreconnect_recovers_from_recoverable_stream_error() {
+        let initial = stream::iter(vec![Err(Status::unavailable("disconnect"))]).boxed();
+        let connector = MockGrpcConnector::new(vec![ConnectPlan {
+            expected_from_slot: Some(None),
+            result: Ok(vec![Ok(make_slot_msg(42, 0))]),
+        }]);
+
+        let mut auto = AutoReconnect::new(
+            DedupStream::new(initial, DedupState::default()),
+            connector.clone(),
+            SubscribeRequest::default(),
+            reconnect_config_with_retries(1),
+        );
+
+        let next = auto.next().await;
+        let slot = next
+            .expect("expected one item")
+            .expect("expected successful reconnect message");
+        assert_eq!(extract_slot(&slot), Some(42));
+        assert_eq!(connector.calls(), vec![None]);
+    }
+
+    #[tokio::test]
+    async fn test_autoreconnect_no_reconnect_when_max_retries_zero() {
+        let initial = stream::iter(vec![Err(Status::unavailable("disconnect"))]).boxed();
+        let connector = MockGrpcConnector::new(vec![]);
+
+        let mut auto = AutoReconnect::new(
+            DedupStream::new(initial, DedupState::default()),
+            connector.clone(),
+            SubscribeRequest::default(),
+            reconnect_config_with_retries(0),
+        );
+
+        let first = auto.next().await.expect("expected one item");
+        assert!(first.is_err());
+        assert_eq!(first.expect_err("expected recoverable error").code(), Code::Unavailable);
+        assert_eq!(connector.calls().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_autoreconnect_passes_checkpoint_as_from_slot() {
+        let initial = stream::iter(vec![Err(Status::unavailable("disconnect"))]).boxed();
+        let connector = MockGrpcConnector::new(vec![ConnectPlan {
+            expected_from_slot: Some(Some(77)),
+            result: Ok(vec![Ok(make_slot_msg(90, 0))]),
+        }]);
+
+        let mut auto = AutoReconnect::new(
+            DedupStream::new(initial, DedupState::default()),
+            connector.clone(),
+            SubscribeRequest::default(),
+            reconnect_config_with_retries(1),
+        );
+        auto.last_checkpoint = Some(77);
+
+        let msg = auto
+            .next()
+            .await
+            .expect("expected one item")
+            .expect("expected message after reconnect");
+        assert_eq!(extract_slot(&msg), Some(90));
+        assert_eq!(connector.calls(), vec![Some(77)]);
     }
 }

--- a/yellowstone-grpc-client/src/stream.rs
+++ b/yellowstone-grpc-client/src/stream.rs
@@ -29,16 +29,19 @@ use {
 /// and out-of-order delivery within a slot.
 const CHECKPOINT_SLOT_BUFFER: u64 = 2;
 
+/// Wrapper stream that filters out duplicate subscribe updates.
 pub struct DedupStream<S> {
     state: DedupState,
     inner: S,
 }
 
 impl<S> DedupStream<S> {
+    /// Creates a deduplicating stream wrapper from an inner stream and initial state.
     pub const fn new(inner: S, state: DedupState) -> Self {
         Self { state, inner }
     }
 
+    /// Splits the wrapper into its dedup state and inner stream.
     pub fn into_parts(self) -> (DedupState, S) {
         (self.state, self.inner)
     }
@@ -72,6 +75,7 @@ where
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+/// Unique identity used to detect duplicate messages per slot.
 enum DedupKey {
     Slot(i32),                           // status
     Account([u8; 32], Option<[u8; 64]>), // pubkey, txn_signature
@@ -83,6 +87,7 @@ enum DedupKey {
 }
 
 #[derive(Debug, Clone)]
+/// In-memory deduplication state keyed by slot and update identity.
 pub struct DedupState {
     seen_messages: HashMap<u64, HashSet<DedupKey>>, // slot -> message_key
     slot_order: VecDeque<u64>,
@@ -100,6 +105,7 @@ impl Default for DedupState {
 }
 
 impl DedupState {
+    /// Creates dedup state with a custom retained slot window size.
     pub fn with_slot_retention(slot_retention: usize) -> Self {
         Self {
             slot_retention: slot_retention,
@@ -107,6 +113,7 @@ impl DedupState {
         }
     }
 
+    /// Extracts a comparable `(slot, key)` pair from a subscribe update.
     fn extract_key(msg: &SubscribeUpdate) -> Option<(u64, DedupKey)> {
         let oneof = msg.update_oneof.as_ref()?;
         match oneof {
@@ -135,6 +142,7 @@ impl DedupState {
         }
     }
 
+    /// Returns true if this update was previously recorded for its slot.
     pub fn is_duplicate(&self, msg: &SubscribeUpdate) -> bool {
         if let Some((slot, key)) = Self::extract_key(msg) {
             if let Some(keys) = self.seen_messages.get(&slot) {
@@ -144,6 +152,7 @@ impl DedupState {
         false
     }
 
+    /// Records an update key and prunes old slots when retention is exceeded.
     pub fn record(&mut self, msg: &SubscribeUpdate) {
         if let Some((slot, key)) = Self::extract_key(msg) {
             if self.seen_messages.entry(slot).or_default().insert(key) {
@@ -156,6 +165,7 @@ impl DedupState {
         }
     }
 
+    /// Prunes dedup state to the configured slot retention window.
     pub fn prune(&mut self) {
         while self.slot_order.len() > self.slot_retention {
             if let Some(slot) = self.slot_order.pop_front() {
@@ -165,6 +175,7 @@ impl DedupState {
     }
 
     #[allow(dead_code)]
+    /// Clears all dedup state.
     pub fn clear(&mut self) {
         self.seen_messages.clear();
         self.slot_order.clear();
@@ -176,6 +187,7 @@ type ConnectFuture<S> =
     Pin<Box<dyn Future<Output = Result<DedupStream<S>, GeyserGrpcClientError>> + Send + 'static>>;
 
 #[derive(Debug, Clone)]
+/// Exponential backoff policy used for reconnect attempts.
 pub struct Backoff {
     pub initial_interval: Duration,
     pub max_interval: Duration,
@@ -183,16 +195,19 @@ pub struct Backoff {
     pub max_retries: u32,
 }
 
+/// Classifies an operation failure as retryable or terminal.
 pub(crate) enum ErrorCategory<E> {
     Retryable(E),
     Unrecoverable(E),
 }
 
 impl<E> ErrorCategory<E> {
+    /// Returns true when this error category should be retried.
     fn is_retryable(&self) -> bool {
         matches!(self, Self::Retryable(_))
     }
 
+    /// Extracts the underlying error value.
     fn into_inner(self) -> E {
         match self {
             Self::Retryable(e) | Self::Unrecoverable(e) => e,
@@ -201,6 +216,7 @@ impl<E> ErrorCategory<E> {
 }
 
 #[derive(Debug, Clone)]
+/// Mutable runtime state for a single backoff execution.
 struct BackoffInstance {
     current_interval: Duration,
     attempts: u32,
@@ -210,6 +226,7 @@ struct BackoffInstance {
 }
 
 impl BackoffInstance {
+    /// Builds runtime backoff state from the immutable `Backoff` configuration.
     fn new(config: &Backoff) -> Self {
         Self {
             current_interval: config.initial_interval,
@@ -220,10 +237,12 @@ impl BackoffInstance {
         }
     }
 
+    /// Returns true once the configured retry budget has been consumed.
     fn exhausted(&self) -> bool {
         self.attempts >= self.max_retries
     }
 
+    /// Advances retry counters and computes the next interval.
     fn advance(&mut self) {
         self.attempts += 1;
         self.current_interval = self
@@ -234,22 +253,27 @@ impl BackoffInstance {
 }
 
 impl Backoff {
+    /// Default initial retry interval.
     const fn default_initial_interval() -> Duration {
         Duration::from_millis(10)
     }
 
+    /// Default maximum retry interval.
     const fn default_max_interval() -> Duration {
         Duration::from_secs(30)
     }
 
+    /// Default exponential multiplier.
     const fn default_multiplier() -> f64 {
         2.0
     }
 
+    /// Default number of retries.
     const fn default_max_retries() -> u32 {
         3
     }
 
+    /// Creates a new backoff policy.
     pub const fn new(
         initial_interval: Duration,
         max_interval: Duration,
@@ -264,10 +288,15 @@ impl Backoff {
         }
     }
 
+    /// Creates mutable runtime state for one retry execution.
     fn instance(&self) -> BackoffInstance {
         BackoffInstance::new(self)
     }
 
+    /// Retries an async operation according to this policy.
+    ///
+    /// The operation returns `ErrorCategory::Retryable` for transient failures,
+    /// and `ErrorCategory::Unrecoverable` for terminal failures.
     pub(crate) fn retry<F, Fut, T, E>(&self, mut operation: F) -> impl Future<Output = Result<T, E>>
     where
         F: FnMut() -> Fut,
@@ -303,36 +332,29 @@ impl Default for Backoff {
     }
 }
 
-#[derive(Clone)]
-struct ConsumeOnce<T> {
-    inner: Arc<Mutex<Option<T>>>,
-}
-
-impl<T> ConsumeOnce<T> {
-    fn new(value: T) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(Some(value))),
-        }
-    }
-
-    fn take(&self) -> Option<T> {
-        self.inner.lock().ok()?.take()
-    }
-}
-
+/// Connector abstraction used by `AutoReconnect` to establish new streams.
 pub trait GrpcConnector: Clone + Send + Sync + 'static {
+    /// Stream type produced by the connector.
     type Stream: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static;
+    /// Error type returned when connecting fails.
     type ConnectError: std::error::Error + Send + Sync + 'static;
+    /// Future type resolving to a connected stream.
     type ConnectFuture: Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static;
+
+    /// Connects a new subscribe stream from the provided request and optional checkpoint slot.
     fn connect(
         &self,
         request: Arc<SubscribeRequest>,
         from_slot: Option<u64>,
     ) -> Self::ConnectFuture;
-    fn backoff(&self) -> Backoff;
+
+    /// Returns true when reconnect attempts should be performed.
+    fn should_reconnect(&self) -> bool;
 }
 
 #[derive(Clone)]
+/// Connector implementation backed by tonic that can re-establish both sides
+/// of the bidirectional subscribe stream.
 pub struct TonicGrpcConnector {
     backoff: Backoff,
     request_sink: Arc<Mutex<mpsc::Sender<SubscribeRequest>>>,
@@ -346,6 +368,7 @@ pub struct TonicGrpcConnector {
 }
 
 impl TonicGrpcConnector {
+    /// Creates a tonic-backed connector and shared request sink handle.
     pub fn new(
         endpoint: Endpoint,
         config: ReconnectConfig,
@@ -372,11 +395,13 @@ impl GrpcConnector for TonicGrpcConnector {
     type ConnectFuture =
         Pin<Box<dyn Future<Output = Result<Self::Stream, Self::ConnectError>> + Send + 'static>>;
 
+    /// Opens a fresh tonic stream and atomically swaps the active request sender.
     fn connect(
         &self,
         request: Arc<SubscribeRequest>,
         from_slot: Option<u64>,
     ) -> Self::ConnectFuture {
+        let backoff = self.backoff.clone();
         let endpoint = self.endpoint.clone();
         let request_sink = self.request_sink.clone();
         let x_token = self.x_token.clone();
@@ -385,54 +410,77 @@ impl GrpcConnector for TonicGrpcConnector {
         let accept_compressed = self.accept_compressed;
         let max_decoding_message_size = self.max_decoding_message_size;
         let max_encoding_message_size = self.max_encoding_message_size;
-        let mut request = (*request).clone();
-        request.from_slot = from_slot;
+        let base_request = (*request).clone();
 
-        Box::pin(async move {
-            let channel = endpoint
-                .connect()
-                .await
-                .map_err(GeyserGrpcClientError::TransportError)?;
+        let fut = backoff.retry(move || {
+            let endpoint = endpoint.clone();
+            let request_sink = request_sink.clone();
+            let x_token = x_token.clone();
+            let mut request = base_request.clone();
+            async move {
+                request.from_slot = from_slot;
 
-            let interceptor = InterceptorXToken {
-                x_token,
-                x_request_snapshot,
-            };
+                let channel = endpoint
+                    .connect()
+                    .await
+                    .map_err(GeyserGrpcClientError::TransportError)
+                    .map_err(ErrorCategory::Retryable)?;
 
-            let mut geyser = GeyserClient::with_interceptor(channel.clone(), interceptor.clone());
-            if let Some(encoding) = send_compressed {
-                geyser = geyser.send_compressed(encoding);
+                let interceptor = InterceptorXToken {
+                    x_token,
+                    x_request_snapshot,
+                };
+
+                let mut geyser = GeyserClient::with_interceptor(channel.clone(), interceptor.clone());
+                if let Some(encoding) = send_compressed {
+                    geyser = geyser.send_compressed(encoding);
+                }
+                if let Some(encoding) = accept_compressed {
+                    geyser = geyser.accept_compressed(encoding);
+                }
+                if let Some(limit) = max_decoding_message_size {
+                    geyser = geyser.max_decoding_message_size(limit);
+                }
+                if let Some(limit) = max_encoding_message_size {
+                    geyser = geyser.max_encoding_message_size(limit);
+                }
+
+                let (mut subscribe_tx, subscribe_rx) = mpsc::channel(1000);
+                subscribe_tx
+                    .send(request)
+                    .await
+                    .map_err(GeyserGrpcClientError::SubscribeSendError)
+                    .map_err(ErrorCategory::Unrecoverable)?;
+                let response = geyser
+                    .subscribe(subscribe_rx)
+                    .await
+                    .map_err(GeyserGrpcClientError::from)
+                    .map_err(|e| {
+                        if is_recoverable_client_error(&e) {
+                            ErrorCategory::Retryable(e)
+                        } else {
+                            ErrorCategory::Unrecoverable(e)
+                        }
+                    })?;
+
+                // Reconnect creates a new bidi request channel; swap sender so user-facing
+                // SubscribeRequestSink continues writing into the active stream.
+                *request_sink.lock().expect("request sink mutex poisoned") = subscribe_tx;
+
+                Ok(response.into_inner())
             }
-            if let Some(encoding) = accept_compressed {
-                geyser = geyser.accept_compressed(encoding);
-            }
-            if let Some(limit) = max_decoding_message_size {
-                geyser = geyser.max_decoding_message_size(limit);
-            }
-            if let Some(limit) = max_encoding_message_size {
-                geyser = geyser.max_encoding_message_size(limit);
-            }
+        });
 
-            let (mut subscribe_tx, subscribe_rx) = mpsc::channel(1000);
-            subscribe_tx
-                .send(request)
-                .await
-                .map_err(GeyserGrpcClientError::SubscribeSendError)?;
-            let response = geyser.subscribe(subscribe_rx).await?;
-
-            // Reconnect creates a new bidi request channel; swap sender so user-facing
-            // SubscribeRequestSink continues writing into the active stream.
-            *request_sink.lock().expect("request sink mutex poisoned") = subscribe_tx;
-
-            Ok(response.into_inner())
-        })
+        Box::pin(fut)
     }
 
-    fn backoff(&self) -> Backoff {
-        self.backoff.clone()
+    fn should_reconnect(&self) -> bool {
+        self.backoff.max_retries > 0
     }
 }
 
+/// Stream wrapper that reconnects recoverable failures and resumes from the
+/// last checkpoint while preserving deduplication state.
 pub struct AutoReconnect<GrpcStream, Connector> {
     request: Arc<ArcSwap<SubscribeRequest>>,
     last_checkpoint: Option<u64>,
@@ -447,6 +495,7 @@ where
     S: Stream<Item = Result<SubscribeUpdate, Status>> + Unpin + Send + 'static,
     Connector: GrpcConnector<Stream = S, ConnectError = GeyserGrpcClientError>,
 {
+    /// Creates an auto-reconnecting stream from an initial stream and connector.
     pub(crate) fn new(
         stream: DedupStream<S>,
         connector: Connector,
@@ -462,38 +511,20 @@ where
         }
     }
 
+    /// Builds a reconnect future by delegating connection policy to the connector.
     fn make_connection_future(&self, dedup_state: DedupState) -> ConnectFuture<S> {
-        let backoff = self.connector.backoff();
         let connector = self.connector.clone();
-        let request = self.request.clone();
+        let request = self.request.load_full();
         let from_slot = self.last_checkpoint;
-        let dedup_state = ConsumeOnce::new(dedup_state);
-        let fut = backoff.retry(move || {
-            let connector = connector.clone();
-            let request = request.clone();
-            let from_slot = from_slot;
-            let dedup_state = dedup_state.clone();
-            async move {
-                let stream = connector
-                    .connect(request.load_full(), from_slot)
-                    .await
-                    .map_err(|e| {
-                        if is_recoverable_client_error(&e) {
-                            ErrorCategory::Retryable(e)
-                        } else {
-                            ErrorCategory::Unrecoverable(e)
-                        }
-                    })?;
-
-                let dedup_state = dedup_state.take().expect("dedup_state must exists");
-
-                Ok(DedupStream::new(stream, dedup_state))
-            }
-        });
+        let fut = async move {
+            let stream = connector.connect(request, from_slot).await?;
+            Ok(DedupStream::new(stream, dedup_state))
+        };
         Box::pin(fut)
     }
 }
 
+/// Returns true if a client error is considered transient and reconnectable.
 fn is_recoverable_client_error(err: &GeyserGrpcClientError) -> bool {
     match err {
         GeyserGrpcClientError::TonicStatus(status) => is_recoverable_status_code(&status.code()),
@@ -502,6 +533,7 @@ fn is_recoverable_client_error(err: &GeyserGrpcClientError) -> bool {
     }
 }
 
+/// Returns true for gRPC status codes that should trigger reconnect.
 const fn is_recoverable_status_code(code: &Code) -> bool {
     matches!(
         code,
@@ -549,7 +581,7 @@ where
                     Poll::Ready(Some(Err(status)))
                         if is_recoverable_status_code(&status.code()) =>
                     {
-                        if me.connector.backoff().max_retries == 0 {
+                        if !me.connector.should_reconnect() {
                             me.stop = true;
                             return Poll::Ready(Some(Err(status)));
                         }
@@ -602,6 +634,7 @@ where
     }
 }
 
+/// Extracts the slot number from a subscribe update when available.
 pub(crate) fn extract_slot(msg: &SubscribeUpdate) -> Option<u64> {
     match msg.update_oneof.as_ref()? {
         UpdateOneof::Account(m) => Some(m.slot),
@@ -697,8 +730,8 @@ mod tests {
             })
         }
 
-        fn backoff(&self) -> Backoff {
-            self.backoff.clone()
+        fn should_reconnect(&self) -> bool {
+            self.backoff.max_retries > 0
         }
     }
 


### PR DESCRIPTION
@Ozodimgba 

I simplified the code quite a bit, and leverage generic to avoid Boxing streams.

First is the backoff logic, I think you complexity yourself by adding intermidiary state to backoff and retry.
The backoff logic on its own is fine, but you could simplify your life by just making the connection code do the multi attempt and let the auto reconnect don't care about it.
TLDR: connection drop -> call "abstract magic reconnect code".
The "abstract magic reconnect code" can attempt multiple time no problem no need to make `AutoReconnect` complex.


Secondly I had to create another generic type to make sure we can be generic over the actual grpc stream.
By doing this, we can unit test without an actual GrpcStream, it also allow us to stack stream wrappers in a more complex generic type (will be require later).


All the logic of reconnecting is not dedicating into its own abstraction, allowing us to more easily mock during tests:

```
 // Now connector creete `GrpcStream`, no need to do boxing.
pub struct AutoReconnect<GrpcStream, Connector> {
    ..
}
``` 

The implementation of AutoReconnect is now simpler: either you poll from an existing stream or wait to reconnect.
Previously I wrote pseudo-rust code with state machine but state machine does not need to be with enum necessarly, that was just to more depict what we should strive for.


Your ReonnectConfig object used to have fields that would prevent a Default implementation to be like x_token and endpoint. Most software out there make a default configuration with smart default so you don't waste time on those as you get familiar with the tool. X_token and endpoint are not configurable values in the sense of tweaking software behaviour.
they are mostly crendentials and always handled different in software.
Putting credentials inside configuration makes it hard to test too.



Lastly, you did not account for `SubscribeRequest` change which on reconnect would not send the proper `SubscribeRequest`. I had to change it to use a shared ArcSwap and also make the frontend type called for our API that hides a mutex that makes sure reconnection + subscribe request update are consistent.



