### PR TITLE
str-452: added `uri_path` to dimension to `yellowstone_grpc_service_outbound_bytes` metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,9 +2484,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/deny.toml
+++ b/deny.toml
@@ -18,8 +18,4 @@ ignore = [
     # time 0.3.45 — fix (>=0.3.47) requires Rust 1.88.0, we are on 1.86.0
     # Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0009
     "RUSTSEC-2026-0009",
-
-    # rand 0.8.5 — fix (>=0.9.3) not available, pinned by solana ecosystem
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0097
-    "RUSTSEC-2026-0097",
 ]

--- a/yellowstone-grpc-client/src/test_tools.rs
+++ b/yellowstone-grpc-client/src/test_tools.rs
@@ -43,9 +43,7 @@ where
         if let Some(stream) = &mut this.inner {
             return stream.poll_next_unpin(cx);
         }
-        {
-            return Poll::Ready(None);
-        }
+        Poll::Ready(None)
     }
 }
 
@@ -66,7 +64,7 @@ pub struct UnstableConnector {
 }
 
 impl UnstableConnector {
-    pub fn new(inner: TonicGrpcConnector, drop_interval: Duration) -> Self {
+    pub const fn new(inner: TonicGrpcConnector, drop_interval: Duration) -> Self {
         Self {
             inner,
             drop_interval,

--- a/yellowstone-grpc-geyser/src/metered.rs
+++ b/yellowstone-grpc-geyser/src/metered.rs
@@ -20,30 +20,34 @@ pub const X_SUBSCRIPTION_ID_HEADER: &str = "x-subscription-id";
 pub const UNKNOWN_SUBSCRIBER_ID: &str = "unknown";
 
 static ACTIVE_METERED_BODIES_PER_SUBSCRIBER_ID: LazyLock<
-    Mutex<HashMap<String /* subscriber_id */, u64 /* cumulative bytes */>>,
+    Mutex<HashMap<(String /* subscriber_id */, String /* uri_path */), u64 /* active bodies */>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
 
-fn increment_active_metered_bodies_for_subscriber_id(subscriber_id: &str) {
+fn increment_active_metered_bodies_for_subscriber_and_path(subscriber_id: &str, uri_path: &str) {
     let mut active_by_subscriber = ACTIVE_METERED_BODIES_PER_SUBSCRIBER_ID
         .lock()
         .expect("ACTIVE_METERED_BODIES_PER_SUBSCRIBER_ID mutex poisoned");
     active_by_subscriber
-        .entry(subscriber_id.to_owned())
+        .entry((subscriber_id.to_owned(), uri_path.to_owned()))
         .and_modify(|count| *count += 1)
         .or_insert(1);
 }
 
-fn decrement_active_metered_bodies_for_subscriber_id(subscriber_id: &str) -> bool {
+fn decrement_active_metered_bodies_for_subscriber_and_path(
+    subscriber_id: &str,
+    uri_path: &str,
+) -> bool {
     let mut active_by_subscriber = ACTIVE_METERED_BODIES_PER_SUBSCRIBER_ID
         .lock()
         .expect("ACTIVE_METERED_BODIES_PER_SUBSCRIBER_ID mutex poisoned");
-    if let Some(count) = active_by_subscriber.get_mut(subscriber_id) {
+    let key = (subscriber_id.to_owned(), uri_path.to_owned());
+    if let Some(count) = active_by_subscriber.get_mut(&key) {
         if *count > 1 {
             *count -= 1;
             false
         } else {
-            active_by_subscriber.remove(subscriber_id);
-            metrics::reset_grpc_service_outbound_bytes(subscriber_id);
+            active_by_subscriber.remove(&key);
+            metrics::reset_grpc_service_outbound_bytes(subscriber_id, uri_path);
             true
         }
     } else {
@@ -83,6 +87,7 @@ pub struct MeteredService<S> {
 pub struct MeteredFuture<F, B, E> {
     #[pin]
     future: F,
+    uri_path: String,
     subscriber_id: String,
     _marker: std::marker::PhantomData<(B, E)>,
 }
@@ -95,13 +100,14 @@ pub struct MeteredBody<B> {
     #[pin]
     inner: B,
     subscriber_id: String,
+    uri_path: String,
 }
 
 #[pinned_drop]
 impl<B> PinnedDrop for MeteredBody<B> {
     fn drop(self: Pin<&mut Self>) {
         let this = self.project();
-        decrement_active_metered_bodies_for_subscriber_id(this.subscriber_id);
+        decrement_active_metered_bodies_for_subscriber_and_path(this.subscriber_id, this.uri_path);
     }
 }
 
@@ -122,6 +128,7 @@ where
                 if let Some(data) = frame.data_ref() {
                     metrics::add_grpc_service_outbound_bytes(
                         this.subscriber_id,
+                        this.uri_path,
                         data.remaining() as u64,
                     );
                 }
@@ -153,13 +160,15 @@ where
         let this = self.as_mut().project();
         let result = ready!(this.future.poll(cx));
         let subscriber_id = this.subscriber_id.clone();
+        let uri_path = this.uri_path.clone();
         match result {
             Ok(response) => {
                 let (parts, body) = response.into_parts();
-                increment_active_metered_bodies_for_subscriber_id(&subscriber_id);
+                increment_active_metered_bodies_for_subscriber_and_path(&subscriber_id, &uri_path);
                 let metered_body = MeteredBody {
                     inner: body,
                     subscriber_id,
+                    uri_path,
                 };
                 Poll::Ready(Ok(Response::from_parts(parts, metered_body)))
             }
@@ -190,10 +199,12 @@ where
             .and_then(|value| value.to_str().ok())
             .unwrap_or(UNKNOWN_SUBSCRIBER_ID)
             .to_owned();
+        let uri_path = request.uri().path().to_string();
         let future = self.inner.call(request);
         MeteredFuture {
             future,
             subscriber_id,
+            uri_path,
             _marker: std::marker::PhantomData,
         }
     }
@@ -247,13 +258,21 @@ mod tests {
         let _ = metrics::PrometheusService::spawn(None, None, token, tracker).await;
     }
 
-    fn outbound_bytes_for_subscriber_id(subscriber_id: &str) -> u64 {
+    fn outbound_bytes_for_subscriber_id_and_path(subscriber_id: &str, uri_path: &str) -> u64 {
         for metric_family in metrics::REGISTRY.gather() {
             if metric_family.name() == "yellowstone_grpc_service_outbound_bytes" {
                 for metric in metric_family.get_metric() {
-                    let matched = metric.get_label().iter().any(|label| {
-                        label.name() == "subscriber_id" && label.value() == subscriber_id
-                    });
+                    let mut has_subscriber_id = false;
+                    let mut has_uri_path = false;
+                    for label in metric.get_label() {
+                        if label.name() == "subscriber_id" && label.value() == subscriber_id {
+                            has_subscriber_id = true;
+                        }
+                        if label.name() == "uri_path" && label.value() == uri_path {
+                            has_uri_path = true;
+                        }
+                    }
+                    let matched = has_subscriber_id && has_uri_path;
                     if matched {
                         return metric.get_gauge().value() as u64;
                     }
@@ -291,9 +310,15 @@ mod tests {
             frame.expect("frame");
         }
 
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-1"), 8);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-1", "/geyser.Geyser/Subscribe"),
+            8
+        );
         drop(response);
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-1"), 0);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-1", "/geyser.Geyser/Subscribe"),
+            0
+        );
     }
 
     #[tokio::test]
@@ -317,9 +342,15 @@ mod tests {
             frame.expect("frame");
         }
 
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-2"), 2);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-2", "/foo.Bar/Baz"),
+            2
+        );
         drop(response);
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-2"), 0);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-2", "/foo.Bar/Baz"),
+            0
+        );
     }
 
     #[tokio::test]
@@ -346,10 +377,16 @@ mod tests {
             .expect("expected first frame")
             .expect("frame");
         assert!(first_frame.is_data());
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-drop"), 3);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-drop", "/geyser.Geyser/Subscribe"),
+            3
+        );
 
         drop(response);
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-drop"), 0);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-drop", "/geyser.Geyser/Subscribe"),
+            0
+        );
     }
 
     #[tokio::test]
@@ -383,12 +420,21 @@ mod tests {
             .expect("expected first frame")
             .expect("frame");
         assert!(first_frame.is_data());
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-shared"), 3);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-shared", "/geyser.Geyser/Subscribe"),
+            3
+        );
 
         drop(response1);
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-shared"), 3);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-shared", "/geyser.Geyser/Subscribe"),
+            3
+        );
 
         drop(response2);
-        assert_eq!(outbound_bytes_for_subscriber_id("sub-shared"), 0);
+        assert_eq!(
+            outbound_bytes_for_subscriber_id_and_path("sub-shared", "/geyser.Geyser/Subscribe"),
+            0
+        );
     }
 }

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -171,7 +171,7 @@ lazy_static::lazy_static! {
 
     static ref GRPC_SERVICE_OUTBOUND_BYTES: IntGaugeVec = IntGaugeVec::new(
         Opts::new("yellowstone_grpc_service_outbound_bytes", "Current emitted bytes by tonic service response bodies per active subscriber stream"),
-        &["subscriber_id"]
+        &["subscriber_id", "uri_path"]
     ).unwrap();
 
 
@@ -581,15 +581,22 @@ pub fn incr_grpc_method_call_count<S: AsRef<str>>(method: S) {
         .inc();
 }
 
-pub fn add_grpc_service_outbound_bytes<S: AsRef<str>>(subscriber_id: S, bytes: u64) {
+pub fn add_grpc_service_outbound_bytes<S: AsRef<str>, P: AsRef<str>>(
+    subscriber_id: S,
+    uri_path: P,
+    bytes: u64,
+) {
     GRPC_SERVICE_OUTBOUND_BYTES
-        .with_label_values(&[subscriber_id.as_ref()])
+        .with_label_values(&[subscriber_id.as_ref(), uri_path.as_ref()])
         .add(bytes as i64);
 }
 
-pub fn reset_grpc_service_outbound_bytes<S: AsRef<str>>(subscriber_id: S) {
+pub fn reset_grpc_service_outbound_bytes<S: AsRef<str>, P: AsRef<str>>(
+    subscriber_id: S,
+    uri_path: P,
+) {
     GRPC_SERVICE_OUTBOUND_BYTES
-        .with_label_values(&[subscriber_id.as_ref()])
+        .with_label_values(&[subscriber_id.as_ref(), uri_path.as_ref()])
         .set(0);
 }
 


### PR DESCRIPTION
In order to improve observability, I added `uri_path` dimension to the `yellowstone_grpc_service_outbound_bytes` prometheus metric.

Prior to this change, it was impossible to see where the bandwidth consumption came from for a given customer.
