### PR TITLE
feat: connection-close metrics and client_unresponsive disconnect reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+- yellowstone-grpc-geyser 13.1.2
+
+### Features
+
+- geyser: add `connections_closed_total{reason}` metric that breaks down the TCP-level close cause (connection_reset, broken_pipe, unexpected_eof, clean, etc) behind an ungraceful `client_closed`, plus a `client_unresponsive` reason on `grpc_client_disconnects_total` for heartbeat-detected dead clients (previously mislabeled `server_shutdown`) ([#748](https://github.com/rpcpool/yellowstone-grpc/pull/748))
+
 
 ## 2026-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "13.1.1"
+version = "13.1.2"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "examples/rust", # 12.3.0
     "yellowstone-grpc-client", # 13.1.0
-    "yellowstone-grpc-geyser", # 13.1.0
+    "yellowstone-grpc-geyser", # 13.1.2
     "yellowstone-grpc-proto", # 12.4.0
 ]
 exclude = [
@@ -99,7 +99,7 @@ spl-token-2022-interface = "2.1.0"
 
 # Yellowstone
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.1.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.1.2" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.4.0", default-features = false }
 
 [workspace.lints.clippy]

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "13.1.1"
+version = "13.1.2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -37,7 +37,7 @@ use {
         os::unix::fs::PermissionsExt,
         path::PathBuf,
         sync::{
-            atomic::{AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
             Arc, LazyLock, Mutex as StdMutex,
         },
         time::SystemTime,
@@ -1107,6 +1107,7 @@ impl GrpcService {
         debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
         maybe_remote_peer_sk_addr: Option<SocketAddr>,
         cancellation_token: CancellationToken,
+        client_unresponsive: Arc<AtomicBool>,
         task_tracker: TaskTracker,
         subscription_tracker: SubscriptionTracker,
     ) {
@@ -1141,7 +1142,11 @@ impl GrpcService {
                     let _ = stream_tx.try_send(Err(Status::internal(
                         "server is shutting down try again later",
                     )));
-                    session.disconnect_reason = "server_shutdown";
+                    session.disconnect_reason = if client_unresponsive.load(Ordering::Acquire) {
+                        "client_unresponsive"
+                    } else {
+                        "server_shutdown"
+                    };
                     return;
                 }
                 Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed) => {
@@ -1161,7 +1166,11 @@ impl GrpcService {
                 _ = cancellation_token.cancelled() => {
                     info!("client #{id}: cancelled");
                     let _ = stream_tx.try_send(Err(Status::unavailable("server is shutting down try again later")));
-                    session.disconnect_reason = "server_shutdown";
+                    session.disconnect_reason = if client_unresponsive.load(Ordering::Acquire) {
+                        "client_unresponsive"
+                    } else {
+                        "server_shutdown"
+                    };
                     break 'outer;
                 }
                 mut message = client_rx.recv() => {
@@ -1562,6 +1571,10 @@ impl Geyser for GrpcService {
         });
         let (client_tx, client_rx) = mpsc::unbounded_channel();
 
+        // Set by the ping task before it cancels, so client_loop can attribute the
+        // disconnect to "client_unresponsive" instead of the generic "server_shutdown".
+        let client_unresponsive = Arc::new(AtomicBool::new(false));
+        let ping_unresponsive = Arc::clone(&client_unresponsive);
         let ping_stream_tx = stream_tx.clone();
         let ping_cancellation_token = client_cancellation_token.clone();
         let ping_client_cancel = client_cancellation_token.clone();
@@ -1585,6 +1598,7 @@ impl Geyser for GrpcService {
                             // does reject every geyser event thus we never write to the HTTP/2 stream and we never detect that the client TCP connection is closed.
                             // By sending a ping every 10 seconds, we can detect if the client is still alive and if it's not,
                             // we can cancel the client loop.
+                            ping_unresponsive.store(true, Ordering::Release);
                             ping_client_cancel.cancel();
                             info!("detected dead client #{id}");
                             break;
@@ -1672,6 +1686,7 @@ impl Geyser for GrpcService {
             self.debug_clients_tx.clone(),
             maybe_remote_peer_sk_addr,
             client_cancellation_token,
+            client_unresponsive,
             self.task_tracker.clone(),
             Arc::clone(&self.subscription_tracker),
         ));
@@ -1880,6 +1895,7 @@ mod tests {
             None,
             None,
             ct.clone(),
+            Arc::new(AtomicBool::new(false)),
             tt.clone(),
             Arc::clone(&st),
         ));

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -65,6 +65,14 @@ lazy_static::lazy_static! {
         "connections_total", "Total number of connections to gRPC service"
     ).unwrap();
 
+    static ref CONNECTIONS_CLOSED: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "connections_closed_total",
+            "Total TCP connections closed, by socket-level close reason (connection_reset, broken_pipe, clean, etc). One count per TCP connection, not per gRPC subscription."
+        ),
+        &["reason"]
+    ).unwrap();
+
     static ref SUBSCRIPTIONS_TOTAL: IntGaugeVec = IntGaugeVec::new(
         Opts::new("subscriptions_total", "Total number of subscriptions to gRPC service"),
         &["endpoint", "subscription"]
@@ -320,6 +328,7 @@ impl PrometheusService {
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
             register!(CONNECTIONS_TOTAL);
+            register!(CONNECTIONS_CLOSED);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);
             register!(GRPC_MESSAGE_SENT);
@@ -505,6 +514,10 @@ pub fn connections_total_dec() {
     CONNECTIONS_TOTAL.dec()
 }
 
+pub fn incr_connection_closed(reason: &str) {
+    CONNECTIONS_CLOSED.with_label_values(&[reason]).inc();
+}
+
 pub fn subscription_limit_exceeded_inc<S: AsRef<str>>(subscriber_id: S) {
     GRPC_SUBSCRIPTION_LIMIT_EXCEEDED
         .with_label_values(&[subscriber_id.as_ref()])
@@ -640,6 +653,7 @@ pub fn reset_metrics() {
     MISSED_STATUS_MESSAGE.reset();
     GRPC_MESSAGE_SENT.reset();
     GRPC_CLIENT_DISCONNECTS.reset();
+    CONNECTIONS_CLOSED.reset();
     GRPC_CONCURRENT_SUBSCRIBE_PER_TCP_CONNECTION.reset();
     TOTAL_TRAFFIC_SENT.reset();
     TRAFFIC_SENT_PER_REMOTE_IP.reset();

--- a/yellowstone-grpc-geyser/src/transport.rs
+++ b/yellowstone-grpc-geyser/src/transport.rs
@@ -669,13 +669,19 @@ mod tests {
         use io::ErrorKind;
         // No error observed -> clean close (FIN/EOF or graceful GOAWAY).
         assert_eq!(close_reason(None), "clean");
-        assert_eq!(close_reason(Some(ErrorKind::ConnectionReset)), "connection_reset");
+        assert_eq!(
+            close_reason(Some(ErrorKind::ConnectionReset)),
+            "connection_reset"
+        );
         assert_eq!(close_reason(Some(ErrorKind::BrokenPipe)), "broken_pipe");
         assert_eq!(
             close_reason(Some(ErrorKind::ConnectionAborted)),
             "connection_aborted"
         );
-        assert_eq!(close_reason(Some(ErrorKind::UnexpectedEof)), "unexpected_eof");
+        assert_eq!(
+            close_reason(Some(ErrorKind::UnexpectedEof)),
+            "unexpected_eof"
+        );
         assert_eq!(close_reason(Some(ErrorKind::TimedOut)), "timed_out");
         assert_eq!(close_reason(Some(ErrorKind::NotConnected)), "not_connected");
         // Any other (non-exhaustive) kind falls into the catch-all bucket.

--- a/yellowstone-grpc-geyser/src/transport.rs
+++ b/yellowstone-grpc-geyser/src/transport.rs
@@ -134,6 +134,36 @@ pub struct SpyIO<IO> {
     remote_peer_ip_str: Option<String>,
     unreported_traffic_sent: u64,
     traffic_reporting_threshold: u64,
+    /// Last socket error kind observed on read/write, used to attribute the
+    /// close reason on Drop. `None` means a clean close (see [`close_reason`]).
+    last_close_error: Option<std::io::ErrorKind>,
+}
+
+/// Maps the last observed socket error into a bounded, low-cardinality label
+/// for the `connections_closed_total` metric (one count per TCP connection, not
+/// per gRPC subscription; the per-subscription view is `grpc_client_disconnects_total`).
+///
+/// `None` means no read/write error was seen before the socket dropped: a clean
+/// peer FIN surfaces as `Ok(0)` (EOF), and a graceful HTTP/2 GOAWAY (including a
+/// hyper keepalive-ping timeout, which is sent as `GOAWAY(NO_ERROR)`) is
+/// indistinguishable from a normal close here. All of these report `"clean"`.
+/// Neither hyper nor tonic exposes a keepalive-timeout callback, so it cannot
+/// get its own bucket; the application ping (`client_unresponsive`) is the
+/// substitute for catching a silently-gone peer.
+///
+/// `std::io::ErrorKind` is `#[non_exhaustive]`, so the wildcard arm is required.
+const fn close_reason(kind: Option<std::io::ErrorKind>) -> &'static str {
+    use std::io::ErrorKind;
+    match kind {
+        None => "clean",
+        Some(ErrorKind::ConnectionReset) => "connection_reset",
+        Some(ErrorKind::BrokenPipe) => "broken_pipe",
+        Some(ErrorKind::ConnectionAborted) => "connection_aborted",
+        Some(ErrorKind::UnexpectedEof) => "unexpected_eof",
+        Some(ErrorKind::TimedOut) => "timed_out",
+        Some(ErrorKind::NotConnected) => "not_connected",
+        Some(_) => "other",
+    }
 }
 
 impl<IO> Drop for SpyIO<IO> {
@@ -144,6 +174,7 @@ impl<IO> Drop for SpyIO<IO> {
                 log::debug!("Last connection from remote ip {remote_peer_ip_str} closed, resetting its traffic metrics");
             }
         }
+        metrics::incr_connection_closed(close_reason(self.last_close_error));
         metrics::connections_total_dec();
     }
 }
@@ -171,6 +202,7 @@ where
             remote_peer_ip_str: maybe_remote_peer_ip_string,
             unreported_traffic_sent: 0,
             traffic_reporting_threshold,
+            last_close_error: None,
         }
     }
 }
@@ -197,7 +229,12 @@ where
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().wrappee).poll_read(cx, buf)
+        let this = self.get_mut();
+        let result = Pin::new(&mut this.wrappee).poll_read(cx, buf);
+        if let std::task::Poll::Ready(Err(e)) = &result {
+            this.last_close_error = Some(e.kind());
+        }
+        result
     }
 }
 
@@ -227,10 +264,15 @@ where
     ) -> std::task::Poll<std::io::Result<usize>> {
         let this = self.get_mut();
         let result = ready!(Pin::new(&mut this.wrappee).poll_write(cx, buf));
-        if let Ok(bytes_written) = &result {
-            this.unreported_traffic_sent += *bytes_written as u64;
-            if this.unreported_traffic_sent >= this.traffic_reporting_threshold {
-                this.flush_metrics();
+        match &result {
+            Ok(bytes_written) => {
+                this.unreported_traffic_sent += *bytes_written as u64;
+                if this.unreported_traffic_sent >= this.traffic_reporting_threshold {
+                    this.flush_metrics();
+                }
+            }
+            Err(e) => {
+                this.last_close_error = Some(e.kind());
             }
         }
         result.into()
@@ -241,7 +283,12 @@ where
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().wrappee).poll_flush(cx)
+        let this = self.get_mut();
+        let result = Pin::new(&mut this.wrappee).poll_flush(cx);
+        if let std::task::Poll::Ready(Err(e)) = &result {
+            this.last_close_error = Some(e.kind());
+        }
+        result
     }
 
     /// Shuts down the wrapped IO.
@@ -249,7 +296,12 @@ where
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().wrappee).poll_shutdown(cx)
+        let this = self.get_mut();
+        let result = Pin::new(&mut this.wrappee).poll_shutdown(cx);
+        if let std::task::Poll::Ready(Err(e)) = &result {
+            this.last_close_error = Some(e.kind());
+        }
+        result
     }
 }
 
@@ -515,6 +567,7 @@ mod tests {
             remote_peer_ip_str: None,
             unreported_traffic_sent: 0,
             traffic_reporting_threshold: u64::MAX,
+            last_close_error: None,
         };
 
         let mut dst = [0u8; 5];
@@ -539,6 +592,7 @@ mod tests {
             remote_peer_ip_str: None,
             unreported_traffic_sent: 0,
             traffic_reporting_threshold: u64::MAX,
+            last_close_error: None,
         };
 
         let mut cx = noop_context();
@@ -554,5 +608,107 @@ mod tests {
         assert_eq!(spy.wrappee.written_data, b"abc");
         assert_eq!(spy.wrappee.flush_calls, 1);
         assert_eq!(spy.wrappee.shutdown_calls, 1);
+    }
+
+    /// IO whose read/write fail with a fixed error kind, to exercise close-reason capture.
+    struct MockIoErr {
+        kind: io::ErrorKind,
+    }
+
+    impl Connected for MockIoErr {
+        type ConnectInfo = TcpConnectInfo;
+
+        fn connect_info(&self) -> Self::ConnectInfo {
+            TcpConnectInfo {
+                local_addr: None,
+                remote_addr: None,
+            }
+        }
+    }
+
+    impl AsyncRead for MockIoErr {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::from(self.kind)))
+        }
+    }
+
+    impl AsyncWrite for MockIoErr {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Err(io::Error::from(self.kind)))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::from(self.kind)))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::from(self.kind)))
+        }
+    }
+
+    fn spyio_with(wrappee: MockIoErr) -> SpyIO<MockIoErr> {
+        SpyIO {
+            wrappee,
+            remote_peer_ip_str: None,
+            unreported_traffic_sent: 0,
+            traffic_reporting_threshold: u64::MAX,
+            last_close_error: None,
+        }
+    }
+
+    #[test]
+    fn close_reason_maps_error_kinds_to_bounded_labels() {
+        use io::ErrorKind;
+        // No error observed -> clean close (FIN/EOF or graceful GOAWAY).
+        assert_eq!(close_reason(None), "clean");
+        assert_eq!(close_reason(Some(ErrorKind::ConnectionReset)), "connection_reset");
+        assert_eq!(close_reason(Some(ErrorKind::BrokenPipe)), "broken_pipe");
+        assert_eq!(
+            close_reason(Some(ErrorKind::ConnectionAborted)),
+            "connection_aborted"
+        );
+        assert_eq!(close_reason(Some(ErrorKind::UnexpectedEof)), "unexpected_eof");
+        assert_eq!(close_reason(Some(ErrorKind::TimedOut)), "timed_out");
+        assert_eq!(close_reason(Some(ErrorKind::NotConnected)), "not_connected");
+        // Any other (non-exhaustive) kind falls into the catch-all bucket.
+        assert_eq!(close_reason(Some(ErrorKind::OutOfMemory)), "other");
+    }
+
+    #[test]
+    fn spyio_captures_last_close_error_on_read_error() {
+        let mut spy = spyio_with(MockIoErr {
+            kind: io::ErrorKind::ConnectionReset,
+        });
+        let mut dst = [0u8; 4];
+        let mut read_buf = tokio::io::ReadBuf::new(&mut dst);
+        let mut cx = noop_context();
+
+        let poll = Pin::new(&mut spy).poll_read(&mut cx, &mut read_buf);
+
+        assert!(matches!(poll, Poll::Ready(Err(_))));
+        assert_eq!(spy.last_close_error, Some(io::ErrorKind::ConnectionReset));
+        assert_eq!(close_reason(spy.last_close_error), "connection_reset");
+    }
+
+    #[test]
+    fn spyio_captures_last_close_error_on_write_error() {
+        let mut spy = spyio_with(MockIoErr {
+            kind: io::ErrorKind::BrokenPipe,
+        });
+        let mut cx = noop_context();
+
+        let poll = Pin::new(&mut spy).poll_write(&mut cx, b"abc");
+
+        assert!(matches!(poll, Poll::Ready(Err(_))));
+        assert_eq!(spy.last_close_error, Some(io::ErrorKind::BrokenPipe));
+        assert_eq!(close_reason(spy.last_close_error), "broken_pipe");
     }
 }


### PR DESCRIPTION
## What

Adds visibility into *why* a gRPC client connection actually goes away, at two layers.

### `connections_closed_total{reason}` (new, transport layer)
A counter incremented once per TCP connection close, classified from the last socket `io::ErrorKind` observed in `SpyIO`:

- `connection_reset` (peer sent a TCP RST), `broken_pipe` (write to a gone peer), `connection_aborted`, `unexpected_eof`, `timed_out`, `not_connected`
- `clean` (no error: a clean FIN is `Ok(0)`/EOF, and a graceful HTTP/2 GOAWAY also lands here)
- `other` (catch-all, required because `io::ErrorKind` is `#[non_exhaustive]`)

This breaks down what an ungraceful `client_closed` on `grpc_client_disconnects_total` actually was at the TCP level. The kind is captured only on the error branch of the poll methods, so the data path is unaffected (no allocation, no locking, no work on the success path). This is per TCP connection, distinct from the per-subscription `grpc_client_disconnects_total`.

### `client_unresponsive` (new reason on `grpc_client_disconnects_total`)
The 10s heartbeat task already detects a dead "zombie" client (for example one whose filter matches nothing, so the send loop never writes and never notices the peer is gone). It now flags the session before cancelling, so that disconnect is attributed to `client_unresponsive` instead of being mislabeled `server_shutdown`.

## Why not a dedicated keepalive-timeout metric

An HTTP/2 keepalive ping timeout is emitted by hyper as `GOAWAY(NO_ERROR)`, which is byte-for-byte indistinguishable from a clean close at the socket, so it falls into the `clean` bucket. Neither hyper nor tonic exposes a callback for it (confirmed by reading the pinned hyper 1.8.1 / h2 0.4.13 / tonic 0.14.3 source). The heartbeat (`client_unresponsive`) is the practical substitute. The rationale and caveat are documented inline next to the classifier.

## Tests

Unit tests for the close-reason classifier (including the `clean` and `other` buckets) and for the error-capture path on read and write.

## Notes

- Patch bump `yellowstone-grpc-geyser` 13.1.1 -> 13.1.2.
- `cargo clippy --all-targets` clean; full geyser lib test suite green.