### PR TITLE
STR-529: Auto reconnect support in TS SDK

### DIFF
--- a/.github/workflows/napi-integration-tests.yml
+++ b/.github/workflows/napi-integration-tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -115,7 +115,7 @@ jobs:
             binutils
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set rust version (BusyBox compatible)
         run: |
@@ -177,10 +177,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -240,10 +240,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -43,6 +43,68 @@ npm start -- --endpoint http://sg131.rpcpool.wg:10000 \
   --slots
 ```
 
+### subscribe with auto-reconnect
+
+Auto-reconnect is opt-in and applies to standard `subscribe` streams. It reconnects after recoverable stream failures, replays from the last completed slot checkpoint, and deduplicates replayed updates before they reach the TypeScript stream.
+
+```shell
+npm start -- --endpoint https://api.rpcpool.com \
+  --x-token "<token>" \
+  --autoreconnect \
+  subscribe \
+  --slots
+```
+
+Backoff and slot retention can be configured from the example CLI:
+
+```shell
+npm start -- --endpoint https://api.rpcpool.com \
+  --x-token "<token>" \
+  --autoreconnect \
+  --autoreconnect-initial-interval-ms 100 \
+  --autoreconnect-multiplier 2 \
+  --autoreconnect-max-retries 10 \
+  --autoreconnect-slot-retention 250 \
+  subscribe \
+  --slots
+```
+
+The same setup in application code passes reconnect options as the fourth `Client` constructor argument. Passing the request to `subscribe(request)` sends the initial subscription when the stream opens.
+
+```ts
+const client = new Client(
+  "https://api.rpcpool.com",
+  "<token>",
+  { grpcMaxDecodingMessageSize: 64 * 1024 * 1024 },
+  {
+    enabled: true,
+    backoff: {
+      initialIntervalMs: 100,
+      multiplier: 2,
+      maxRetries: 10,
+    },
+    slotRetention: 250,
+  },
+);
+
+await client.connect();
+
+const stream = await client.subscribe({
+  accounts: {},
+  slots: { client: { filterByCommitment: false } },
+  transactions: {},
+  transactionsStatus: {},
+  entry: {},
+  blocks: {},
+  blocksMeta: {},
+  accountsDataSlice: [],
+  commitment: undefined,
+  ping: undefined,
+});
+```
+
+If reconnect options are omitted, the client keeps the original non-reconnecting behavior. `subscribeDeshred` is not covered by auto-reconnect.
+
 ### subscribe to slot updates, commitment processed
 
 ```shell

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../yellowstone-grpc-client-nodejs": {
       "name": "@triton-one/yellowstone-grpc",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "=2.10.2",
@@ -50,10 +50,10 @@
         "node": ">=20.18.0"
       },
       "optionalDependencies": {
-        "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.12",
-        "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.12",
-        "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.12",
-        "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.12"
+        "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.13",
+        "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.13",
+        "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.13",
+        "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.13"
       }
     },
     "node_modules/@triton-one/yellowstone-grpc": {

--- a/examples/typescript/src/client.ts
+++ b/examples/typescript/src/client.ts
@@ -10,17 +10,24 @@ import Client, {
   txEncode,
   txErrDecode,
 } from "@triton-one/yellowstone-grpc";
+import type { ReconnectOptions } from "@triton-one/yellowstone-grpc";
 
 async function main() {
   const args = parseCommandLineArgs();
+  const reconnectOptions = buildReconnectOptions(args);
 
   // Open connection.
-  const client = new Client(args.endpoint, args.xToken, {
-    // "grpc.max_receive_message_length": 64 * 1024 * 1024, // 64MiB
-    grpcMaxDecodingMessageSize: 64 * 1024 * 1024
-  });
+  const client = new Client(
+    args.endpoint,
+    args.xToken,
+    {
+      // "grpc.max_receive_message_length": 64 * 1024 * 1024, // 64MiB
+      grpcMaxDecodingMessageSize: 64 * 1024 * 1024,
+    },
+    reconnectOptions,
+  );
 
-  await client.connect()
+  await client.connect();
 
   const commitment = parseCommitmentLevel(args.commitment);
 
@@ -64,7 +71,7 @@ async function main() {
 
     default:
       console.error(
-        `Unknown command: ${args["_"]}. Use "--help" for a list of supported commands.`
+        `Unknown command: ${args["_"]}. Use "--help" for a list of supported commands.`,
       );
       break;
   }
@@ -79,52 +86,23 @@ function parseCommitmentLevel(commitment: string | undefined) {
   return CommitmentLevel[typedCommitment];
 }
 
-async function subscribeCommand(client: Client, args) {
+function buildReconnectOptions(args): ReconnectOptions | undefined {
+  if (!args.autoreconnect) {
+    return undefined;
+  }
 
-  // Subscribe for events
-  const stream = await client.subscribe();
+  return {
+    enabled: true,
+    backoff: {
+      initialIntervalMs: args.autoreconnectInitialIntervalMs,
+      multiplier: args.autoreconnectMultiplier,
+      maxRetries: args.autoreconnectMaxRetries,
+    },
+    slotRetention: args.autoreconnectSlotRetention,
+  };
+}
 
-  // Create `error` / `end` handler
-  const streamClosed = new Promise<void>((resolve, reject) => {
-    stream.on("error", (error) => {
-      reject(error);
-      stream.end();
-    });
-    stream.on("end", () => {
-      resolve();
-    });
-    stream.on("close", () => {
-      resolve();
-    });
-  });
-
-  // Handle updates
-  stream.on("data", (data) => {
-    if (
-      data.transaction &&
-      (args.transactionsParsed || args.transactionsDecodeErr)
-    ) {
-      const slot = data.transaction.slot;
-      const message = data.transaction.transaction;
-      if (args.transactionsParsed) {
-        const tx = txEncode.encode(message, txEncode.encoding.Json, 255, true);
-        console.log(
-          `TX filters: ${data.filters}, slot#${slot}, tx: ${JSON.stringify(tx)}`
-        );
-      }
-      if (message.meta.err && args.transactionsDecodeErr) {
-        const err = txErrDecode.decode(message.meta.err.err);
-        console.log(
-          `TX filters: ${data.filters}, slot#${slot}, err: ${inspect(err)}}`
-        );
-      }
-      return;
-    }
-
-    console.log("data", data);
-  });
-
-  // Create subscribe request based on provided arguments.
+function buildSubscribeRequest(args): SubscribeRequest {
   const request: SubscribeRequest = {
     accounts: {},
     slots: {},
@@ -269,19 +247,74 @@ async function subscribeCommand(client: Client, args) {
     request.ping = { id: args.ping };
   }
 
-  // Send subscribe request
-  await new Promise<void>((resolve, reject) => {
-    stream.write(request, (err) => {
-      if (err === null || err === undefined) {
-        resolve();
-      } else {
-        reject(err);
-      }
+  return request;
+}
+
+async function subscribeCommand(client: Client, args) {
+  // Create subscribe request based on provided arguments.
+  const request = buildSubscribeRequest(args);
+
+  // Subscribe for events. When auto-reconnect is enabled, pass the initial
+  // request at stream creation so reconnects can resume that subscription.
+  const stream = args.autoreconnect
+    ? await client.subscribe(request)
+    : await client.subscribe();
+
+  // Create `error` / `end` handler
+  const streamClosed = new Promise<void>((resolve, reject) => {
+    stream.on("error", (error) => {
+      reject(error);
+      stream.end();
     });
-  }).catch((reason) => {
-    console.error(reason);
-    throw reason;
+    stream.on("end", () => {
+      resolve();
+    });
+    stream.on("close", () => {
+      resolve();
+    });
   });
+
+  // Handle updates
+  stream.on("data", (data) => {
+    if (
+      data.transaction &&
+      (args.transactionsParsed || args.transactionsDecodeErr)
+    ) {
+      const slot = data.transaction.slot;
+      const message = data.transaction.transaction;
+      if (args.transactionsParsed) {
+        const tx = txEncode.encode(message, txEncode.encoding.Json, 255, true);
+        console.log(
+          `TX filters: ${data.filters}, slot#${slot}, tx: ${JSON.stringify(tx)}`,
+        );
+      }
+      if (message.meta.err && args.transactionsDecodeErr) {
+        const err = txErrDecode.decode(message.meta.err.err);
+        console.log(
+          `TX filters: ${data.filters}, slot#${slot}, err: ${inspect(err)}}`,
+        );
+      }
+      return;
+    }
+
+    console.log("data", data);
+  });
+
+  // Send subscribe request
+  if (!args.autoreconnect) {
+    await new Promise<void>((resolve, reject) => {
+      stream.write(request, (err) => {
+        if (err === null || err === undefined) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+    }).catch((reason) => {
+      console.error(reason);
+      throw reason;
+    });
+  }
 
   await streamClosed;
 }
@@ -317,12 +350,12 @@ async function subscribeDeshredCommand(client: Client, args) {
           txDeshredEncode.encoding.JsonParsed,
         );
         console.log(
-          `DESHRED filters: ${data.filters}, slot#${data.deshredTransaction.slot}, tx: ${JSON.stringify(tx)}`
+          `DESHRED filters: ${data.filters}, slot#${data.deshredTransaction.slot}, tx: ${JSON.stringify(tx)}`,
         );
       } catch (error) {
         console.error(
           `failed to parse deshred tx (slot#${data.deshredTransaction.slot})`,
-          error
+          error,
         );
       }
       return;
@@ -330,7 +363,7 @@ async function subscribeDeshredCommand(client: Client, args) {
 
     console.log("data", data);
   });
-  
+
   const request: SubscribeDeshredRequest = {
     deshredTransactions: {
       client: {
@@ -377,6 +410,31 @@ function parseCommandLineArgs() {
         describe: "commitment level",
         choices: ["processed", "confirmed", "finalized"],
       },
+      autoreconnect: {
+        default: false,
+        describe: "enable auto-reconnect for standard subscribe streams",
+        type: "boolean",
+      },
+      "autoreconnect-initial-interval-ms": {
+        default: 10,
+        describe: "auto-reconnect first retry delay in milliseconds",
+        type: "number",
+      },
+      "autoreconnect-multiplier": {
+        default: 2,
+        describe: "auto-reconnect exponential backoff multiplier",
+        type: "number",
+      },
+      "autoreconnect-max-retries": {
+        default: 3,
+        describe: "auto-reconnect retry count per reconnect attempt",
+        type: "number",
+      },
+      "autoreconnect-slot-retention": {
+        default: 250,
+        describe: "slots retained for auto-reconnect deduplication",
+        type: "number",
+      },
     })
     .command("subscribe-replay-info", "get subscribe replay info")
     .command("ping", "single ping of the RPC server")
@@ -394,7 +452,7 @@ function parseCommandLineArgs() {
             demandOption: true,
           },
         });
-      }
+      },
     )
     .command("subscribe", "subscribe to events", (yargs) => {
       return yargs.options({
@@ -571,42 +629,46 @@ function parseCommandLineArgs() {
         },
       });
     })
-    .command("subscribeDeshred", "subscribe to deshred transactions", (yargs) => {
-      return yargs.options({
-        "deshred-parsed": {
-          default: false,
-          describe: "parse deshred transactions using txDeshredEncode",
-          type: "boolean",
-        },
-        "deshred-vote": {
-          description: "filter vote transactions",
-          type: "boolean",
-        },
-        "deshred-account-include": {
-          default: [],
-          description:
-            "filter included accounts in deshred transactions (static + ALT)",
-          type: "array",
-        },
-        "deshred-account-exclude": {
-          default: [],
-          description:
-            "filter excluded accounts in deshred transactions (static + ALT)",
-          type: "array",
-        },
-        "deshred-account-required": {
-          default: [],
-          description:
-            "filter required accounts in deshred transactions (static + ALT)",
-          type: "array",
-        },
-        ping: {
-          default: undefined,
-          description: "send ping request in subscribeDeshred",
-          type: "number",
-        },
-      });
-    })
+    .command(
+      "subscribeDeshred",
+      "subscribe to deshred transactions",
+      (yargs) => {
+        return yargs.options({
+          "deshred-parsed": {
+            default: false,
+            describe: "parse deshred transactions using txDeshredEncode",
+            type: "boolean",
+          },
+          "deshred-vote": {
+            description: "filter vote transactions",
+            type: "boolean",
+          },
+          "deshred-account-include": {
+            default: [],
+            description:
+              "filter included accounts in deshred transactions (static + ALT)",
+            type: "array",
+          },
+          "deshred-account-exclude": {
+            default: [],
+            description:
+              "filter excluded accounts in deshred transactions (static + ALT)",
+            type: "array",
+          },
+          "deshred-account-required": {
+            default: [],
+            description:
+              "filter required accounts in deshred transactions (static + ALT)",
+            type: "array",
+          },
+          ping: {
+            default: undefined,
+            description: "send ping request in subscribeDeshred",
+            type: "number",
+          },
+        });
+      },
+    )
     .demandCommand(1)
     .help().argv;
 }

--- a/yellowstone-grpc-client-nodejs/README.md
+++ b/yellowstone-grpc-client-nodejs/README.md
@@ -25,6 +25,29 @@ npm run build
 
 Please refer to [examples/typescript](../examples/typescript/README.md) for some usage examples.
 
+### Auto reconnect
+
+Standard `subscribe` streams can opt into the native Rust client's reconnect,
+backfill, and deduplication layer by passing reconnect options as the fourth
+constructor argument:
+
+```ts
+const client = new Client(endpoint, xToken, channelOptions, {
+  backoff: {
+    initialIntervalMs: 100,
+    multiplier: 2,
+    maxRetries: 10,
+  },
+  slotRetention: 250,
+});
+
+await client.connect();
+const stream = await client.subscribe(request);
+```
+
+Omit the fourth argument, or pass `{ enabled: false }`, to keep the previous
+no-reconnect behavior. Deshred subscriptions are unchanged.
+
 ## Troubleshooting
 
 ### For macOS:

--- a/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
+++ b/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
@@ -3,6 +3,7 @@ import Client, {
   ClientDuplexStream,
   txDeshredEncode,
 } from "../src";
+import * as net from "node:net";
 import {
   GetBlockHeightResponse,
   GetLatestBlockhashResponse,
@@ -69,6 +70,171 @@ function closeStreamAndWait(stream: any, timeoutMs = 2500): Promise<void> {
       stream.destroy();
     } catch {}
   });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type DisconnectableTcpProxy = {
+  endpoint: string;
+  connectionCount: () => number;
+  disconnectFor: (durationMs: number) => Promise<void>;
+  waitForConnectionCountGreaterThan: (
+    previousConnectionCount: number,
+    timeoutMs: number,
+  ) => Promise<void>;
+  close: () => Promise<void>;
+};
+
+async function startDisconnectableTcpProxy(
+  targetEndpoint: string,
+): Promise<DisconnectableTcpProxy | null> {
+  const targetUrl = new URL(targetEndpoint);
+  if (targetUrl.protocol !== "http:") {
+    return null;
+  }
+
+  const activeSockets = new Set<net.Socket>();
+  const connectionWaiters: Array<() => void> = [];
+  const targetHost = targetUrl.hostname;
+  const targetPort = Number(targetUrl.port || "80");
+  let acceptingConnections = true;
+  let proxiedConnectionCount = 0;
+
+  const destroySocket = (socket: net.Socket) => {
+    activeSockets.delete(socket);
+    socket.destroy();
+  };
+
+  const destroyAllSockets = () => {
+    for (const socket of Array.from(activeSockets)) {
+      destroySocket(socket);
+    }
+  };
+
+  const server = net.createServer((clientSocket) => {
+    if (!acceptingConnections) {
+      clientSocket.destroy();
+      return;
+    }
+
+    const upstreamSocket = net.connect({
+      host: targetHost,
+      port: targetPort,
+    });
+
+    activeSockets.add(clientSocket);
+    activeSockets.add(upstreamSocket);
+    proxiedConnectionCount += 1;
+
+    for (const notifyConnection of [...connectionWaiters]) {
+      notifyConnection();
+    }
+
+    const cleanup = () => {
+      destroySocket(clientSocket);
+      destroySocket(upstreamSocket);
+    };
+
+    clientSocket.once("error", cleanup);
+    upstreamSocket.once("error", cleanup);
+    clientSocket.once("close", cleanup);
+    upstreamSocket.once("close", cleanup);
+
+    clientSocket.pipe(upstreamSocket);
+    upstreamSocket.pipe(clientSocket);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, "127.0.0.1");
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("TCP proxy did not bind to an IP address");
+  }
+
+  const proxyUrl = new URL(targetEndpoint);
+  proxyUrl.hostname = "127.0.0.1";
+  proxyUrl.port = String(address.port);
+
+  return {
+    endpoint: proxyUrl.toString(),
+    connectionCount: () => proxiedConnectionCount,
+    disconnectFor: async (durationMs: number) => {
+      acceptingConnections = false;
+      destroyAllSockets();
+      await delay(durationMs);
+      acceptingConnections = true;
+    },
+    waitForConnectionCountGreaterThan: (
+      previousConnectionCount: number,
+      timeoutMs: number,
+    ) =>
+      new Promise<void>((resolve, reject) => {
+        if (proxiedConnectionCount > previousConnectionCount) {
+          resolve();
+          return;
+        }
+
+        let settled = false;
+        const settleOnce = (handler: () => void) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearTimeout(timeoutId);
+          const waiterIndex = connectionWaiters.indexOf(onConnection);
+          if (waiterIndex !== -1) {
+            connectionWaiters.splice(waiterIndex, 1);
+          }
+          handler();
+        };
+        const onConnection = () => {
+          if (proxiedConnectionCount > previousConnectionCount) {
+            settleOnce(resolve);
+          }
+        };
+        const timeoutId = setTimeout(
+          () =>
+            settleOnce(() =>
+              reject(
+                new Error(
+                  `Timed out waiting for reconnect after ${timeoutMs}ms`,
+                ),
+              ),
+            ),
+          timeoutMs,
+        );
+
+        connectionWaiters.push(onConnection);
+      }),
+    close: async () => {
+      acceptingConnections = false;
+      destroyAllSockets();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error?: Error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+  };
 }
 
 function waitForSubscribeUpdateMatchingPredicate(
@@ -142,6 +308,74 @@ function waitForSubscribeUpdateMatchingPredicate(
           `Timed out waiting for expected subscribe update after ${timeoutMs}ms`,
         );
         void closeStreamAndWait(stream).finally(() => reject(error));
+      });
+    }, timeoutMs);
+
+    stream.on("data", onData);
+    stream.on("error", onError);
+    stream.on("end", onEndOrClose);
+    stream.on("close", onEndOrClose);
+  });
+}
+
+function waitForNextSubscribeUpdateMatchingPredicate(
+  stream: any,
+  predicate: (data: any) => boolean,
+  timeoutMs: number,
+  maxUnmatchedUpdates = 500,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let unmatchedUpdates = 0;
+
+    const settleOnce = (handler: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      handler();
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      stream.off("data", onData);
+      stream.off("error", onError);
+      stream.off("end", onEndOrClose);
+      stream.off("close", onEndOrClose);
+    };
+
+    const onData = (data: any) => {
+      if (!predicate(data)) {
+        unmatchedUpdates += 1;
+        if (unmatchedUpdates >= maxUnmatchedUpdates) {
+          settleOnce(() => {
+            reject(
+              new Error(
+                `No matching subscribe update after ${unmatchedUpdates} updates (timeout ${timeoutMs}ms)`,
+              ),
+            );
+          });
+        }
+        return;
+      }
+
+      settleOnce(() => resolve(data));
+    };
+
+    const onError = (error: Error) => settleOnce(() => reject(error));
+    const onEndOrClose = () =>
+      settleOnce(() =>
+        reject(new Error("Stream ended before receiving expected update")),
+      );
+
+    const timeoutId = setTimeout(() => {
+      settleOnce(() => {
+        reject(
+          new Error(
+            `Timed out waiting for expected subscribe update after ${timeoutMs}ms`,
+          ),
+        );
       });
     }, timeoutMs);
 
@@ -1499,6 +1733,107 @@ describe("Client subscription independence behavior", () => {
     expect(nativeStreamA.close).toHaveBeenCalledTimes(1);
     expect(nativeStreamB.close).toHaveBeenCalledTimes(1);
   });
+});
+
+describe("Client auto-reconnect integration", () => {
+  const TEST_TIMEOUT = 100000;
+
+  // .env
+  const { TEST_ENDPOINT: endpoint, TEST_TOKEN: xToken } = process.env;
+
+  test(
+    "slot stream resumes after a transient disconnect",
+    async () => {
+      if (!endpoint) {
+        throw new Error("TEST_ENDPOINT is required");
+      }
+
+      const proxy = await startDisconnectableTcpProxy(endpoint);
+      if (proxy === null) {
+        console.warn(
+          "Skipping auto-reconnect disconnect test: TEST_ENDPOINT must use plaintext http so the test can cut the TCP connection without terminating TLS.",
+        );
+        return;
+      }
+
+      const client = new Client(
+        proxy.endpoint,
+        xToken,
+        {},
+        {
+          enabled: true,
+          backoff: {
+            initialIntervalMs: 10,
+            multiplier: 1,
+            maxRetries: 20,
+          },
+          slotRetention: 250,
+        },
+      );
+      let stream: any | undefined;
+
+      try {
+        await client.connect();
+
+        const request: SubscribeRequest = {
+          ...makeMinimalSubscribeRequest(),
+          slots: {
+            client: {
+              filterByCommitment: true,
+              interslotUpdates: false,
+            },
+          },
+        };
+        stream = await client.subscribe(request);
+        const seenSlotUpdates = new Set<string>();
+        let latestSlotBeforeDisconnect = BigInt(0);
+
+        const slotUpdateKey = (update: any) =>
+          `${update.slot.slot}:${update.slot.status}`;
+
+        for (let i = 0; i < 3; i += 1) {
+          const update = await waitForNextSubscribeUpdateMatchingPredicate(
+            stream,
+            (data) => Boolean(data?.slot),
+            TEST_TIMEOUT,
+          );
+
+          expect(update.filters).toEqual(["client"]);
+          seenSlotUpdates.add(slotUpdateKey(update));
+          const slot = BigInt(update.slot.slot);
+          if (slot > latestSlotBeforeDisconnect) {
+            latestSlotBeforeDisconnect = slot;
+          }
+        }
+
+        const connectionsBeforeDisconnect = proxy.connectionCount();
+        await proxy.disconnectFor(50);
+        await proxy.waitForConnectionCountGreaterThan(
+          connectionsBeforeDisconnect,
+          TEST_TIMEOUT,
+        );
+
+        const updateAfterReconnect =
+          await waitForNextSubscribeUpdateMatchingPredicate(
+            stream,
+            (data) => Boolean(data?.slot),
+            TEST_TIMEOUT,
+          );
+        const updateAfterReconnectKey = slotUpdateKey(updateAfterReconnect);
+        const slotAfterReconnect = BigInt(updateAfterReconnect.slot.slot);
+
+        expect(updateAfterReconnect.filters).toEqual(["client"]);
+        expect(seenSlotUpdates.has(updateAfterReconnectKey)).toBe(false);
+        expect(slotAfterReconnect >= latestSlotBeforeDisconnect).toBe(true);
+      } finally {
+        if (stream !== undefined) {
+          await closeStreamAndWait(stream);
+        }
+        await proxy.close();
+      }
+    },
+    TEST_TIMEOUT,
+  );
 });
 
 // subscribe to both subscribe & subscribeDeshred, do all unary calls, modify subscribe request for both, do unary calls again

--- a/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
+++ b/yellowstone-grpc-client-nodejs/__tests__/subscribe.test.ts
@@ -581,6 +581,25 @@ describe("ClientDuplexStream shutdown behavior", () => {
 });
 
 describe("Client connection guard behavior", () => {
+  test("constructor stores reconnect options for native connect", () => {
+    const reconnectOptions = {
+      backoff: {
+        initialIntervalMs: 100,
+        multiplier: 2,
+        maxRetries: 10,
+      },
+      slotRetention: 250,
+    };
+    const client = new Client(
+      "http://localhost:10000",
+      undefined,
+      {},
+      reconnectOptions,
+    );
+
+    expect((client as any)._reconnectOptions).toBe(reconnectOptions);
+  });
+
   test("all public client methods fail before connect", async () => {
     const client = new Client("http://localhost:10000", undefined, {});
 
@@ -625,6 +644,39 @@ describe("Client connection guard behavior", () => {
     await expect(client.subscribe()).rejects.toThrow(
       "subscribe stream open failed",
     );
+  });
+
+  test("subscribe accepts an optional initial request without mutating it", async () => {
+    const nativeStream = {
+      close: jest.fn(),
+      writeRaw: jest.fn(),
+      read: jest.fn(() => new Promise(() => {})),
+    };
+    const nativeSubscribe = jest.fn().mockResolvedValue(nativeStream);
+    const client = new Client("http://localhost:10000", undefined, {});
+    (client as any)._grpcClient = {
+      subscribe: nativeSubscribe,
+    };
+
+    const request = makeComprehensiveSubscribeRequest();
+    const requestBeforeSubscribe = geyser.SubscribeRequest.decode(
+      geyser.SubscribeRequest.encode(request).finish(),
+    );
+
+    const stream = await client.subscribe(request);
+
+    expect(nativeSubscribe).toHaveBeenCalledTimes(1);
+    const forwardedBytes = nativeSubscribe.mock.calls[0][0] as Uint8Array;
+    const decoded = geyser.SubscribeRequest.decode(forwardedBytes);
+    expect(decoded.fromSlot).toBe("777");
+    expect(decoded.transactions.txClient.signature).toBe("txSig1");
+
+    const requestAfterSubscribe = geyser.SubscribeRequest.decode(
+      geyser.SubscribeRequest.encode(request).finish(),
+    );
+    expect(requestAfterSubscribe).toEqual(requestBeforeSubscribe);
+
+    await closeStreamAndWait(stream);
   });
 
   test("subscribeDeshred bubbles native stream-open errors", async () => {

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.lock
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.lock
@@ -108,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,13 +4258,16 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "13.0.0"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c3e9328306945410423b40714b0fe9bfe361e5eba1da3e0a63288228313bfb"
+checksum = "a66894f04139a5c4a2c1108fed68fc3e7efdf4120464ad86e14013c7e2cbeec5"
 dependencies = [
+ "arc-swap",
  "bytes",
  "futures",
  "hyper-util",
+ "log",
+ "pin-project",
  "thiserror 2.0.18",
  "tokio",
  "tonic",

--- a/yellowstone-grpc-client-nodejs/napi/Cargo.toml
+++ b/yellowstone-grpc-client-nodejs/napi/Cargo.toml
@@ -28,7 +28,7 @@ futures-util = "0.3"
 futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
-yellowstone-grpc-client = "13.0.0"
+yellowstone-grpc-client = "13.1.0"
 yellowstone-grpc-proto = "12.2.0"
 prost = "0.14"
 prost011 = { package = "prost", version = "0.11" }

--- a/yellowstone-grpc-client-nodejs/napi/index.d.ts
+++ b/yellowstone-grpc-client-nodejs/napi/index.d.ts
@@ -60,7 +60,7 @@ export declare class GrpcClient {
    *
    * The connection is persistent and will be reused for all subsequent operations.
    */
-  static new(endpoint: string, xToken?: string | undefined | null, channelOptions?: JsChannelOptions | undefined | null): Promise<GrpcClient>
+  static new(endpoint: string, xToken?: string | undefined | null, channelOptions?: JsChannelOptions | undefined | null, reconnectConfig?: JsReconnectConfig | undefined | null): Promise<GrpcClient>
   getLatestBlockhash(request: JsGetLatestBlockhashRequest): Promise<JsGetLatestBlockhashResponse>
   ping(request: JsPingRequest): Promise<JsPongResponse>
   getBlockHeight(request: JsGetBlockHeightRequest): Promise<JsGetBlockHeightResponse>
@@ -74,7 +74,7 @@ export declare class GrpcClient {
    * The returned value is consumed by the JS SDK `ClientDuplexStream` wrapper,
    * which handles Node stream lifecycle and protobuf-shape normalization.
    */
-  subscribe(): Promise<DuplexStream>
+  subscribe(initialRequestBytes?: Buffer | undefined | null): Promise<DuplexStream>
   /**
    * Creates a deshred subscription stream bound to this client connection.
    *
@@ -84,6 +84,8 @@ export declare class GrpcClient {
    */
   subscribeDeshred(): Promise<DuplexStreamDeshred>
 }
+
+export const AUTORECONNECT_FILTER_KEY: string
 
 export declare function decodeTxError(err: Array<number>): string
 
@@ -237,6 +239,22 @@ export interface JsPingRequest {
 
 export interface JsPongResponse {
   count: number
+}
+
+export interface JsReconnectBackoff {
+  initialIntervalMs?: number
+  multiplier?: number
+  maxRetries?: number
+}
+
+export interface JsReconnectConfig {
+  /**
+   * Omitted or true enables reconnect when this object is provided.
+   * False keeps legacy no-reconnect behavior.
+   */
+  enabled?: boolean
+  backoff?: JsReconnectBackoff
+  slotRetention?: number
 }
 
 export interface JsReturnData {

--- a/yellowstone-grpc-client-nodejs/napi/index.js
+++ b/yellowstone-grpc-client-nodejs/napi/index.js
@@ -579,6 +579,7 @@ module.exports = nativeBinding
 module.exports.DuplexStream = nativeBinding.DuplexStream
 module.exports.DuplexStreamDeshred = nativeBinding.DuplexStreamDeshred
 module.exports.GrpcClient = nativeBinding.GrpcClient
+module.exports.AUTORECONNECT_FILTER_KEY = nativeBinding.AUTORECONNECT_FILTER_KEY
 module.exports.decodeTxError = nativeBinding.decodeTxError
 module.exports.encodeDeshredTx = nativeBinding.encodeDeshredTx
 module.exports.encodeTx = nativeBinding.encodeTx

--- a/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
@@ -47,6 +47,24 @@ pub struct JsChannelOptions {
   pub grpc_tcp_nodelay: Option<bool>,
 }
 
+#[napi(object)]
+#[derive(Deserialize, Debug, Clone)]
+pub struct JsReconnectBackoff {
+  pub initial_interval_ms: Option<u32>,
+  pub multiplier: Option<f64>,
+  pub max_retries: Option<u32>,
+}
+
+#[napi(object)]
+#[derive(Deserialize, Debug, Clone)]
+pub struct JsReconnectConfig {
+  /// Omitted or true enables reconnect when this object is provided.
+  /// False keeps legacy no-reconnect behavior.
+  pub enabled: Option<bool>,
+  pub backoff: Option<JsReconnectBackoff>,
+  pub slot_retention: Option<u32>,
+}
+
 impl Default for JsChannelOptions {
   /// Sets the following configuration to
   /// sensible defaults.

--- a/yellowstone-grpc-client-nodejs/napi/src/client.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/client.rs
@@ -1,13 +1,13 @@
 // GrpcClient: A persistent, reusable gRPC client
 
-use napi::bindgen_prelude::PromiseRaw;
+use napi::bindgen_prelude::{Buffer, PromiseRaw};
 use napi::Env;
 use napi_derive::napi;
 use yellowstone_grpc_client::GeyserGrpcClient;
 use yellowstone_grpc_proto::geyser::CommitmentLevel;
 
 use crate::{
-  bindings::JsChannelOptions,
+  bindings::{JsChannelOptions, JsReconnectConfig},
   init_crypto_provider,
   js_types::{
     JsGetBlockHeightRequest, JsGetBlockHeightResponse, JsGetLatestBlockhashRequest,
@@ -68,11 +68,13 @@ impl GrpcClient {
     endpoint: String,
     x_token: Option<String>,
     channel_options: Option<JsChannelOptions>,
+    reconnect_config: Option<JsReconnectConfig>,
   ) -> napi::Result<Self> {
     init_crypto_provider();
 
     // Build the client with the provided configuration
-    let builder = utils::get_client_builder(endpoint, x_token, channel_options).await?;
+    let builder =
+      utils::get_client_builder(endpoint, x_token, channel_options, reconnect_config).await?;
 
     // Connect and get the client (returns GeyserGrpcClient<impl Interceptor>)
     let client = builder.connect().await.map_err(|error| {
@@ -316,8 +318,9 @@ impl GrpcClient {
   pub fn subscribe<'env>(
     &self,
     env: &'env napi::Env,
+    initial_request_bytes: Option<Buffer>,
   ) -> napi::Result<PromiseRaw<'env, crate::DuplexStream>> {
-    crate::DuplexStream::subscribe(env, self)
+    crate::DuplexStream::subscribe(env, self, initial_request_bytes)
   }
 
   /// Creates a deshred subscription stream bound to this client connection.

--- a/yellowstone-grpc-client-nodejs/napi/src/lib.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/lib.rs
@@ -41,6 +41,9 @@ pub mod js_types;
 
 static INITIALIZE_CRYPTO_PROVIDER: Once = Once::new();
 
+#[napi(js_name = "AUTORECONNECT_FILTER_KEY")]
+pub const AUTORECONNECT_FILTER_KEY: &str = "__autoreconnect";
+
 /// Initialize crypto provider once.
 fn init_crypto_provider() {
   INITIALIZE_CRYPTO_PROVIDER.call_once(|| {
@@ -95,6 +98,14 @@ fn napi_error(status: napi::Status, reason: impl Into<String>) -> napi::Error {
   error
 }
 
+fn strip_autoreconnect_filter(update: &mut SubscribeUpdate) -> bool {
+  let before = update.filters.len();
+  update
+    .filters
+    .retain(|filter| filter != AUTORECONNECT_FILTER_KEY);
+  before != update.filters.len()
+}
+
 /// DuplexStream Engine
 ///
 /// The inner engine for a custom implementation of stream.Duplex
@@ -130,7 +141,24 @@ impl DuplexStream {
   pub fn subscribe<'env>(
     env: &'env Env,
     grpc_client: &GrpcClient,
+    initial_request_bytes: Option<Buffer>,
   ) -> Result<PromiseRaw<'env, Self>> {
+    let initial_request = match initial_request_bytes {
+      Some(request_bytes) => {
+        let request = SubscribeRequest::decode(request_bytes.as_ref()).map_err(|error| {
+          napi_error_with_cause(
+            napi::Status::InvalidArg,
+            "invalid SubscribeRequest payload",
+            &error,
+          )
+        })?;
+        validate_subscribe_request(&request).map_err(|error| {
+          napi_error_with_cause(napi::Status::InvalidArg, error.to_string(), &error)
+        })?;
+        Some(request)
+      }
+      None => None,
+    };
     let mut client = grpc_client.client.clone();
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
@@ -139,13 +167,16 @@ impl DuplexStream {
       async move {
         // Acquire lock, call subscribe, and immediately release the lock.
         let (mut stream_tx, mut stream_rx) = {
-          client.subscribe().await.map_err(|error| {
-            napi_error_with_cause(
-              napi::Status::GenericFailure,
-              "failed to open subscribe stream",
-              &error,
-            )
-          })?
+          client
+            .subscribe_with_request(initial_request)
+            .await
+            .map_err(|error| {
+              napi_error_with_cause(
+                napi::Status::GenericFailure,
+                "failed to open subscribe stream",
+                &error,
+              )
+            })?
         };
 
         // TODO : Fine tune unbounded channels.
@@ -196,7 +227,12 @@ impl DuplexStream {
               // 2. SubscribeUpdate is propagated to self.read() for NodeJS consumption.
               maybe_update_result = stream_rx.next() => {
                 match maybe_update_result {
-                  Some(Ok(update)) => {
+                  Some(Ok(mut update)) => {
+                    let stripped = strip_autoreconnect_filter(&mut update);
+                    if stripped && update.filters.is_empty() {
+                      continue;
+                    }
+
                     // JS reader side disappeared; no point continuing the worker.
                     if readable_tx.send(update).is_err() {
                       break;
@@ -653,7 +689,7 @@ mod tests {
     JsSubscribeDeshredRequest {
       deshred_transactions: HashMap::new(),
       ping: None,
-      slots: None,
+      slots: HashMap::new(),
     }
   }
 
@@ -777,6 +813,44 @@ mod tests {
       cause_message.to_string(),
     ));
     error
+  }
+
+  fn subscribe_update_with_filters(filters: &[&str]) -> SubscribeUpdate {
+    SubscribeUpdate {
+      filters: filters.iter().map(|filter| (*filter).to_string()).collect(),
+      update_oneof: None,
+      created_at: None,
+    }
+  }
+
+  #[test]
+  fn strip_autoreconnect_filter_removes_internal_filter_from_mixed_update() {
+    let mut update = subscribe_update_with_filters(&[crate::AUTORECONNECT_FILTER_KEY, "client"]);
+
+    let stripped = super::strip_autoreconnect_filter(&mut update);
+
+    assert!(stripped);
+    assert_eq!(update.filters, vec!["client".to_string()]);
+  }
+
+  #[test]
+  fn strip_autoreconnect_filter_leaves_internal_only_update_empty() {
+    let mut update = subscribe_update_with_filters(&[crate::AUTORECONNECT_FILTER_KEY]);
+
+    let stripped = super::strip_autoreconnect_filter(&mut update);
+
+    assert!(stripped);
+    assert!(update.filters.is_empty());
+  }
+
+  #[test]
+  fn strip_autoreconnect_filter_does_not_mark_naturally_empty_update_internal() {
+    let mut update = subscribe_update_with_filters(&[]);
+
+    let stripped = super::strip_autoreconnect_filter(&mut update);
+
+    assert!(!stripped);
+    assert!(update.filters.is_empty());
   }
 
   #[tokio::test]
@@ -1293,7 +1367,7 @@ mod tests {
     let request = JsSubscribeDeshredRequest {
       deshred_transactions,
       ping: Some(JsSubscribeRequestPing { id: 99 }),
-      slots: None,
+      slots: HashMap::new(),
     };
 
     stream

--- a/yellowstone-grpc-client-nodejs/napi/src/subscribe_request_validation.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/subscribe_request_validation.rs
@@ -6,8 +6,11 @@ use yellowstone_grpc_proto::geyser::{
 };
 use yellowstone_grpc_proto::prelude::SubscribeRequest;
 
+use crate::AUTORECONNECT_FILTER_KEY;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubscribeRequestValidationError {
+  ReservedFilterName,
   MissingFilter { path: String },
   MissingMemcmpData { path: String },
   MissingLamportsComparator { path: String },
@@ -16,6 +19,12 @@ pub enum SubscribeRequestValidationError {
 impl fmt::Display for SubscribeRequestValidationError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
+      Self::ReservedFilterName => {
+        write!(
+          f,
+          "invalid subscribe request: filter name {AUTORECONNECT_FILTER_KEY} is reserved"
+        )
+      }
       Self::MissingFilter { path } => {
         write!(
           f,
@@ -43,6 +52,10 @@ impl std::error::Error for SubscribeRequestValidationError {}
 pub fn validate_subscribe_request(
   request: &SubscribeRequest,
 ) -> Result<(), SubscribeRequestValidationError> {
+  if contains_reserved_autoreconnect_filter(request) {
+    return Err(SubscribeRequestValidationError::ReservedFilterName);
+  }
+
   for (account_key, account_filter) in &request.accounts {
     for (index, filter) in account_filter.filters.iter().enumerate() {
       let filter_path = format!("accounts[\"{account_key}\"].filters[{index}]");
@@ -69,6 +82,20 @@ pub fn validate_subscribe_request(
   }
 
   Ok(())
+}
+
+fn contains_reserved_filter_name<T>(filters: &std::collections::HashMap<String, T>) -> bool {
+  filters.contains_key(AUTORECONNECT_FILTER_KEY)
+}
+
+fn contains_reserved_autoreconnect_filter(request: &SubscribeRequest) -> bool {
+  contains_reserved_filter_name(&request.accounts)
+    || contains_reserved_filter_name(&request.slots)
+    || contains_reserved_filter_name(&request.transactions)
+    || contains_reserved_filter_name(&request.transactions_status)
+    || contains_reserved_filter_name(&request.blocks)
+    || contains_reserved_filter_name(&request.blocks_meta)
+    || contains_reserved_filter_name(&request.entry)
 }
 
 fn validate_memcmp_filter(
@@ -388,6 +415,19 @@ mod tests {
     request.accounts.get_mut("full").unwrap().filters = Vec::new();
 
     validate_subscribe_request(&request).expect("empty filters array should be valid");
+  }
+
+  #[test]
+  fn rejects_reserved_autoreconnect_filter_name() {
+    let mut request = fully_populated_request();
+    let full_filter = request.accounts.remove("full").unwrap();
+    request
+      .accounts
+      .insert(crate::AUTORECONNECT_FILTER_KEY.to_string(), full_filter);
+
+    let error = validate_subscribe_request(&request).expect_err("reserved filter name must fail");
+
+    assert_eq!(error, SubscribeRequestValidationError::ReservedFilterName);
   }
 
   #[test]

--- a/yellowstone-grpc-client-nodejs/napi/src/utils.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/utils.rs
@@ -1,7 +1,7 @@
-use crate::bindings::{JsChannelOptions, JsCompressionAlgorithm};
+use crate::bindings::{JsChannelOptions, JsCompressionAlgorithm, JsReconnectConfig};
 use napi::bindgen_prelude::{Result, Status};
 use std::time::Duration;
-use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcBuilder};
+use yellowstone_grpc_client::{Backoff, ClientTlsConfig, GeyserGrpcBuilder, ReconnectConfig};
 use yellowstone_grpc_proto::tonic::codec::CompressionEncoding;
 
 fn to_napi_cause(status: Status, source: &dyn std::error::Error) -> napi::Error {
@@ -18,10 +18,65 @@ fn invalid_arg_with_cause(reason: impl Into<String>, cause: &dyn std::error::Err
   error
 }
 
+fn invalid_arg(reason: impl Into<String>) -> napi::Error {
+  let reason = reason.into();
+  let mut error = napi::Error::new(Status::InvalidArg, reason.clone());
+  error.set_cause(napi::Error::new(Status::InvalidArg, reason));
+  error
+}
+
+fn reconnect_config_from_js(
+  reconnect_config: Option<JsReconnectConfig>,
+) -> Result<Option<ReconnectConfig>> {
+  let Some(reconnect_config) = reconnect_config else {
+    return Ok(None);
+  };
+
+  if reconnect_config.enabled == Some(false) {
+    return Ok(None);
+  }
+
+  let mut native_config = ReconnectConfig::default();
+
+  if let Some(slot_retention) = reconnect_config.slot_retention {
+    if slot_retention == 0 {
+      return Err(invalid_arg(
+        "invalid reconnect.slotRetention: expected a positive integer",
+      ));
+    }
+    native_config = native_config.with_slot_retention(slot_retention as usize);
+  }
+
+  if let Some(backoff) = reconnect_config.backoff {
+    let initial_interval = backoff
+      .initial_interval_ms
+      .map(|ms| Duration::from_millis(ms as u64))
+      .unwrap_or(native_config.backoff.initial_interval);
+    let multiplier = backoff
+      .multiplier
+      .unwrap_or(native_config.backoff.multiplier);
+    let max_retries = backoff
+      .max_retries
+      .unwrap_or(native_config.backoff.max_retries);
+
+    if !multiplier.is_finite() || multiplier < 1.0 {
+      return Err(invalid_arg(
+        "invalid reconnect.backoff.multiplier: expected a finite number >= 1",
+      ));
+    }
+
+    native_config =
+      native_config.with_backoff(Backoff::new(initial_interval, multiplier, max_retries));
+  }
+
+  Ok(Some(native_config))
+}
+
 pub async fn get_client_builder(
   endpoint: String,
   x_token: Option<String>,
   channel_options: Option<JsChannelOptions>,
+  reconnect_config: Option<JsReconnectConfig>,
 ) -> Result<GeyserGrpcBuilder> {
   let use_tls = endpoint.starts_with("https://");
 
@@ -56,6 +111,10 @@ pub async fn get_client_builder(
           ))
         }
       };
+  }
+
+  if let Some(reconnect_config) = reconnect_config_from_js(reconnect_config)? {
+    grpc_client_builder = grpc_client_builder.set_reconnect_config(reconnect_config);
   }
 
   const DEFAULT_GRPC_CONNECT_TIMEOUT_MS: u32 = 10_000;
@@ -191,7 +250,7 @@ mod tests {
 
   #[tokio::test]
   async fn get_client_builder_invalid_endpoint_includes_cause() {
-    let error = get_client_builder("http://127.0.0.1:10000\n".to_string(), None, None)
+    let error = get_client_builder("http://127.0.0.1:10000\n".to_string(), None, None, None)
       .await
       .expect_err("invalid endpoint should fail");
     assert!(
@@ -212,6 +271,7 @@ mod tests {
       "http://127.0.0.1:10000".to_string(),
       Some("bad\nheader".to_string()),
       None,
+      None,
     )
     .await
     .expect_err("invalid x-token should fail");
@@ -222,6 +282,66 @@ mod tests {
     assert!(
       error.cause.is_some(),
       "expected native cause on invalid x-token"
+    );
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_applies_reconnect_config() {
+    use crate::bindings::{JsReconnectBackoff, JsReconnectConfig};
+    use std::time::Duration;
+
+    let builder = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        enabled: Some(true),
+        backoff: Some(JsReconnectBackoff {
+          initial_interval_ms: Some(125),
+          multiplier: Some(1.5),
+          max_retries: Some(8),
+        }),
+        slot_retention: Some(300),
+      }),
+    )
+    .await
+    .expect("valid reconnect config should build");
+
+    assert_eq!(
+      builder.reconnect_config.backoff.initial_interval,
+      Duration::from_millis(125)
+    );
+    assert_eq!(builder.reconnect_config.backoff.multiplier, 1.5);
+    assert_eq!(builder.reconnect_config.backoff.max_retries, 8);
+    assert_eq!(builder.reconnect_config.slot_retention, 300);
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_rejects_invalid_reconnect_config() {
+    use crate::bindings::{JsReconnectBackoff, JsReconnectConfig};
+
+    let error = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        enabled: Some(true),
+        backoff: Some(JsReconnectBackoff {
+          initial_interval_ms: None,
+          multiplier: Some(0.5),
+          max_retries: None,
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect_err("invalid multiplier should fail");
+
+    assert!(
+      error
+        .to_string()
+        .contains("invalid reconnect.backoff.multiplier"),
+      "unexpected error message: {error}"
     );
   }
 }

--- a/yellowstone-grpc-client-nodejs/napi/tests/js_types_tests.rs
+++ b/yellowstone-grpc-client-nodejs/napi/tests/js_types_tests.rs
@@ -532,7 +532,7 @@ fn js_subscribe_deshred_request_conversion_preserves_vote_false_and_ping() {
   let js_subscribe_deshred_request_value = JsSubscribeDeshredRequest {
     deshred_transactions,
     ping: Some(JsSubscribeRequestPing { id: 17 }),
-    slots: None,
+    slots: HashMap::new(),
   };
 
   let protobuf_subscribe_deshred_request_value = js_subscribe_deshred_request_value

--- a/yellowstone-grpc-client-nodejs/src/index.ts
+++ b/yellowstone-grpc-client-nodejs/src/index.ts
@@ -75,12 +75,24 @@ import type {
 import { Duplex } from "stream";
 import * as napi from "./napi/index";
 
+export const AUTORECONNECT_FILTER_KEY: string = napi.AUTORECONNECT_FILTER_KEY;
+
 /**
  * Public channel options accepted by the SDK constructor.
  * This is sourced from the native N-API constructor signature to avoid
  * duplicating option fields in this file.
  */
 export type ChannelOptions = NonNullable<Parameters<typeof napi.GrpcClient.new>[2]>;
+
+export interface ReconnectOptions {
+  enabled?: boolean;
+  backoff?: {
+    initialIntervalMs?: number;
+    multiplier?: number;
+    maxRetries?: number;
+  };
+  slotRetention?: number;
+}
 
 /**
  * Convert N-API `JsSubscribeUpdate` shape (with `updateOneof`) into the
@@ -190,16 +202,19 @@ export default class Client {
   private _insecureEndpoint: string;
   private _insecureXToken: string | undefined;
   private _channelOptions: ChannelOptions | undefined;
+  private _reconnectOptions: ReconnectOptions | undefined;
   private _grpcClient: unknown | null = null;
 
   constructor(
     endpoint: string,
     xToken: string | undefined,
     channel_options: ChannelOptions | undefined,
+    reconnect_options?: ReconnectOptions,
   ) {
     this._insecureEndpoint = endpoint;
     this._insecureXToken = xToken;
     this._channelOptions = channel_options;
+    this._reconnectOptions = reconnect_options;
   }
 
   private _connectedGrpcClient(): napi.GrpcClient {
@@ -215,6 +230,7 @@ export default class Client {
       this._insecureEndpoint,
       this._insecureXToken,
       this._channelOptions,
+      this._reconnectOptions,
     );
   }
 
@@ -314,7 +330,7 @@ export default class Client {
     });
   }
 
-  async subscribe(): Promise<ClientDuplexStream> {
+  async subscribe(request?: SubscribeRequest): Promise<ClientDuplexStream> {
     const grpcClient = this._connectedGrpcClient();
 
     // Inner stream.Duplex config passed to both stream.Readable and Writable.
@@ -330,7 +346,12 @@ export default class Client {
 
     // Native stream produces N-API generated JS objects; wrapper below adapts
     // to public protobuf-generated SDK shapes and Node stream semantics.
-    const stream = await grpcClient.subscribe();
+    const stream =
+      request === undefined
+        ? await grpcClient.subscribe()
+        : await grpcClient.subscribe(
+            Buffer.from(SubscribeRequestMessage.encode(request).finish()),
+          );
 
     return new Promise<ClientDuplexStream>((resolve, reject) => {
       try {


### PR DESCRIPTION
  Adds opt-in auto-reconnect support to the Yellowstone gRPC TypeScript client via the NAPI bridge.

  - Upgrades the NAPI client to `yellowstone-grpc-client` `13.1.0`.
  - Adds `ReconnectOptions` to the TypeScript `Client` constructor and maps it to Rust `ReconnectConfig`.
  - Adds support for `client.subscribe(request)` so the initial subscription request is available when the native stream opens and can be reused on reconnect.
  - Keeps reconnect disabled by default; existing clients behave as before unless reconnect config is passed.
  - Strips the internal `__autoreconnect` filter in the NAPI bridge before updates reach JS, and exports the filter key as a single native constant.
  - Rejects user subscribe filters named `__autoreconnect` to avoid collisions with the Rust client’s internal checkpoint subscription.
  - Adds TypeScript example CLI flags and README docs for auto-reconnect usage.
  - Adds integration coverage for slot subscriptions using auto-reconnect, including a forced transient disconnect via a local TCP proxy.