### PR TITLE
Updating goreleaser to publish as pre release instead of draft

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+---
 # .goreleaser.yaml for rpcpool/yellowstone-grpc
 #
 # This file must be committed to the root of the yellowstone-grpc source repo.
@@ -75,8 +76,8 @@ release:
     github:
         owner: rpcpool
         name: yellowstone-grpc
-    #disable: '{{ .Prerelease != "" }}'
-    draft: true # publish as draft release to begin with
+    # disable: '{{ .Prerelease != "" }}'
+    prerelease: auto # autodetect prerelase with codewords on tag
     header: |
         rust {{ .Env.RUST_VERSION }}
     extra_files:


### PR DESCRIPTION
## Summary   

- Changed `.goreleaser.yaml` release configuration to publish releases as pre-releases instead of drafts    
- Replaced `draft: true` with `prerelease: auto`, which auto-detects pre-release status based on codewords (e.g. `-rc`, `-beta`, `-alpha`) in the tag name    
- Minor: added YAML document start marker (`---`) and fixed comment spacing

## Testing     
- Verified the goreleaser configuration change targets the correct `rpcpool/yellowstone-grpc` GitHub release destination    
- Pre-release detection is driven by tag naming conventions; tags containing pre-release codewords will be marked as pre-releases automatically