### PR TITLE
feat(napi): add slot and V2 shred fields to deshred bindings

### DIFF
--- a/examples/typescript/src/client.ts
+++ b/examples/typescript/src/client.ts
@@ -341,6 +341,7 @@ async function subscribeDeshredCommand(client: Client, args) {
       },
     },
     ping: args.ping ? { id: args.ping } : undefined,
+    slots: {},
   };
 
   await new Promise<void>((resolve, reject) => {

--- a/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
+++ b/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
@@ -265,6 +265,7 @@ function makeComprehensiveSubscribeRequest(): SubscribeRequest {
 function makeMinimalSubscribeDeshredRequest(): SubscribeDeshredRequest {
   return {
     deshredTransactions: {},
+    slots: {},
   };
 }
 
@@ -934,6 +935,7 @@ describe("ClientDuplexStream read and lifecycle behavior", () => {
         },
       },
       ping: { id: 11 },
+      slots: {},
     };
 
     const writeError = await writeAndCaptureError(stream, request);
@@ -958,7 +960,7 @@ describe("ClientDuplexStream read and lifecycle behavior", () => {
     await closeStreamAndWait(stream);
   });
 
-  test("deshred write: normalizes vote='false' string without mutating request object", async () => {
+  test("deshred write: rejects vote='false' string without mutating request object", async () => {
     const nativeWriteRaw = jest.fn();
     const stream = new ClientDeshredDuplexStream(
       {
@@ -984,11 +986,11 @@ describe("ClientDuplexStream read and lifecycle behavior", () => {
     const requestBeforeWrite = JSON.parse(JSON.stringify(request));
 
     const writeError = await writeAndCaptureError(stream, request);
-    expect(writeError).toBeNull();
-
-    const forwardedBytes = nativeWriteRaw.mock.calls[0][0] as Uint8Array;
-    const decoded = geyser.SubscribeDeshredRequest.decode(forwardedBytes);
-    expect(decoded.deshredTransactions.client.vote).toBe(false);
+    expect(writeError).not.toBeNull();
+    expect(String(writeError?.message ?? "")).toContain(
+      "Invalid deshredTransactions.client.vote",
+    );
+    expect(nativeWriteRaw).toHaveBeenCalledTimes(0);
 
     expect(request).toEqual(requestBeforeWrite);
 
@@ -1279,6 +1281,7 @@ describe("ClientDuplexStream read and lifecycle behavior", () => {
           accountRequired: [],
         },
       },
+      slots: {},
     };
 
     const writeError = await writeAndCaptureError(stream, request);
@@ -1488,6 +1491,7 @@ describe("Concurrent subscriptions with unary calls", () => {
             },
           },
           ping: { id: 101 },
+          slots: {},
         };
 
         expect(
@@ -1535,6 +1539,7 @@ describe("Concurrent subscriptions with unary calls", () => {
             },
           },
           ping: { id: 201 },
+          slots: {},
         };
 
         expect(
@@ -2520,6 +2525,7 @@ describe("subscribeDeshred response schema tests", () => {
   function baseSubscribeDeshredRequest(): SubscribeDeshredRequest {
     return {
       deshredTransactions: {},
+      slots: {},
     };
   }
 
@@ -2597,6 +2603,7 @@ describe("subscribeDeshred response schema tests", () => {
               accountRequired: [],
             },
           },
+          slots: {},
         };
 
         const writeError = await writeAndWaitCallback(stream, request);
@@ -2622,6 +2629,7 @@ describe("subscribeDeshred response schema tests", () => {
         ping: {
           id: 42,
         },
+        slots: {},
       };
 
       const waitForPingOrPong = waitForSubscribeUpdateMatchingPredicate(

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.lock
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.lock
@@ -4307,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "12.1.0"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab52445da59c3e710dd2128e3e49598cfa45c8ba7f30feb608cafbd404e5e8cf"
+checksum = "c3dd0babb9241c4bda5fe3d55cfa33d87d04ca64db0b877e9e1c94afa4dec8ef"
 dependencies = [
  "anyhow",
  "prost 0.14.3",

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.toml
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.toml
@@ -29,7 +29,7 @@ futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
 yellowstone-grpc-client = "13.0.0"
-yellowstone-grpc-proto = "12.1.0"
+yellowstone-grpc-proto = "12.2.0"
 prost = "0.14"
 prost011 = { package = "prost", version = "0.11" }
 bs58 = { version = "0.5.0", features = ["alloc"] }
@@ -49,7 +49,7 @@ quote = "1"
 proc-macro2 = "1"
 walkdir = "2.5.0"
 napi-derive = "3.3.0"
-yellowstone-grpc-proto = "12.1.0"
+yellowstone-grpc-proto = "12.2.0"
 
 [dev-dependencies]
 syn = { version = "2", features = ["full"] }

--- a/yellowstone-grpc-client-nodejs/napi/index.d.ts
+++ b/yellowstone-grpc-client-nodejs/napi/index.d.ts
@@ -260,6 +260,7 @@ export interface JsRewards {
 export interface JsSubscribeDeshredRequest {
   deshredTransactions: Record<string, JsSubscribeRequestFilterDeshredTransactions>
   ping?: JsSubscribeRequestPing
+  slots?: Record<string, JsSubscribeRequestFilterSlots>
 }
 
 export interface JsSubscribeReplayInfoRequest {
@@ -437,12 +438,15 @@ export interface JsSubscribeUpdateDeshredTransactionInfo {
   transaction?: JsTransaction
   loadedWritableAddresses: Array<Buffer>
   loadedReadonlyAddresses: Array<Buffer>
+  completedDataSetStartingShredIndex: number
+  completedDataSetEndingShredIndexExclusive: number
 }
 
 export interface JsSubscribeUpdateDeshredUpdateOneof {
   deshredTransaction?: JsSubscribeUpdateDeshredTransaction
   ping?: JsSubscribeUpdatePing
   pong?: JsSubscribeUpdatePong
+  slot?: JsSubscribeUpdateSlot
 }
 
 export interface JsSubscribeUpdateEntry {

--- a/yellowstone-grpc-client-nodejs/napi/index.d.ts
+++ b/yellowstone-grpc-client-nodejs/napi/index.d.ts
@@ -260,7 +260,7 @@ export interface JsRewards {
 export interface JsSubscribeDeshredRequest {
   deshredTransactions: Record<string, JsSubscribeRequestFilterDeshredTransactions>
   ping?: JsSubscribeRequestPing
-  slots?: Record<string, JsSubscribeRequestFilterSlots>
+  slots: Record<string, JsSubscribeRequestFilterSlots>
 }
 
 export interface JsSubscribeReplayInfoRequest {

--- a/yellowstone-grpc-client-nodejs/napi/src/encoding.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/encoding.rs
@@ -274,6 +274,8 @@ mod tests {
       transaction: None,
       loaded_writable_addresses: Vec::new(),
       loaded_readonly_addresses: Vec::new(),
+      completed_data_set_starting_shred_index: 0,
+      completed_data_set_ending_shred_index_exclusive: 0,
     }
     .encode_to_vec();
 

--- a/yellowstone-grpc-client-nodejs/napi/src/js_types.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/js_types.rs
@@ -649,6 +649,7 @@ pub struct JsSubscribeUpdateDeshredUpdateOneof<'env> {
   pub deshred_transaction: ::core::option::Option<JsSubscribeUpdateDeshredTransaction<'env>>,
   pub ping: ::core::option::Option<JsSubscribeUpdatePing>,
   pub pong: ::core::option::Option<JsSubscribeUpdatePong>,
+  pub slot: ::core::option::Option<JsSubscribeUpdateSlot>,
 }
 impl<'env> JsSubscribeUpdateDeshredUpdateOneof<'env> {
   pub fn from_protobuf_to_js_type(
@@ -662,6 +663,7 @@ impl<'env> JsSubscribeUpdateDeshredUpdateOneof<'env> {
         ),
         ping: None,
         pong: None,
+        slot: None,
       }),
       subscribe_update_deshred::UpdateOneof::Ping(oneof_variant_value) => Ok(Self {
         ping: Some(JsSubscribeUpdatePing::from_protobuf_to_js_type(
@@ -670,6 +672,7 @@ impl<'env> JsSubscribeUpdateDeshredUpdateOneof<'env> {
         )?),
         deshred_transaction: None,
         pong: None,
+        slot: None,
       }),
       subscribe_update_deshred::UpdateOneof::Pong(oneof_variant_value) => Ok(Self {
         pong: Some(JsSubscribeUpdatePong::from_protobuf_to_js_type(
@@ -678,6 +681,16 @@ impl<'env> JsSubscribeUpdateDeshredUpdateOneof<'env> {
         )?),
         deshred_transaction: None,
         ping: None,
+        slot: None,
+      }),
+      subscribe_update_deshred::UpdateOneof::Slot(oneof_variant_value) => Ok(Self {
+        slot: Some(JsSubscribeUpdateSlot::from_protobuf_to_js_type(
+          env,
+          oneof_variant_value,
+        )?),
+        deshred_transaction: None,
+        ping: None,
+        pong: None,
       }),
     }
   }
@@ -686,6 +699,7 @@ impl<'env> JsSubscribeUpdateDeshredUpdateOneof<'env> {
       deshred_transaction,
       ping,
       pong,
+      slot,
     } = self;
     let mut selected_oneof_variant: ::core::option::Option<subscribe_update_deshred::UpdateOneof> =
       None;
@@ -722,6 +736,18 @@ impl<'env> JsSubscribeUpdateDeshredUpdateOneof<'env> {
       }
       let converted_variant_value = oneof_variant_value.from_js_to_protobuf_type()?;
       selected_oneof_variant = Some(subscribe_update_deshred::UpdateOneof::Pong(
+        converted_variant_value,
+      ));
+    }
+    if let Some(oneof_variant_value) = slot {
+      if selected_oneof_variant.is_some() {
+        return Err(__typegen_invalid_arg(format!(
+          "Multiple variants set for {}",
+          "subscribe_update_deshred::UpdateOneof"
+        )));
+      }
+      let converted_variant_value = oneof_variant_value.from_js_to_protobuf_type()?;
+      selected_oneof_variant = Some(subscribe_update_deshred::UpdateOneof::Slot(
         converted_variant_value,
       ));
     }
@@ -1426,6 +1452,9 @@ pub struct JsSubscribeDeshredRequest {
     JsSubscribeRequestFilterDeshredTransactions,
   >,
   pub ping: ::core::option::Option<JsSubscribeRequestPing>,
+  pub slots: ::core::option::Option<
+    ::std::collections::HashMap<::prost::alloc::string::String, JsSubscribeRequestFilterSlots>,
+  >,
 }
 impl JsSubscribeDeshredRequest {
   pub fn from_protobuf_to_js_type(env: &Env, value: SubscribeDeshredRequest) -> napi::Result<Self> {
@@ -1448,6 +1477,17 @@ impl JsSubscribeDeshredRequest {
           JsSubscribeRequestPing::from_protobuf_to_js_type(env, option_inner_value)
         })
         .transpose()?,
+      slots: Some(
+        value
+          .slots
+          .into_iter()
+          .map(|(hash_map_entry_key, hash_map_entry_value)| {
+            let converted_hash_map_value =
+              JsSubscribeRequestFilterSlots::from_protobuf_to_js_type(env, hash_map_entry_value)?;
+            Ok::<_, napi::Error>((hash_map_entry_key, converted_hash_map_value))
+          })
+          .collect::<napi::Result<::std::collections::HashMap<_, _>>>()?,
+      ),
     })
   }
   pub fn from_js_to_protobuf_type(self) -> napi::Result<SubscribeDeshredRequest> {
@@ -1465,6 +1505,16 @@ impl JsSubscribeDeshredRequest {
         .ping
         .map(|option_inner_value| option_inner_value.from_js_to_protobuf_type())
         .transpose()?,
+      slots: self
+        .slots
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(hash_map_entry_key, hash_map_entry_value)| {
+          let converted_hash_map_key = Ok::<_, napi::Error>(hash_map_entry_key)?;
+          let converted_hash_map_value = hash_map_entry_value.from_js_to_protobuf_type()?;
+          Ok::<_, napi::Error>((converted_hash_map_key, converted_hash_map_value))
+        })
+        .collect::<napi::Result<::std::collections::HashMap<_, _>>>()?,
     })
   }
 }
@@ -2146,6 +2196,8 @@ pub struct JsSubscribeUpdateDeshredTransactionInfo<'env> {
   pub transaction: ::core::option::Option<JsTransaction<'env>>,
   pub loaded_writable_addresses: ::prost::alloc::vec::Vec<BufferSlice<'env>>,
   pub loaded_readonly_addresses: ::prost::alloc::vec::Vec<BufferSlice<'env>>,
+  pub completed_data_set_starting_shred_index: u32,
+  pub completed_data_set_ending_shred_index_exclusive: u32,
 }
 impl<'env> JsSubscribeUpdateDeshredTransactionInfo<'env> {
   pub fn from_protobuf_to_js_type(
@@ -2169,6 +2221,12 @@ impl<'env> JsSubscribeUpdateDeshredTransactionInfo<'env> {
         .into_iter()
         .map(|vec_inner_value| BufferSlice::copy_from(env, &vec_inner_value))
         .collect::<napi::Result<::prost::alloc::vec::Vec<_>>>()?,
+      completed_data_set_starting_shred_index: Ok::<_, napi::Error>(
+        value.completed_data_set_starting_shred_index,
+      )?,
+      completed_data_set_ending_shred_index_exclusive: Ok::<_, napi::Error>(
+        value.completed_data_set_ending_shred_index_exclusive,
+      )?,
     })
   }
   pub fn from_js_to_protobuf_type(self) -> napi::Result<SubscribeUpdateDeshredTransactionInfo> {
@@ -2189,6 +2247,12 @@ impl<'env> JsSubscribeUpdateDeshredTransactionInfo<'env> {
         .into_iter()
         .map(|vec_inner_value| Ok::<_, napi::Error>(vec_inner_value.as_ref().to_vec()))
         .collect::<napi::Result<::prost::alloc::vec::Vec<_>>>()?,
+      completed_data_set_starting_shred_index: Ok::<_, napi::Error>(
+        self.completed_data_set_starting_shred_index,
+      )?,
+      completed_data_set_ending_shred_index_exclusive: Ok::<_, napi::Error>(
+        self.completed_data_set_ending_shred_index_exclusive,
+      )?,
     })
   }
 }

--- a/yellowstone-grpc-client-nodejs/napi/src/js_types.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/js_types.rs
@@ -1452,9 +1452,8 @@ pub struct JsSubscribeDeshredRequest {
     JsSubscribeRequestFilterDeshredTransactions,
   >,
   pub ping: ::core::option::Option<JsSubscribeRequestPing>,
-  pub slots: ::core::option::Option<
+  pub slots:
     ::std::collections::HashMap<::prost::alloc::string::String, JsSubscribeRequestFilterSlots>,
-  >,
 }
 impl JsSubscribeDeshredRequest {
   pub fn from_protobuf_to_js_type(env: &Env, value: SubscribeDeshredRequest) -> napi::Result<Self> {
@@ -1477,17 +1476,15 @@ impl JsSubscribeDeshredRequest {
           JsSubscribeRequestPing::from_protobuf_to_js_type(env, option_inner_value)
         })
         .transpose()?,
-      slots: Some(
-        value
-          .slots
-          .into_iter()
-          .map(|(hash_map_entry_key, hash_map_entry_value)| {
-            let converted_hash_map_value =
-              JsSubscribeRequestFilterSlots::from_protobuf_to_js_type(env, hash_map_entry_value)?;
-            Ok::<_, napi::Error>((hash_map_entry_key, converted_hash_map_value))
-          })
-          .collect::<napi::Result<::std::collections::HashMap<_, _>>>()?,
-      ),
+      slots: value
+        .slots
+        .into_iter()
+        .map(|(hash_map_entry_key, hash_map_entry_value)| {
+          let converted_hash_map_value =
+            JsSubscribeRequestFilterSlots::from_protobuf_to_js_type(env, hash_map_entry_value)?;
+          Ok::<_, napi::Error>((hash_map_entry_key, converted_hash_map_value))
+        })
+        .collect::<napi::Result<::std::collections::HashMap<_, _>>>()?,
     })
   }
   pub fn from_js_to_protobuf_type(self) -> napi::Result<SubscribeDeshredRequest> {
@@ -1507,7 +1504,6 @@ impl JsSubscribeDeshredRequest {
         .transpose()?,
       slots: self
         .slots
-        .unwrap_or_default()
         .into_iter()
         .map(|(hash_map_entry_key, hash_map_entry_value)| {
           let converted_hash_map_key = Ok::<_, napi::Error>(hash_map_entry_key)?;

--- a/yellowstone-grpc-client-nodejs/napi/src/lib.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/lib.rs
@@ -653,6 +653,7 @@ mod tests {
     JsSubscribeDeshredRequest {
       deshred_transactions: HashMap::new(),
       ping: None,
+      slots: None,
     }
   }
 
@@ -1259,6 +1260,7 @@ mod tests {
     let request = SubscribeDeshredRequest {
       deshred_transactions,
       ping: None,
+      slots: HashMap::new(),
     };
 
     stream
@@ -1291,6 +1293,7 @@ mod tests {
     let request = JsSubscribeDeshredRequest {
       deshred_transactions,
       ping: Some(JsSubscribeRequestPing { id: 99 }),
+      slots: None,
     };
 
     stream
@@ -1398,6 +1401,7 @@ mod tests {
         SubscribeDeshredRequest {
           deshred_transactions: HashMap::new(),
           ping: None,
+          slots: HashMap::new(),
         }
         .encode_to_vec(),
       ))

--- a/yellowstone-grpc-client-nodejs/napi/tests/js_types_tests.rs
+++ b/yellowstone-grpc-client-nodejs/napi/tests/js_types_tests.rs
@@ -532,6 +532,7 @@ fn js_subscribe_deshred_request_conversion_preserves_vote_false_and_ping() {
   let js_subscribe_deshred_request_value = JsSubscribeDeshredRequest {
     deshred_transactions,
     ping: Some(JsSubscribeRequestPing { id: 17 }),
+    slots: None,
   };
 
   let protobuf_subscribe_deshred_request_value = js_subscribe_deshred_request_value
@@ -563,6 +564,7 @@ fn js_subscribe_update_deshred_update_oneof_accepts_deshred_transaction_variant(
       }),
       ping: None,
       pong: None,
+      slot: None,
     };
 
   let protobuf_update_oneof_value = js_update_oneof_value.from_js_to_protobuf_type().unwrap();
@@ -582,6 +584,7 @@ fn js_subscribe_update_deshred_update_oneof_rejects_multiple_variants() {
       }),
       ping: Some(JsSubscribeUpdatePing {}),
       pong: None,
+      slot: None,
     };
 
   let conversion_error = js_update_oneof_value
@@ -593,6 +596,28 @@ fn js_subscribe_update_deshred_update_oneof_rejects_multiple_variants() {
     conversion_error.cause.is_some(),
     "expected cause on oneof validation error"
   );
+}
+
+#[test]
+fn js_subscribe_update_deshred_update_oneof_accepts_slot_variant() {
+  let js_update_oneof_value: JsSubscribeUpdateDeshredUpdateOneof<'static> =
+    JsSubscribeUpdateDeshredUpdateOneof {
+      deshred_transaction: None,
+      ping: None,
+      pong: None,
+      slot: Some(JsSubscribeUpdateSlot {
+        slot: "42".to_string(),
+        parent: Some("41".to_string()),
+        status: 0,
+        dead_error: None,
+      }),
+    };
+
+  let protobuf_update_oneof_value = js_update_oneof_value.from_js_to_protobuf_type().unwrap();
+  assert!(matches!(
+    protobuf_update_oneof_value,
+    subscribe_update_deshred::UpdateOneof::Slot(value) if value.slot == 42
+  ));
 }
 
 #[test]

--- a/yellowstone-grpc-client-nodejs/package-lock.json
+++ b/yellowstone-grpc-client-nodejs/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3883,7 +3882,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4570,7 +4568,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5243,7 +5240,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6400,7 +6396,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8860,7 +8855,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/yellowstone-grpc-client-nodejs/src/index.ts
+++ b/yellowstone-grpc-client-nodejs/src/index.ts
@@ -120,6 +120,7 @@ function fromJsSubscribeUpdateDeshred(
     deshredTransaction: oneof.deshredTransaction as any,
     ping: oneof.ping as any,
     pong: oneof.pong as any,
+    slot: oneof.slot as any,
   } as SubscribeUpdateDeshred;
 }
 

--- a/yellowstone-grpc-client-nodejs/src/index.ts
+++ b/yellowstone-grpc-client-nodejs/src/index.ts
@@ -124,7 +124,14 @@ function fromJsSubscribeUpdateDeshred(
   } as SubscribeUpdateDeshred;
 }
 
-function parseOptionalBool(value: unknown, fieldName: string): boolean | undefined {
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStrictOptionalBool(
+  value: unknown,
+  fieldName: string,
+): boolean | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -133,40 +140,49 @@ function parseOptionalBool(value: unknown, fieldName: string): boolean | undefin
     return value;
   }
 
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true") {
-      return true;
-    }
-    if (normalized === "false") {
-      return false;
-    }
-  }
-
   throw new Error(
-    `Invalid ${fieldName}: expected true/false, got ${JSON.stringify(value)}`,
+    `Invalid ${fieldName}: expected true/false boolean, got ${JSON.stringify(value)}`,
   );
 }
 
 function normalizeSubscribeDeshredRequest(
   request: SubscribeDeshredRequest,
 ): SubscribeDeshredRequest {
-  const normalizedEntries = Object.fromEntries(
-    Object.entries(request.deshredTransactions ?? {}).map(([name, filter]) => [
-      name,
-      {
-        ...filter,
-        vote: parseOptionalBool(
-          (filter as { vote?: unknown }).vote,
-          `deshredTransactions.${name}.vote`,
-        ),
-      },
-    ]),
-  );
+  if (!isRecordObject(request)) {
+    throw new Error("Invalid subscribeDeshred request: expected object");
+  }
+
+  const deshredTransactions = (
+    request as { deshredTransactions?: unknown }
+  ).deshredTransactions;
+  if (!isRecordObject(deshredTransactions)) {
+    throw new Error("Invalid deshredTransactions: expected object");
+  }
+
+  const slots = (request as { slots?: unknown }).slots;
+  if (!isRecordObject(slots)) {
+    throw new Error("Invalid slots: expected object");
+  }
+
+  const normalizedEntries: SubscribeDeshredRequest["deshredTransactions"] = {};
+  for (const [name, filter] of Object.entries(deshredTransactions)) {
+    if (!isRecordObject(filter)) {
+      throw new Error(`Invalid deshredTransactions.${name}: expected object`);
+    }
+
+    normalizedEntries[name] = {
+      ...(filter as unknown as SubscribeDeshredRequest["deshredTransactions"][string]),
+      vote: parseStrictOptionalBool(
+        (filter as { vote?: unknown }).vote,
+        `deshredTransactions.${name}.vote`,
+      ),
+    };
+  }
 
   return {
     ...request,
     deshredTransactions: normalizedEntries,
+    slots: slots as SubscribeDeshredRequest["slots"],
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `slot` variant to deshred update oneof in NAPI bindings
- Add `slots` filter to deshred request
- Add completed data set shred index fields to deshred transaction info
- Depends on proto 12.2.0 (#726)