### PR TITLE
Str 428: yellowstone-grpc-napi: use non-generic client types

### DIFF
--- a/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
+++ b/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
@@ -469,7 +469,9 @@ function writeAndWaitCallback(
     };
 
     const timeoutId = setTimeout(() => {
-      settleOnce(new Error(`Timed out waiting for write callback after ${timeoutMs}ms`));
+      settleOnce(
+        new Error(`Timed out waiting for write callback after ${timeoutMs}ms`),
+      );
     }, timeoutMs);
 
     try {
@@ -480,6 +482,37 @@ function writeAndWaitCallback(
       settleOnce(err as Error);
     }
   });
+}
+
+async function callAllUnaryMethodsAndAssert(client: Client): Promise<void> {
+  const latestBlockhash = await client.getLatestBlockhash(2);
+  expect(typeof latestBlockhash.slot).toBe("string");
+  expect(typeof latestBlockhash.blockhash).toBe("string");
+  expect(typeof latestBlockhash.lastValidBlockHeight).toBe("string");
+
+  const pingResponse = await client.ping(7);
+  expect(typeof pingResponse.count).toBe("number");
+  expect(pingResponse.count).toBe(7);
+
+  const blockHeight = await client.getBlockHeight(2);
+  expect(typeof blockHeight.blockHeight).toBe("string");
+
+  const slot = await client.getSlot(2);
+  expect(typeof slot.slot).toBe("string");
+
+  const blockhashValidity = await client.isBlockhashValid(
+    latestBlockhash.blockhash,
+    2,
+  );
+  expect(typeof blockhashValidity.slot).toBe("string");
+  expect(typeof blockhashValidity.valid).toBe("boolean");
+
+  const version = await client.getVersion();
+  expect(typeof version.version).toBe("string");
+  expect(version.version.length).toBeGreaterThan(0);
+
+  const replayInfo = await client.subscribeReplayInfo();
+  expect(typeof replayInfo).toBe("object");
 }
 
 function getAllGeyserMessageFns(): Array<[string, any]> {
@@ -675,12 +708,10 @@ describe("ClientDuplexStream read and lifecycle behavior", () => {
 
   test("read: native NO_UPDATE_AVAILABLE rejection is surfaced as error", async () => {
     const nativeClose = jest.fn();
-    const nativeRead = jest
-      .fn()
-      .mockRejectedValue({
-        code: "NO_UPDATE_AVAILABLE",
-        message: "no update available",
-      });
+    const nativeRead = jest.fn().mockRejectedValue({
+      code: "NO_UPDATE_AVAILABLE",
+      message: "no update available",
+    });
     const stream = new ClientDuplexStream(
       {
         close: nativeClose,
@@ -1415,6 +1446,118 @@ describe("Client subscription independence behavior", () => {
   });
 });
 
+// subscribe to both subscribe & subscribeDeshred, do all unary calls, modify subscribe request for both, do unary calls again
+describe("Concurrent subscriptions with unary calls", () => {
+  const TEST_TIMEOUT = 180000;
+
+  // .env
+  const { TEST_ENDPOINT: endpoint, TEST_TOKEN: xToken } = process.env;
+
+  const channelOptions = {};
+  const client = new Client(endpoint, xToken, channelOptions);
+
+  beforeAll(async () => {
+    await client.connect();
+  });
+
+  test(
+    "subscribe + subscribeDeshred remain active while unary calls run before and after request updates",
+    async () => {
+      const subscribeStream = await client.subscribe();
+      const subscribeDeshredStream = await client.subscribeDeshred();
+
+      try {
+        // 1) Send initial requests on both streams to establish active subscriptions.
+        const subscribeInitialRequest: SubscribeRequest = {
+          ...makeMinimalSubscribeRequest(),
+          slots: {
+            initial_slot_client: {
+              filterByCommitment: true,
+              interslotUpdates: false,
+            },
+          },
+          ping: { id: 100 },
+        };
+        const subscribeDeshredInitialRequest: SubscribeDeshredRequest = {
+          deshredTransactions: {
+            initial_deshred_client: {
+              vote: true,
+              accountInclude: [],
+              accountExclude: [],
+              accountRequired: [],
+            },
+          },
+          ping: { id: 101 },
+        };
+
+        expect(
+          await writeAndWaitCallback(subscribeStream, subscribeInitialRequest),
+        ).toBeNull();
+        expect(
+          await writeAndWaitCallback(
+            subscribeDeshredStream,
+            subscribeDeshredInitialRequest,
+          ),
+        ).toBeNull();
+
+        // 2) While both subscriptions are open, execute every unary method once.
+        await callAllUnaryMethodsAndAssert(client);
+
+        // 3) Update both subscription requests without recreating streams.
+        const subscribeUpdatedRequest: SubscribeRequest = {
+          ...makeMinimalSubscribeRequest(),
+          accounts: {
+            updated_accounts_client: {
+              account: [],
+              owner: [],
+              filters: [{ datasize: "165" }],
+            },
+          },
+          transactions: {
+            updated_tx_client: {
+              vote: false,
+              failed: false,
+              accountInclude: [],
+              accountExclude: [],
+              accountRequired: [],
+            },
+          },
+          ping: { id: 200 },
+          fromSlot: "1",
+        };
+        const subscribeDeshredUpdatedRequest: SubscribeDeshredRequest = {
+          deshredTransactions: {
+            updated_deshred_client: {
+              vote: false,
+              accountInclude: ["11111111111111111111111111111111"],
+              accountExclude: [],
+              accountRequired: [],
+            },
+          },
+          ping: { id: 201 },
+        };
+
+        expect(
+          await writeAndWaitCallback(subscribeStream, subscribeUpdatedRequest),
+        ).toBeNull();
+        expect(
+          await writeAndWaitCallback(
+            subscribeDeshredStream,
+            subscribeDeshredUpdatedRequest,
+          ),
+        ).toBeNull();
+
+        // 4) Call every unary method again while updated subscriptions are still running.
+        await callAllUnaryMethodsAndAssert(client);
+      } finally {
+        await closeStreamAndWait(subscribeStream);
+        await closeStreamAndWait(subscribeDeshredStream);
+      }
+    },
+    TEST_TIMEOUT,
+  );
+});
+
 describe("subscribe response schema tests", () => {
   const TEST_TIMEOUT = 100000;
 
@@ -1627,33 +1770,37 @@ describe("subscribe response schema tests", () => {
     await assertRequestsAcceptedOnSingleStream(requests);
   }, 180000);
 
-  test("runtime server errors are propagated via stream error event", async () => {
-    const stream = await client.subscribe();
-    try {
-      // Ensure `_read()` is driven so native terminal errors can surface to JS.
-      stream.on("data", () => {});
-      const runtimeError = waitForStreamError(stream, TEST_TIMEOUT);
-      const request = baseSubscribeRequest();
-      request.transactions = {
-        invalid_pubkey_filter: {
-          signature: "abc",
-          accountInclude: ["not_base58_!!!"],
-          accountExclude: [],
-          accountRequired: [],
-        },
-      };
+  test(
+    "runtime server errors are propagated via stream error event",
+    async () => {
+      const stream = await client.subscribe();
+      try {
+        // Ensure `_read()` is driven so native terminal errors can surface to JS.
+        stream.on("data", () => {});
+        const runtimeError = waitForStreamError(stream, TEST_TIMEOUT);
+        const request = baseSubscribeRequest();
+        request.transactions = {
+          invalid_pubkey_filter: {
+            signature: "abc",
+            accountInclude: ["not_base58_!!!"],
+            accountExclude: [],
+            accountRequired: [],
+          },
+        };
 
-      const writeError = await writeAndWaitCallback(stream, request);
-      expect(writeError).toBeNull();
+        const writeError = await writeAndWaitCallback(stream, request);
+        expect(writeError).toBeNull();
 
-      const observedError = await runtimeError;
-      const message = String(observedError?.message ?? "").toLowerCase();
-      expect(message.length).toBeGreaterThan(0);
-      expect(message.includes("no update available")).toBe(false);
-    } finally {
-      await closeStreamAndWait(stream);
-    }
-  }, TEST_TIMEOUT);
+        const observedError = await runtimeError;
+        const message = String(observedError?.message ?? "").toLowerCase();
+        expect(message.length).toBeGreaterThan(0);
+        expect(message.includes("no update available")).toBe(false);
+      } finally {
+        await closeStreamAndWait(stream);
+      }
+    },
+    TEST_TIMEOUT,
+  );
 
   test(
     "account",
@@ -2434,33 +2581,37 @@ describe("subscribeDeshred response schema tests", () => {
     await assertDeshredRequestsAcceptedOnSingleStream(requests);
   }, 180000);
 
-  test("deshred runtime server errors are propagated via stream error event", async () => {
-    const stream = await client.subscribeDeshred();
-    try {
-      // Ensure `_read()` is driven so native terminal errors can surface to JS.
-      stream.on("data", () => {});
-      const runtimeError = waitForStreamError(stream, TEST_TIMEOUT);
-      const request: SubscribeDeshredRequest = {
-        deshredTransactions: {
-          invalid_pubkey_filter: {
-            accountInclude: ["not_base58_!!!"],
-            accountExclude: [],
-            accountRequired: [],
+  test(
+    "deshred runtime server errors are propagated via stream error event",
+    async () => {
+      const stream = await client.subscribeDeshred();
+      try {
+        // Ensure `_read()` is driven so native terminal errors can surface to JS.
+        stream.on("data", () => {});
+        const runtimeError = waitForStreamError(stream, TEST_TIMEOUT);
+        const request: SubscribeDeshredRequest = {
+          deshredTransactions: {
+            invalid_pubkey_filter: {
+              accountInclude: ["not_base58_!!!"],
+              accountExclude: [],
+              accountRequired: [],
+            },
           },
-        },
-      };
+        };
 
-      const writeError = await writeAndWaitCallback(stream, request);
-      expect(writeError).toBeNull();
+        const writeError = await writeAndWaitCallback(stream, request);
+        expect(writeError).toBeNull();
 
-      const observedError = await runtimeError;
-      const message = String(observedError?.message ?? "").toLowerCase();
-      expect(message.length).toBeGreaterThan(0);
-      expect(message.includes("no update available")).toBe(false);
-    } finally {
-      await closeStreamAndWait(stream);
-    }
-  }, TEST_TIMEOUT);
+        const observedError = await runtimeError;
+        const message = String(observedError?.message ?? "").toLowerCase();
+        expect(message.length).toBeGreaterThan(0);
+        expect(message.includes("no update available")).toBe(false);
+      } finally {
+        await closeStreamAndWait(stream);
+      }
+    },
+    TEST_TIMEOUT,
+  );
 
   test(
     "deshred ping/pong",

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.lock
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.lock
@@ -3956,6 +3956,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4537,15 +4538,18 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "12.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a31478dd10ad437b6b39cb463706915ca9668201a6889957f740ed1b3cd8ec8"
+checksum = "d9c3e9328306945410423b40714b0fe9bfe361e5eba1da3e0a63288228313bfb"
 dependencies = [
  "bytes",
  "futures",
+ "hyper-util",
  "thiserror 2.0.18",
+ "tokio",
  "tonic 0.14.3",
  "tonic-health",
+ "tower 0.4.13",
  "yellowstone-grpc-proto",
 ]
 

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.lock
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.lock
@@ -120,28 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,70 +175,25 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -273,12 +206,12 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -303,12 +236,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -902,25 +829,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -930,8 +838,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.0",
+ "http",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -946,12 +854,6 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1000,17 +902,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1021,23 +912,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1048,8 +928,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1067,30 +947,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1099,9 +955,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1114,23 +970,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1146,12 +990,12 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1168,16 +1012,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -1319,12 +1153,6 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1392,7 +1220,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a1135cfe16ca43ac82ac05858554fc39c037d8e4592f2b4a83d7ef8e822f43"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "ctor",
  "futures-core",
  "napi-build",
@@ -1564,7 +1392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1575,7 +1403,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1683,15 +1511,6 @@ checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -1870,7 +1689,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -1944,7 +1763,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2017,7 +1836,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2030,25 +1849,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2062,7 +1867,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2080,32 +1885,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -2156,7 +1941,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2320,16 +2105,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -2395,7 +2170,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -2410,7 +2185,7 @@ dependencies = [
  "serde_json",
  "solana-account",
  "solana-pubkey 3.0.0",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -2682,7 +2457,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "solana-account-info",
  "solana-instruction",
  "solana-instruction-error",
@@ -3577,12 +3352,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3667,19 +3436,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -3695,22 +3454,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls",
  "tokio",
 ]
 
@@ -3754,7 +3502,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -3771,67 +3519,35 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "flate2",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.12.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "zstd 0.12.4",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-timeout 0.5.2",
+ "hyper",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.2",
- "sync_wrapper 1.0.2",
+ "socket2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -3868,7 +3584,7 @@ dependencies = [
  "prost 0.14.3",
  "tokio",
  "tokio-stream",
- "tonic 0.14.3",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -3880,7 +3596,7 @@ checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
 dependencies = [
  "bytes",
  "prost 0.14.3",
- "tonic 0.14.3",
+ "tonic",
 ]
 
 [[package]]
@@ -3907,13 +3623,8 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3927,10 +3638,10 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -4181,7 +3892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4192,9 +3903,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4476,7 +4187,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap",
  "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4506,8 +4217,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
- "indexmap 2.13.0",
+ "bitflags",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -4526,7 +4237,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -4547,7 +4258,7 @@ dependencies = [
  "hyper-util",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.14.3",
+ "tonic",
  "tonic-health",
  "tower 0.4.13",
  "yellowstone-grpc-proto",
@@ -4577,7 +4288,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "quote",
- "rustls 0.23.36",
+ "rustls",
  "serde",
  "serde_json",
  "solana-storage-proto",
@@ -4587,7 +4298,6 @@ dependencies = [
  "syn 2.0.117",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
  "uuid",
  "walkdir",
  "wincode 0.4.5",
@@ -4605,7 +4315,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "protoc-bin-vendored",
- "tonic 0.14.3",
+ "tonic",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -4658,30 +4368,11 @@ checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.toml
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.toml
@@ -21,7 +21,6 @@ base64 = "0.21"
 wincode = "0.4.4"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tonic = { version = "0.11", features = ["transport", "tls", "gzip", "zstd"] }
 rustls = { version = "0.23", features = ["ring"] }
 bytes = "1"
 futures = "0.3"

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.toml
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = "0.3"
 futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
-yellowstone-grpc-client = "12.1.0"
+yellowstone-grpc-client = "13.0.0"
 yellowstone-grpc-proto = "12.1.0"
 prost = "0.14"
 prost011 = { package = "prost", version = "0.11" }

--- a/yellowstone-grpc-client-nodejs/napi/index.js
+++ b/yellowstone-grpc-client-nodejs/napi/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-android-arm64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-android-arm-eabi')
         const bindingPackageVersion = require('yellowstone-grpc-napi-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-win32-x64-gnu')
         const bindingPackageVersion = require('yellowstone-grpc-napi-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-win32-x64-msvc')
         const bindingPackageVersion = require('yellowstone-grpc-napi-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-win32-ia32-msvc')
         const bindingPackageVersion = require('yellowstone-grpc-napi-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-win32-arm64-msvc')
         const bindingPackageVersion = require('yellowstone-grpc-napi-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('yellowstone-grpc-napi-darwin-universal')
       const bindingPackageVersion = require('yellowstone-grpc-napi-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-darwin-x64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-darwin-arm64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-freebsd-x64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-freebsd-arm64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-x64-musl')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-x64-gnu')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-arm64-musl')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-arm64-gnu')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-arm-musleabihf')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-arm-gnueabihf')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-loong64-musl')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-loong64-gnu')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-riscv64-musl')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('yellowstone-grpc-napi-linux-riscv64-gnu')
           const bindingPackageVersion = require('yellowstone-grpc-napi-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-linux-ppc64-gnu')
         const bindingPackageVersion = require('yellowstone-grpc-napi-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-linux-s390x-gnu')
         const bindingPackageVersion = require('yellowstone-grpc-napi-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-openharmony-arm64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-openharmony-x64')
         const bindingPackageVersion = require('yellowstone-grpc-napi-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('yellowstone-grpc-napi-openharmony-arm')
         const bindingPackageVersion = require('yellowstone-grpc-napi-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/yellowstone-grpc-client-nodejs/napi/package.json
+++ b/yellowstone-grpc-client-nodejs/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yellowstone-grpc-napi",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Yellowstone gRPC NAPI bindings",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yellowstone-grpc-client-nodejs/napi/src/client.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/client.rs
@@ -3,8 +3,6 @@
 use napi::bindgen_prelude::PromiseRaw;
 use napi::Env;
 use napi_derive::napi;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use yellowstone_grpc_client::GeyserGrpcClient;
 use yellowstone_grpc_proto::geyser::CommitmentLevel;
 
@@ -51,7 +49,7 @@ fn napi_error(status: napi::Status, reason: impl Into<String>) -> napi::Error {
 /// in the constructor and reused for all subsequent operations.
 #[napi]
 pub struct GrpcClient {
-  pub(crate) client: Arc<Mutex<GeyserGrpcClient>>,
+  pub(crate) client: GeyserGrpcClient,
 }
 
 #[napi]
@@ -86,7 +84,7 @@ impl GrpcClient {
     })?;
 
     Ok(Self {
-      client: Arc::new(Mutex::new(client)),
+      client: client,
     })
   }
 
@@ -100,13 +98,11 @@ impl GrpcClient {
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
-
-        let protobuf_response = grpc_client_guard
+        let protobuf_response = client
           .get_latest_blockhash(commitment_level_option)
           .await
           .map_err(|error| {
@@ -136,13 +132,12 @@ impl GrpcClient {
   ) -> napi::Result<PromiseRaw<'env, JsPongResponse>> {
     let ping_count = request.count;
 
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
 
-        let protobuf_response = grpc_client_guard.ping(ping_count).await.map_err(|error| {
+        let protobuf_response = client.ping(ping_count).await.map_err(|error| {
           napi_error_with_cause(napi::Status::GenericFailure, "ping request failed", &error)
         })?;
 
@@ -164,13 +159,11 @@ impl GrpcClient {
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
-
-        let protobuf_response = grpc_client_guard
+        let protobuf_response = client
           .get_block_height(commitment_level_option)
           .await
           .map_err(|error| {
@@ -199,13 +192,12 @@ impl GrpcClient {
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
 
-        let protobuf_response = grpc_client_guard
+        let protobuf_response = client
           .get_slot(commitment_level_option)
           .await
           .map_err(|error| {
@@ -235,13 +227,12 @@ impl GrpcClient {
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
 
-        let protobuf_response = grpc_client_guard
+        let protobuf_response = client
           .is_blockhash_valid(blockhash_value, commitment_level_option)
           .await
           .map_err(|error| {
@@ -269,13 +260,12 @@ impl GrpcClient {
     environment: &'env Env,
     _get_version_request: JsGetVersionRequest,
   ) -> napi::Result<PromiseRaw<'env, JsGetVersionResponse>> {
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
 
-        let protobuf_response = grpc_client_guard.get_version().await.map_err(|error| {
+        let protobuf_response = client.get_version().await.map_err(|error| {
           napi_error_with_cause(
             napi::Status::GenericFailure,
             "get_version request failed",
@@ -297,14 +287,13 @@ impl GrpcClient {
     environment: &'env Env,
     _subscribe_replay_info_request: JsSubscribeReplayInfoRequest,
   ) -> napi::Result<PromiseRaw<'env, JsSubscribeReplayInfoResponse>> {
-    let client = self.client.clone();
+    let mut client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response =
-          grpc_client_guard
+          client
             .subscribe_replay_info()
             .await
             .map_err(|error| {

--- a/yellowstone-grpc-client-nodejs/napi/src/client.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/client.rs
@@ -1,37 +1,12 @@
 // GrpcClient: A persistent, reusable gRPC client
-//
-// ## Problem:
-// The yellowstone-grpc library's builder returns `GeyserGrpcClient<impl Interceptor>`,
-// which is an opaque type that cannot be directly stored in a struct. We need to:
-// 1. Store a persistent client connection (created once, reused for all operations)
-// 2. Make the client accessible to NAPI for JavaScript interop
-// 3. Avoid exposing complex generic types to NAPI (which doesn't understand Rust generics)
-// 4. Avoid unsafe code
-//
-// ## Solution:
-// We use a two-layer architecture with type erasure:
-//
-// 1. **Internal Layer (`ClientHolder<I>`)**:
-//    - Generic holder that can wrap any `GeyserGrpcClient<I: Interceptor>`
-//    - Stores the client in `Arc<Mutex<>>` for thread-safe async access
-//    - Implements business logic methods that delegate to the underlying client
-//
-// 2. **NAPI Layer (`GrpcClient`)**:
-//    - Uses `Arc<dyn Any + Send + Sync>` to erase the generic type
-//    - Private field prevents NAPI from trying to expose it to JavaScript
-//    - Methods downcast back to the concrete type when needed
-//
-// ## Why This Works:
-// - The builder configured with `x_token` creates `InterceptorXToken`
-// - We know the concrete type will always be `ClientHolder<InterceptorXToken>`
-// - Type erasure with `Any` allows us to store it without exposing generics to NAPI
-// - Downcast is safe because we control the type at creation time
 
 use napi::bindgen_prelude::PromiseRaw;
 use napi::Env;
 use napi_derive::napi;
+use yellowstone_grpc_client::GeyserGrpcClient;
 use std::sync::Arc;
 use yellowstone_grpc_proto::geyser::CommitmentLevel;
+use tokio::sync::Mutex;
 
 use crate::{
   bindings::JsChannelOptions,
@@ -70,62 +45,17 @@ fn napi_error(status: napi::Status, reason: impl Into<String>) -> napi::Error {
   error
 }
 
-/// Internal module containing the generic client holder implementation.
-/// This is kept separate from the NAPI-exposed types to avoid generic type exposure.
-pub mod internal {
-  use std::sync::Arc;
-  use tokio::sync::Mutex;
-  use yellowstone_grpc_client::{GeyserGrpcClient, Interceptor};
-
-  /// Generic holder for GeyserGrpcClient with any interceptor type.
-  /// Wraps the client in Arc<Mutex<>> to allow safe sharing across async tasks.
-  pub struct ClientHolder<I: Interceptor> {
-    pub client: Arc<Mutex<GeyserGrpcClient<I>>>,
-  }
-
-  impl<I: Interceptor + Send + Sync + 'static> ClientHolder<I> {
-    /// Creates a new holder with a connected client.
-    /// The client is wrapped in Arc<Mutex<>> for thread-safe access.
-    pub fn new(client: GeyserGrpcClient<I>) -> Self {
-      Self {
-        client: Arc::new(Mutex::new(client)),
-      }
-    }
-  }
-}
-
 /// Main client struct exposed to JavaScript via NAPI.
 ///
 /// The client maintains a persistent gRPC connection that is created once
 /// in the constructor and reused for all subsequent operations.
 #[napi]
 pub struct GrpcClient {
-  /// Type-erased holder storing the actual client.
-  ///
-  /// We use `Arc<dyn Any>` to hide the generic type from NAPI:
-  /// - NAPI cannot handle generic types or complex Rust types
-  /// - The field is private, so NAPI doesn't try to expose it to JavaScript
-  /// - We downcast back to the concrete type in each method
-  ///
-  /// This is safe because:
-  /// - The builder configuration guarantees the interceptor type
-  /// - We always create `ClientHolder<InterceptorXToken>`
-  /// - The downcast will always succeed (or fail gracefully)
-  pub(crate) holder: Arc<dyn std::any::Any + Send + Sync>,
+  pub(crate) client: Arc<Mutex<GeyserGrpcClient>>,
 }
 
 #[napi]
 impl GrpcClient {
-  // Implementation note:
-  // Every unary method follows the same pattern:
-  // 1. clone the type-erased holder
-  // 2. downcast to the concrete `ClientHolder<InterceptorXToken>`
-  // 3. execute the async gRPC call under a mutex guard
-  // 4. convert protobuf response to generated JS type in callback
-  //
-  // `spawn_future_with_callback` is used so `Env` never crosses the async
-  // boundary, which avoids `Send` issues with napi handles.
-
   /// Creates a new gRPC client and establishes a connection.
   ///
   /// This is an async factory method that:
@@ -155,12 +85,8 @@ impl GrpcClient {
       )
     })?;
 
-    // Wrap in our generic holder which can accept any interceptor type
-    let holder = internal::ClientHolder::new(client);
-
-    // Erase the generic type by storing as Arc<dyn Any>
     Ok(Self {
-      holder: Arc::new(holder),
+      client: Arc::new(Mutex::new(client))
     })
   }
 
@@ -170,18 +96,15 @@ impl GrpcClient {
     environment: &'env Env,
     request: JsGetLatestBlockhashRequest,
   ) -> napi::Result<PromiseRaw<'env, JsGetLatestBlockhashResponse>> {
-    let grpc_client_holder = self.holder.clone();
     let commitment_level_option = request
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
+    let client = self.client.clone();
+
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
-
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard
           .get_latest_blockhash(commitment_level_option)
@@ -211,16 +134,14 @@ impl GrpcClient {
     environment: &'env Env,
     request: JsPingRequest,
   ) -> napi::Result<PromiseRaw<'env, JsPongResponse>> {
-    let grpc_client_holder = self.holder.clone();
     let ping_count = request.count;
+
+    let client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
 
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard.ping(ping_count).await.map_err(|error| {
           napi_error_with_cause(napi::Status::GenericFailure, "ping request failed", &error)
@@ -240,18 +161,16 @@ impl GrpcClient {
     environment: &'env Env,
     request: JsGetBlockHeightRequest,
   ) -> napi::Result<PromiseRaw<'env, JsGetBlockHeightResponse>> {
-    let grpc_client_holder = self.holder.clone();
     let commitment_level_option = request
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
+      let client = self.client.clone();
+      
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
 
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard
           .get_block_height(commitment_level_option)
@@ -278,18 +197,16 @@ impl GrpcClient {
     environment: &'env Env,
     request: JsGetSlotRequest,
   ) -> napi::Result<PromiseRaw<'env, JsGetSlotResponse>> {
-    let grpc_client_holder = self.holder.clone();
     let commitment_level_option = request
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
+    let client = self.client.clone();
+
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
 
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard
           .get_slot(commitment_level_option)
@@ -316,19 +233,16 @@ impl GrpcClient {
     environment: &'env Env,
     request: JsIsBlockhashValidRequest,
   ) -> napi::Result<PromiseRaw<'env, JsIsBlockhashValidResponse>> {
-    let grpc_client_holder = self.holder.clone();
     let blockhash_value = request.blockhash;
     let commitment_level_option = request
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
+    let client = self.client.clone();
+
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
-
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard
           .is_blockhash_valid(blockhash_value, commitment_level_option)
@@ -358,15 +272,12 @@ impl GrpcClient {
     environment: &'env Env,
     _get_version_request: JsGetVersionRequest,
   ) -> napi::Result<PromiseRaw<'env, JsGetVersionResponse>> {
-    let grpc_client_holder = self.holder.clone();
+
+let client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
-
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard.get_version().await.map_err(|error| {
           napi_error_with_cause(
@@ -390,15 +301,12 @@ impl GrpcClient {
     environment: &'env Env,
     _subscribe_replay_info_request: JsSubscribeReplayInfoRequest,
   ) -> napi::Result<PromiseRaw<'env, JsSubscribeReplayInfoResponse>> {
-    let grpc_client_holder = self.holder.clone();
+let client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-        let grpc_client_holder = grpc_client_holder
-          .downcast_ref::<internal::ClientHolder<yellowstone_grpc_client::InterceptorXToken>>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
 
-        let mut grpc_client_guard = grpc_client_holder.client.lock().await;
+        let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response =
           grpc_client_guard

--- a/yellowstone-grpc-client-nodejs/napi/src/client.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/client.rs
@@ -83,9 +83,7 @@ impl GrpcClient {
       )
     })?;
 
-    Ok(Self {
-      client: client,
-    })
+    Ok(Self { client: client })
   }
 
   #[napi]
@@ -136,7 +134,6 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
         let protobuf_response = client.ping(ping_count).await.map_err(|error| {
           napi_error_with_cause(napi::Status::GenericFailure, "ping request failed", &error)
         })?;
@@ -196,17 +193,17 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
-        let protobuf_response = client
-          .get_slot(commitment_level_option)
-          .await
-          .map_err(|error| {
-            napi_error_with_cause(
-              napi::Status::GenericFailure,
-              "get_slot request failed",
-              &error,
-            )
-          })?;
+        let protobuf_response =
+          client
+            .get_slot(commitment_level_option)
+            .await
+            .map_err(|error| {
+              napi_error_with_cause(
+                napi::Status::GenericFailure,
+                "get_slot request failed",
+                &error,
+              )
+            })?;
 
         Ok(protobuf_response)
       },
@@ -231,7 +228,6 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
         let protobuf_response = client
           .is_blockhash_valid(blockhash_value, commitment_level_option)
           .await
@@ -264,7 +260,6 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
         let protobuf_response = client.get_version().await.map_err(|error| {
           napi_error_with_cause(
             napi::Status::GenericFailure,
@@ -291,18 +286,13 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
-        let protobuf_response =
-          client
-            .subscribe_replay_info()
-            .await
-            .map_err(|error| {
-              napi_error_with_cause(
-                napi::Status::GenericFailure,
-                "subscribe_replay_info request failed",
-                &error,
-              )
-            })?;
+        let protobuf_response = client.subscribe_replay_info().await.map_err(|error| {
+          napi_error_with_cause(
+            napi::Status::GenericFailure,
+            "subscribe_replay_info request failed",
+            &error,
+          )
+        })?;
 
         Ok(protobuf_response)
       },

--- a/yellowstone-grpc-client-nodejs/napi/src/client.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/client.rs
@@ -3,10 +3,10 @@
 use napi::bindgen_prelude::PromiseRaw;
 use napi::Env;
 use napi_derive::napi;
-use yellowstone_grpc_client::GeyserGrpcClient;
 use std::sync::Arc;
-use yellowstone_grpc_proto::geyser::CommitmentLevel;
 use tokio::sync::Mutex;
+use yellowstone_grpc_client::GeyserGrpcClient;
+use yellowstone_grpc_proto::geyser::CommitmentLevel;
 
 use crate::{
   bindings::JsChannelOptions,
@@ -86,7 +86,7 @@ impl GrpcClient {
     })?;
 
     Ok(Self {
-      client: Arc::new(Mutex::new(client))
+      client: Arc::new(Mutex::new(client)),
     })
   }
 
@@ -140,7 +140,6 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
         let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard.ping(ping_count).await.map_err(|error| {
@@ -165,11 +164,10 @@ impl GrpcClient {
       .commitment
       .and_then(|c| CommitmentLevel::try_from(c).ok());
 
-      let client = self.client.clone();
-      
+    let client = self.client.clone();
+
     environment.spawn_future_with_callback(
       async move {
-
         let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard
@@ -205,7 +203,6 @@ impl GrpcClient {
 
     environment.spawn_future_with_callback(
       async move {
-
         let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response = grpc_client_guard
@@ -272,8 +269,7 @@ impl GrpcClient {
     environment: &'env Env,
     _get_version_request: JsGetVersionRequest,
   ) -> napi::Result<PromiseRaw<'env, JsGetVersionResponse>> {
-
-let client = self.client.clone();
+    let client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
@@ -301,11 +297,10 @@ let client = self.client.clone();
     environment: &'env Env,
     _subscribe_replay_info_request: JsSubscribeReplayInfoRequest,
   ) -> napi::Result<PromiseRaw<'env, JsSubscribeReplayInfoResponse>> {
-let client = self.client.clone();
+    let client = self.client.clone();
 
     environment.spawn_future_with_callback(
       async move {
-
         let mut grpc_client_guard = client.lock().await;
 
         let protobuf_response =

--- a/yellowstone-grpc-client-nodejs/napi/src/lib.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/lib.rs
@@ -131,21 +131,16 @@ impl DuplexStream {
     env: &'env Env,
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
-    let client_holder = grpc_client.holder.clone();
-
+    let client = grpc_client.client.clone();
+    
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // reject the Promise and bubble to TypeScript callers.
     env.spawn_future_with_callback(
       async move {
-        let holder = client_holder
-          .downcast_ref::<crate::client::internal::ClientHolder<
-            yellowstone_grpc_client::InterceptorXToken,
-          >>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
-
         // Acquire lock, call subscribe, and immediately release the lock.
         let (mut stream_tx, mut stream_rx) = {
-          let mut client = holder.client.lock().await;
+          let mut client = client.lock().await;
+
           client.subscribe().await.map_err(|error| {
             napi_error_with_cause(
               napi::Status::GenericFailure,
@@ -399,21 +394,16 @@ impl DuplexStreamDeshred {
     env: &'env Env,
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
-    let client_holder = grpc_client.holder.clone();
+  let client = grpc_client.client.clone();
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // (e.g. UNIMPLEMENTED) reject the Promise and bubble to TypeScript callers.
     env.spawn_future_with_callback(
       async move {
-        let holder = client_holder
-          .downcast_ref::<crate::client::internal::ClientHolder<
-            yellowstone_grpc_client::InterceptorXToken,
-          >>()
-          .ok_or_else(|| napi_error(napi::Status::GenericFailure, "Invalid client type"))?;
 
         // Acquire lock, open stream, and release lock immediately.
         let (mut stream_tx, mut stream_rx) = {
-          let mut client = holder.client.lock().await;
+          let mut client = client.lock().await;
           client.subscribe_deshred().await.map_err(|error| {
             napi_error_with_cause(
               napi::Status::GenericFailure,

--- a/yellowstone-grpc-client-nodejs/napi/src/lib.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/lib.rs
@@ -132,7 +132,7 @@ impl DuplexStream {
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
     let client = grpc_client.client.clone();
-    
+
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // reject the Promise and bubble to TypeScript callers.
     env.spawn_future_with_callback(
@@ -394,13 +394,12 @@ impl DuplexStreamDeshred {
     env: &'env Env,
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
-  let client = grpc_client.client.clone();
+    let client = grpc_client.client.clone();
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // (e.g. UNIMPLEMENTED) reject the Promise and bubble to TypeScript callers.
     env.spawn_future_with_callback(
       async move {
-
         // Acquire lock, open stream, and release lock immediately.
         let (mut stream_tx, mut stream_rx) = {
           let mut client = client.lock().await;

--- a/yellowstone-grpc-client-nodejs/napi/src/lib.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/lib.rs
@@ -131,7 +131,7 @@ impl DuplexStream {
     env: &'env Env,
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
-    let client = grpc_client.client.clone();
+    let mut client = grpc_client.client.clone();
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // reject the Promise and bubble to TypeScript callers.
@@ -139,8 +139,6 @@ impl DuplexStream {
       async move {
         // Acquire lock, call subscribe, and immediately release the lock.
         let (mut stream_tx, mut stream_rx) = {
-          let mut client = client.lock().await;
-
           client.subscribe().await.map_err(|error| {
             napi_error_with_cause(
               napi::Status::GenericFailure,
@@ -394,7 +392,7 @@ impl DuplexStreamDeshred {
     env: &'env Env,
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
-    let client = grpc_client.client.clone();
+    let mut client = grpc_client.client.clone();
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // (e.g. UNIMPLEMENTED) reject the Promise and bubble to TypeScript callers.
@@ -402,7 +400,6 @@ impl DuplexStreamDeshred {
       async move {
         // Acquire lock, open stream, and release lock immediately.
         let (mut stream_tx, mut stream_rx) = {
-          let mut client = client.lock().await;
           client.subscribe_deshred().await.map_err(|error| {
             napi_error_with_cause(
               napi::Status::GenericFailure,

--- a/yellowstone-grpc-client-nodejs/package-lock.json
+++ b/yellowstone-grpc-client-nodejs/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3882,6 +3883,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4568,6 +4570,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5240,6 +5243,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6396,6 +6400,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8855,6 +8860,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/yellowstone-grpc-client-nodejs/package-lock.json
+++ b/yellowstone-grpc-client-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@triton-one/yellowstone-grpc",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@triton-one/yellowstone-grpc",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "=2.10.2",
@@ -36,10 +36,10 @@
         "node": ">=20.18.0"
       },
       "optionalDependencies": {
-        "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.12",
-        "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.12",
-        "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.12",
-        "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.12"
+        "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.13",
+        "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.13",
+        "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.13",
+        "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.13"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4423,9 +4423,9 @@
       }
     },
     "node_modules/@triton-one/yellowstone-grpc-napi-darwin-arm64": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-darwin-arm64/-/yellowstone-grpc-napi-darwin-arm64-0.0.12.tgz",
-      "integrity": "sha512-i4qk9/7dTo6VfbjEprye9znfhOID6QCPwKhNLUM/bnXcsa5lislTkGrs736tiVSTE5EWiU9ZfL/IuTnyIGyp3Q==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-darwin-arm64/-/yellowstone-grpc-napi-darwin-arm64-0.0.13.tgz",
+      "integrity": "sha512-oEDHWAvkylhFupttQiitmZjf07ZuKiXjWgW8HMvWR4DvZxNOGKeOrWHkyQDZN2IjaJPeLWB9ISlpcXY/i9WLBA==",
       "cpu": [
         "arm64"
       ],
@@ -4435,9 +4435,9 @@
       ]
     },
     "node_modules/@triton-one/yellowstone-grpc-napi-darwin-x64": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-darwin-x64/-/yellowstone-grpc-napi-darwin-x64-0.0.12.tgz",
-      "integrity": "sha512-cV2QFXCFWwl+nTNK2//wS1vcQFiDdJ6E3u8A2+cNt6k6lNK5Qzc4rbMxr/EDV2MJQJhR6ar/IRpF2nGuIX+Wkw==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-darwin-x64/-/yellowstone-grpc-napi-darwin-x64-0.0.13.tgz",
+      "integrity": "sha512-KuJSmPylbUTUibUuFQThi2B1C9yQyWCSf8vxfD1nYj5MyT0+x+uIPKQEqAy+NH4wd0w/0Bdc0ewgp2qYypus3w==",
       "cpu": [
         "x64"
       ],
@@ -4447,9 +4447,9 @@
       ]
     },
     "node_modules/@triton-one/yellowstone-grpc-napi-linux-x64-gnu": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-linux-x64-gnu/-/yellowstone-grpc-napi-linux-x64-gnu-0.0.12.tgz",
-      "integrity": "sha512-UkTU0NrDVjBce4XM0ImyKj+WHMCdjEG6JO67ppnjkqRjYM4gcNYEyGRc/5kjkZ7xmkYKd5Wht9hacBFHyxundw==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-linux-x64-gnu/-/yellowstone-grpc-napi-linux-x64-gnu-0.0.13.tgz",
+      "integrity": "sha512-amdUEAOh0LxHQbGhh8DbZaDTv1IeLASZi9tB/VnBZZuhaqMcrINsMApJdonKYzKpBffEAvH3uGKKvAJoqjaL+Q==",
       "cpu": [
         "x64"
       ],
@@ -4459,9 +4459,9 @@
       ]
     },
     "node_modules/@triton-one/yellowstone-grpc-napi-linux-x64-musl": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-linux-x64-musl/-/yellowstone-grpc-napi-linux-x64-musl-0.0.12.tgz",
-      "integrity": "sha512-mkPByzCgPhlqEPhvwpdwruNTcAook8OYkVQzx9AJWH3K6hMasUlcZhO5aZPMBNyPzB1r9FjIh3mYxrXi5+OdTA==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc-napi-linux-x64-musl/-/yellowstone-grpc-napi-linux-x64-musl-0.0.13.tgz",
+      "integrity": "sha512-qg5VAloVwpPu5zpEv5h2fq15H+LOVQZem8iQdtO9D/UvfXwgXTaOsMJ2MEU0HQzfpISnIJF0IwZhBSCSXIv3qw==",
       "cpu": [
         "x64"
       ],

--- a/yellowstone-grpc-client-nodejs/package.json
+++ b/yellowstone-grpc-client-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triton-one/yellowstone-grpc",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "license": "Apache-2.0",
   "author": "Triton One",
   "description": "Yellowstone gRPC Geyser Node.js Client",
@@ -39,10 +39,10 @@
     "@solana/rpc-types": "=5.1.0"
   },
   "optionalDependencies": {
-    "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.12",
-    "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.12",
-    "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.12",
-    "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.12"
+    "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.13",
+    "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.13",
+    "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.13",
+    "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.13"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",


### PR DESCRIPTION
Refactor the GrpcClient internal representation to now use concrete GrpcGeyserClient type that has no generic, thus no need of Boxing.