### PR TITLE
feat: migrate Rust release to goreleaser Gen 2 via Binaries-ci

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -1,0 +1,32 @@
+---
+name: GoReleaser config check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths:
+      - .goreleaser.yaml
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          install-only: true
+
+      - name: goreleaser check
+        run: goreleaser check

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,88 @@
+# .goreleaser.yaml for rpcpool/yellowstone-grpc
+#
+# This file must be committed to the root of the yellowstone-grpc source repo.
+# GCS upload, cosign signing, Slack announcements, and release settings are
+# injected via ci/goreleaser-patch.yaml in Binaries-ci at build time.
+#
+# Breaking change: dual-OS matrix (-release22 / -release24 suffixed artifacts)
+# is dropped. A single ubuntu-22.04 build produces one artifact per binary.
+# Consumers pinned to *-release22 or *-release24 artifact names must update
+# their references before cutover.
+#
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+before:
+    hooks:
+        # Produce a release metadata file consumed by downstream tooling (nomad, terraform).
+        - >-
+            bash -c 'printf "channel: %s\ncommit: %s\ntarget: x86_64-unknown-linux-gnu\n" "$(git describe --tags --exact-match 2>/dev/null || echo "")" "$(git rev-parse HEAD)" > yellowstone-grpc-geyser-release-x86_64-unknown-linux-gnu.yml'
+
+builds:
+    - id: geyser
+      builder: rust
+      binary: libyellowstone_grpc_geyser.so
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=yellowstone-grpc-geyser
+
+    - id: client
+      builder: rust
+      binary: client
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=yellowstone-grpc-client-simple
+          - --bin=client
+      hooks:
+          post:
+              - cmd: strip {{ .Path }}
+
+    - id: config-check
+      builder: rust
+      binary: config-check
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=yellowstone-grpc-geyser
+          - --bin=config-check
+      hooks:
+          post:
+              - cmd: strip {{ .Path }}
+
+archives:
+    - id: geyser
+      ids: [geyser]
+      formats: [binary]
+      name_template: libyellowstone_grpc_geyser.so
+
+    - id: client
+      formats: [binary]
+      ids: [client]
+      name_template: client-linux-amd64
+
+    - id: config-check
+      formats: [binary]
+      ids: [config-check]
+      name_template: config-check-linux-amd64
+
+release:
+    github:
+        owner: rpcpool
+        name: yellowstone-grpc
+    #disable: '{{ .Prerelease != "" }}'
+    draft: true # publish as draft release to begin with
+    header: |
+        rust {{ .Env.RUST_VERSION }}
+    extra_files:
+        - glob: yellowstone-grpc-geyser-release-x86_64-unknown-linux-gnu.yml
+        - glob: yellowstone-grpc-proto/proto/*.proto
+
+changelog:
+    sort: asc
+    use: github


### PR DESCRIPTION
## Summary

- Adds `.goreleaser.yaml` for the Rust release pipelin
- Removes `release.yml` (Gen 1 dual-OS matrix using `ci/env.sh` + `ci/create-tarball.sh`)
- Releases are now triggered manually via `workflow_dispatch` on CI repo

## Breaking changes

The `-release22` / `-release24` artifact suffix naming is dropped. A single `ubuntu-22.04` build produces one artifact per binary:

| Old | New |
|---|---|
| `client-ubuntu-22.04`, `client-ubuntu-24.04` | `client-linux-amd64` |
| `config-check-ubuntu-22.04`, `config-check-ubuntu-24.04` | `config-check-linux-amd64` |
| `yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2` | `yellowstone-grpc-geyser-release-x86_64-unknown-linux-gnu.tar.bz2` |

GCS path changes from `yellowstone-grpc/<branch>/` → `yellowstone-grpc/v<semver>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)