### PR TITLE
Gate UnixStream behind #[cfg(unix)] for Windows compatibility

### DIFF
--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -14,11 +14,9 @@ use {
         stream::Stream,
     },
     std::{
-        path::PathBuf,
         sync::{Arc, Mutex},
         time::Duration,
     },
-    tokio::net::UnixStream,
     tonic::{
         codec::{CompressionEncoding, Streaming},
         metadata::{errors::InvalidMetadataValue, AsciiMetadataValue, MetadataValue},
@@ -39,6 +37,9 @@ use {
         SubscribeRequest, SubscribeUpdate, SubscribeUpdateDeshred,
     },
 };
+#[cfg(unix)]
+use {std::path::PathBuf, tokio::net::UnixStream};
+
 pub use {
     crate::{
         dedup::{DedupState, DedupStream},
@@ -649,6 +650,9 @@ impl GeyserGrpcBuilder {
     /// The `path` is the filesystem path to the socket (e.g. "/tmp/yellowstone.sock").
     /// tonic requires a dummy HTTP URI for the channel, but the actual transport
     /// goes through the UDS connector.
+    ///
+    /// Unix-only. Tokio's `UnixStream` is not available on `cfg(windows)`.
+    #[cfg(unix)]
     pub async fn connect_uds(
         self,
         path: impl Into<PathBuf>,


### PR DESCRIPTION
## Problem

`yellowstone-grpc-client` fails to compile on Windows targets because
`tokio::net::UnixStream` is not available on `cfg(windows)` — the type
lives at `tokio::net::windows::named_pipe::*` on Windows. The current
unconditional import in `yellowstone-grpc-client/src/lib.rs`:

```rust
tokio::net::UnixStream,
```

…blows up with `unresolved import` when building any downstream crate
that targets `x86_64-pc-windows-msvc`/`gnu`.

## Fix

Gate the platform-specific bits behind `#[cfg(unix)]`:

- The `tokio::net::UnixStream` import.
- The `std::path::PathBuf` import (only used by `connect_uds`).
- The `connect_uds(...)` method on the builder.

This leaves the TCP/TLS connect paths (`.connect()`, `.connect_lazy()`,
etc.) untouched on every target, and `connect_uds()` continues to work
on Linux/macOS as before. The change is purely additive gating — no
behavior change on `cfg(unix)`.

## Verification

- `cargo check -p yellowstone-grpc-client` passes on Linux (Rust
  1.93.1, tonic 0.14.3) against this branch.
- Windows compilation verified by inspection: `UnixStream` is the only
  non-portable item touched, gating it behind `#[cfg(unix)]` is sound.
  The PR author does not have a Windows host to run `cargo check
  --target x86_64-pc-windows-msvc` end-to-end against this fork.

## Motivation

I'm building a cross-platform crate that subscribes to a Yellowstone
gRPC endpoint from both a Linux producer and a Windows consumer. The
consumer only ever uses TCP+TLS, never UDS — but it can't depend on
`yellowstone-grpc-client` at all today because of the unconditional
`UnixStream` import. This PR is the minimal change that unblocks
Windows consumers without changing any Linux behavior.