### PR TITLE
core affinity on mac noop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -78,6 +78,10 @@ prost_011 = { workspace = true, optional = true }
 # Yellowstone
 yellowstone-grpc-proto = { workspace = true, features = ["tonic", "account-data-as-bytes"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+# wrapped in mod cpu_core_affinity
+affinity = { workspace = true }
+
 [[bench]]
 name = "encode"
 harness = false
@@ -85,9 +89,6 @@ required-features = ["bench"]
 
 [features]
 bench = ["dep:prost_011", "dep:solana-storage-proto"]
-
-[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
-affinity = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib", "rlib"]
 name = "config-check"
 
 [dependencies]
-affinity = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -86,6 +85,9 @@ required-features = ["bench"]
 
 [features]
 bench = ["dep:prost_011", "dep:solana-storage-proto"]
+
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+affinity = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -124,7 +124,7 @@ fn parse_taskset(taskset: &str) -> Result<Vec<usize>, String> {
     vec.sort();
 
     if let Some(set_max_index) = vec.last().copied() {
-        let max_index = affinity::get_thread_affinity()
+        let max_index = crate::util::cpu_core_affinity::get_thread_affinity()
             .map_err(|_err| "failed to get affinity".to_owned())?
             .into_iter()
             .max()

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -98,7 +98,8 @@ impl GeyserPlugin for Plugin {
         }
         if let Some(tokio_cpus) = config.tokio.affinity.clone() {
             builder.on_thread_start(move || {
-                affinity::set_thread_affinity(&tokio_cpus).expect("failed to set affinity")
+                crate::util::cpu_core_affinity::set_thread_affinity(&tokio_cpus)
+                    .expect("failed to set affinity")
             });
         }
         let plugin_cancellation_token = CancellationToken::new();

--- a/yellowstone-grpc-geyser/src/util/cpu_core_affinity.rs
+++ b/yellowstone-grpc-geyser/src/util/cpu_core_affinity.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_const_for_fn)]
+
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 pub fn set_thread_affinity(cpus: &[usize]) -> Result<(), String> {
     affinity::set_thread_affinity(cpus).map_err(|e| e.to_string())

--- a/yellowstone-grpc-geyser/src/util/cpu_core_affinity.rs
+++ b/yellowstone-grpc-geyser/src/util/cpu_core_affinity.rs
@@ -13,6 +13,12 @@ pub fn get_thread_affinity() -> Result<Vec<usize>, String> {
     affinity::get_thread_affinity().map_err(|e| e.to_string())
 }
 
+/// Return sensible values though these IDs are not really useful as the set_thread_affinity() method is a no-op.
+///
+/// Returns all CPU indices as available cores. Uses `std::thread::available_parallelism`
+/// which accounts for cgroup/sched_affinity restrictions on Linux but on macOS simply
+/// returns the number of logical CPUs (hw.logicalcpu) without actual affinity support.
+/// See https://doc.rust-lang.org/std/thread/fn.available_parallelism.html
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 pub fn get_thread_affinity() -> Result<Vec<usize>, String> {
     let num_cpus = std::thread::available_parallelism()

--- a/yellowstone-grpc-geyser/src/util/cpu_core_affinity.rs
+++ b/yellowstone-grpc-geyser/src/util/cpu_core_affinity.rs
@@ -1,0 +1,22 @@
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub fn set_thread_affinity(cpus: &[usize]) -> Result<(), String> {
+    affinity::set_thread_affinity(cpus).map_err(|e| e.to_string())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub fn set_thread_affinity(_cpus: &[usize]) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub fn get_thread_affinity() -> Result<Vec<usize>, String> {
+    affinity::get_thread_affinity().map_err(|e| e.to_string())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub fn get_thread_affinity() -> Result<Vec<usize>, String> {
+    let num_cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    Ok((0..num_cpus).collect())
+}

--- a/yellowstone-grpc-geyser/src/util/mod.rs
+++ b/yellowstone-grpc-geyser/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod stream;
 #[cfg(test)]
 pub(crate) mod testkit;
+pub mod cpu_core_affinity;

--- a/yellowstone-grpc-geyser/src/util/mod.rs
+++ b/yellowstone-grpc-geyser/src/util/mod.rs
@@ -1,4 +1,4 @@
+pub mod cpu_core_affinity;
 pub mod stream;
 #[cfg(test)]
 pub(crate) mod testkit;
-pub mod cpu_core_affinity;


### PR DESCRIPTION
Project does not compile on MacOS because the crate `affinity` uses for core pinning does not support MacOS.

### Solution
Implement no-op for MacOS and delegate to crate `affinity` for linux+windows.

picking up this https://github.com/rpcpool/yellowstone-grpc/pull/643