### PR TITLE
geyser: refactor block reconstruction using block-machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## 2026-06-02
+
+- yellowstone-grpc-geyser 13.2.0
+
+### misc
+
+- refactor block reconstruction
 
 ## 2026-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -458,11 +458,27 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
+name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bytesize-serde"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d1eb2fd2668859e9785b99700c66b7ea9fdeda35d99f95827a4e5493440178"
+dependencies = [
+ "bytesize 1.3.3",
+ "serde",
 ]
 
 [[package]]
@@ -653,6 +669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -792,7 +817,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rand_core",
+ "rand_core 0.6.4",
  "rustc_version",
  "serde",
  "subtle",
@@ -937,6 +962,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,7 +1024,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1856,7 +1904,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -1892,6 +1940,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -2496,8 +2553,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2507,7 +2574,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2517,6 +2594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2596,6 +2682,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2863,6 +2955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,7 +2995,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3292,7 +3393,7 @@ checksum = "5ac8be597c9e231b0cab2928ce3bc3e4ee77d9c0ad92977b9d901f3879f25a7a"
 dependencies = [
  "ed25519-dalek",
  "five8",
- "rand",
+ "rand 0.8.6",
  "solana-address 2.6.0",
  "solana-seed-phrase",
  "solana-signature",
@@ -3610,6 +3711,7 @@ checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
 dependencies = [
  "ed25519-dalek",
  "five8",
+ "rand 0.9.4",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -3948,7 +4050,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4305,6 +4407,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4682,6 +4793,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4707,6 +4844,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -4784,6 +4927,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vergen"
@@ -5379,6 +5528,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "yellowstone-block-machine"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bde506698bf9064ce7c5887046a03c4db54e8e74327bc9f3e7e86120477569"
+dependencies = [
+ "bs58",
+ "bytesize 2.3.1",
+ "bytesize-serde",
+ "derive_more",
+ "futures-util",
+ "rustc-hash",
+ "serde",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-hash 4.2.0",
+ "solana-pubkey 4.1.0",
+ "solana-signature",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "yellowstone-grpc-client"
 version = "13.1.0"
 dependencies = [
@@ -5426,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "13.1.1"
+version = "13.2.0"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",
@@ -5435,7 +5607,7 @@ dependencies = [
  "bincode",
  "bs58",
  "bytes",
- "bytesize",
+ "bytesize 2.3.1",
  "cargo-lock",
  "clap",
  "criterion",
@@ -5463,6 +5635,7 @@ dependencies = [
  "solana-account",
  "solana-account-decoder",
  "solana-clock",
+ "solana-commitment-config",
  "solana-hash 4.2.0",
  "solana-keypair",
  "solana-logger",
@@ -5488,6 +5661,7 @@ dependencies = [
  "tonic-prost-build",
  "tower-layer",
  "vergen",
+ "yellowstone-block-machine",
  "yellowstone-grpc-proto",
 ]
 
@@ -5500,7 +5674,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "protoc-bin-vendored",
- "rand",
+ "rand 0.8.6",
  "siphasher",
  "solana-pubkey 4.1.0",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ solana-transaction-status = "4.0.0"
 # Solana SDK
 solana-account = "3.4.0"
 solana-clock = "3.0.1"
+solana-commitment-config = "3.0.0"
 solana-hash = "4.2.0"
 solana-keypair = "3.1.0"
 solana-message = "3.1.0"
@@ -98,6 +99,7 @@ solana-transaction-error = "3.0.0"
 spl-token-2022-interface = "2.1.0"
 
 # Yellowstone
+yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
 yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.1.1" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.1.1" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.4.0", default-features = false }
 
 [workspace.lints.clippy]

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "13.1.1"
+version = "13.2.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"
@@ -60,6 +60,7 @@ solana-logger = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-clock = { workspace = true }
+solana-commitment-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
@@ -79,6 +80,7 @@ prost_011 = { workspace = true, optional = true }
 
 # Yellowstone
 yellowstone-grpc-proto = { workspace = true, features = ["tonic", "account-data-as-bytes"] }
+yellowstone-block-machine = { workspace = true, default-features = false }
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 # wrapped in mod cpu_core_affinity

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -1,0 +1,817 @@
+use {
+    crate::plugin::message::{
+        Message, MessageAccountInfo, MessageBlock, MessageBlockMeta, MessageEntry, MessageSlot,
+        MessageTransactionInfo, SlotStatus,
+    },
+    solana_commitment_config::CommitmentLevel,
+    solana_hash::Hash,
+    solana_pubkey::Pubkey,
+    std::{
+        borrow::Borrow,
+        collections::{btree_map::Range, BTreeMap, HashMap, VecDeque},
+        str::FromStr,
+        sync::Arc,
+    },
+    yellowstone_block_machine::state_machine::{
+        BlockReplayEvent, BlockStateMachineOutput, BlockSummary, BlocksStateMachine,
+        SlotCommitmentStatusUpdate, SlotLifecycle, SlotLifecycleUpdate, UntrackedSlot,
+    },
+};
+
+#[derive(Default)]
+pub struct ProcessingSlot {
+    original_messages: Vec<Message>,
+    account_write_version_map: HashMap<Pubkey, u64>,
+    transactions: Vec<Arc<MessageTransactionInfo>>,
+    accounts: Vec<Arc<MessageAccountInfo>>,
+    entries: Vec<Arc<MessageEntry>>,
+}
+
+impl ProcessingSlot {
+    pub fn add_event(&mut self, event: Message) {
+        match event.borrow() {
+            Message::Account(message_account) => {
+                let write_version = message_account.account.write_version;
+                self.account_write_version_map
+                    .entry(message_account.account.pubkey)
+                    .and_modify(|entry| {
+                        if *entry < write_version {
+                            *entry = write_version;
+                        }
+                    })
+                    .or_insert(write_version);
+                self.accounts.push(Arc::clone(&message_account.account));
+                // Handle account event
+            }
+            Message::Transaction(message_transaction) => {
+                self.transactions
+                    .push(Arc::clone(&message_transaction.transaction));
+                // Handle transaction event
+            }
+            Message::Entry(message_entry) => {
+                self.entries.push(Arc::clone(message_entry));
+                // Handle entry event
+            }
+            _ => {
+                // Handle other events if necessary
+                return;
+            }
+        }
+
+        self.original_messages.push(event);
+    }
+
+    pub fn into_block(self, block_meta: Arc<MessageBlockMeta>) -> FrozenBlock {
+        let account_info_vec = self
+            .accounts
+            .into_iter()
+            .filter_map(|account| {
+                let write_version = self.account_write_version_map.get(&account.pubkey)?;
+                if *write_version == account.write_version {
+                    Some(account)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        // Yet another clone of all the messages, but that prevents from doing this later on anyway, while making iterator code easier to implement.
+        let dedup_messages = self
+            .original_messages
+            .into_iter()
+            .filter_map(|message| {
+                if let Message::Account(account) = &message {
+                    let write_version = self
+                        .account_write_version_map
+                        .get(&account.account.pubkey)?;
+                    if *write_version == account.account.write_version {
+                        Some(message)
+                    } else {
+                        None
+                    }
+                } else {
+                    Some(message)
+                }
+            })
+            .collect::<Vec<_>>();
+        let pre_computed_message_block = MessageBlock::new(
+            Arc::clone(&block_meta),
+            self.transactions,
+            account_info_vec,
+            self.entries,
+        );
+        FrozenBlock {
+            original_messages: Arc::new(dedup_messages),
+            block_meta,
+            pre_computed_message_block,
+        }
+    }
+}
+
+pub struct FrozenBlock {
+    original_messages: Arc<Vec<Message>>,
+    block_meta: Arc<MessageBlockMeta>,
+    pre_computed_message_block: MessageBlock,
+}
+
+impl FrozenBlock {
+    pub fn get_message_block(&self) -> MessageBlock {
+        self.pre_computed_message_block.clone()
+    }
+
+    pub fn messages(&self) -> Arc<Vec<Message>> {
+        Arc::clone(&self.original_messages)
+    }
+}
+
+pub struct SlotProgression {
+    commitment: Vec<SlotCommitmentStatusUpdate>,
+    max_commitment: CommitmentLevel,
+}
+
+pub struct BlockMachineStorage {
+    processing_slots: HashMap<u64, ProcessingSlot>,
+    pending_blockmeta: HashMap<u64, Arc<MessageBlockMeta>>,
+    replayed_slot: BTreeMap<u64, Arc<FrozenBlock>>,
+    slot_commitment_progression_map: HashMap<u64, SlotProgression>,
+    replayed_capacity: usize,
+    ready_queue: VecDeque<(SlotCommitmentStatusUpdate, Arc<FrozenBlock>)>,
+    state: BlocksStateMachine,
+    min_slot: Option<u64>,
+}
+
+pub struct ReplayIter<'storage> {
+    storage: &'storage BlockMachineStorage,
+    iter: Range<'storage, u64, Arc<FrozenBlock>>,
+    min_commitment: CommitmentLevel,
+}
+
+const fn cmp_commitment_level(a: CommitmentLevel, b: CommitmentLevel) -> std::cmp::Ordering {
+    use CommitmentLevel::*;
+    match (a, b) {
+        (Processed, Processed) | (Confirmed, Confirmed) | (Finalized, Finalized) => {
+            std::cmp::Ordering::Equal
+        }
+        (Processed, _) => std::cmp::Ordering::Less,
+        (_, Processed) => std::cmp::Ordering::Greater,
+        (Confirmed, Finalized) => std::cmp::Ordering::Less,
+        (Finalized, Confirmed) => std::cmp::Ordering::Greater,
+    }
+}
+
+pub struct ReplayedSlot<'frozen_block> {
+    pub frozen_block: &'frozen_block FrozenBlock,
+    pub slot_status_messages: Vec<SlotCommitmentStatusUpdate>,
+}
+
+impl<'storage> Iterator for ReplayIter<'storage> {
+    type Item = ReplayedSlot<'storage>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (slot, block) = self.iter.next()?;
+            let progression = self.storage.slot_commitment_progression_map.get(slot)?;
+            let commitment_level = progression.max_commitment;
+            if cmp_commitment_level(commitment_level, self.min_commitment)
+                == std::cmp::Ordering::Less
+            {
+                continue;
+            }
+            return Some(ReplayedSlot {
+                frozen_block: block.as_ref(),
+                slot_status_messages: progression.commitment.clone(),
+            });
+        }
+    }
+}
+
+impl BlockMachineStorage {
+    pub fn new(replayed_capacity: usize) -> Self {
+        Self {
+            processing_slots: HashMap::new(),
+            replayed_slot: BTreeMap::new(),
+            replayed_capacity,
+            pending_blockmeta: HashMap::new(),
+            slot_commitment_progression_map: HashMap::new(),
+            ready_queue: VecDeque::new(),
+            state: BlocksStateMachine::default(),
+            min_slot: None,
+        }
+    }
+
+    fn prune_slot(&mut self, slot: u64) {
+        self.processing_slots.remove(&slot);
+        self.pending_blockmeta.remove(&slot);
+        self.replayed_slot.remove(&slot);
+        self.slot_commitment_progression_map.remove(&slot);
+    }
+
+    fn slot_reset(&mut self, slot: u64) {
+        self.prune_slot(slot);
+        self.ready_queue
+            .retain(|(_, block)| block.block_meta.slot != slot);
+    }
+
+    fn on_message_slot(&mut self, slot_update: MessageSlot) -> Result<(), UntrackedSlot> {
+        let slot_status = slot_update.status;
+        const LIFE_CYCLE_STATUS: [SlotStatus; 4] = [
+            SlotStatus::FirstShredReceived,
+            SlotStatus::Completed,
+            SlotStatus::CreatedBank,
+            SlotStatus::Dead,
+        ];
+
+        if LIFE_CYCLE_STATUS.contains(&slot_status) {
+            let lifecycle_update = SlotLifecycleUpdate {
+                slot: slot_update.slot,
+                parent_slot: slot_update.parent,
+                stage: match slot_status {
+                    SlotStatus::FirstShredReceived => SlotLifecycle::FirstShredReceived,
+                    SlotStatus::Completed => SlotLifecycle::Completed,
+                    SlotStatus::CreatedBank => SlotLifecycle::CreatedBank,
+                    SlotStatus::Dead => SlotLifecycle::Dead,
+                    _ => unreachable!(),
+                },
+            };
+            self.state.process_replay_event(lifecycle_update.into())?;
+        } else if slot_update.dead_error.is_some() {
+            // Downgrade to lifecycle update
+            let lifecycle_update = SlotLifecycleUpdate {
+                slot: slot_update.slot,
+                parent_slot: slot_update.parent,
+                stage: SlotLifecycle::Dead,
+            };
+            self.state.process_replay_event(lifecycle_update.into())?;
+        } else {
+            let commitment_level_update = SlotCommitmentStatusUpdate {
+                parent_slot: slot_update.parent,
+                slot: slot_update.slot,
+                commitment: match slot_status {
+                    SlotStatus::Processed => CommitmentLevel::Processed,
+                    SlotStatus::Confirmed => CommitmentLevel::Confirmed,
+                    SlotStatus::Finalized => CommitmentLevel::Finalized,
+                    _ => unreachable!(),
+                },
+            };
+
+            self.state
+                .process_consensus_event(commitment_level_update.into());
+        }
+        Ok(())
+    }
+
+    fn handle_block_meta(&mut self, block_meta: Arc<MessageBlockMeta>) {
+        let blockhash = Hash::from_str(&block_meta.blockhash).expect("blockhash format");
+        let block_summary = BlockReplayEvent::BlockSummary(BlockSummary {
+            slot: block_meta.slot,
+            parent_slot: block_meta.parent_slot,
+            blockhash,
+            entry_count: block_meta.entries_count,
+            executed_transaction_count: block_meta.executed_transaction_count,
+        });
+        if self.state.process_replay_event(block_summary).is_ok() {
+            self.pending_blockmeta.insert(block_meta.slot, block_meta);
+        }
+    }
+
+    fn handle_block_data(&mut self, block_data: Message) {
+        let slot = block_data.get_slot();
+        if !self.state.is_slot_tracked(slot) {
+            return;
+        }
+        let slot_buf = self.processing_slots.entry(slot).or_default();
+        slot_buf.add_event(block_data);
+    }
+
+    fn gc(&mut self) {
+        while self.replayed_slot.len() > self.replayed_capacity {
+            if let Some((&oldest_slot, _)) = self.replayed_slot.iter().next() {
+                self.prune_slot(oldest_slot);
+            }
+        }
+        self.min_slot = self.replayed_slot.keys().min().copied();
+        self.state.gc(None);
+    }
+
+    fn on_blockmachine_output(&mut self, output: BlockStateMachineOutput) {
+        match output {
+            BlockStateMachineOutput::FrozenBlock(frozen_block) => {
+                let Some(replayed_slot) = self.processing_slots.remove(&frozen_block.slot) else {
+                    return;
+                };
+                let block_meta = self
+                    .pending_blockmeta
+                    .remove(&frozen_block.slot)
+                    .expect("block meta should be present when frozen block is emitted");
+
+                let slot = frozen_block.slot;
+                self.min_slot = Some(self.min_slot.map_or(slot, |min| min.min(slot)));
+                let frozen_slot = replayed_slot.into_block(block_meta);
+                self.replayed_slot
+                    .insert(frozen_block.slot, Arc::new(frozen_slot));
+            }
+            BlockStateMachineOutput::SlotStatus(slot_commitment_status_update) => {
+                let slot = slot_commitment_status_update.slot;
+
+                self.slot_commitment_progression_map
+                    .entry(slot)
+                    .and_modify(|progression| {
+                        progression
+                            .commitment
+                            .push(slot_commitment_status_update.clone());
+                        if cmp_commitment_level(
+                            slot_commitment_status_update.commitment,
+                            progression.max_commitment,
+                        ) == std::cmp::Ordering::Greater
+                        {
+                            progression.max_commitment = slot_commitment_status_update.commitment;
+                        }
+                    })
+                    .or_insert_with(|| SlotProgression {
+                        commitment: vec![slot_commitment_status_update.clone()],
+                        max_commitment: slot_commitment_status_update.commitment,
+                    });
+
+                let commitment_level = slot_commitment_status_update.commitment;
+                if matches!(commitment_level, CommitmentLevel::Finalized) {
+                    // Only gc on finalized, that should be enough.
+                    self.gc();
+                }
+
+                if let Some(frozen_block) = self.replayed_slot.get(&slot) {
+                    self.ready_queue
+                        .push_back((slot_commitment_status_update, Arc::clone(frozen_block)));
+                }
+            }
+            BlockStateMachineOutput::ForksDetected(fork_detected) => {
+                self.prune_slot(fork_detected.slot);
+            }
+            BlockStateMachineOutput::DeadSlotDetected(dead_block_detected) => {
+                self.prune_slot(dead_block_detected.slot);
+            }
+            BlockStateMachineOutput::BankCreated(_) => {}
+            BlockStateMachineOutput::BankReset(slot) => {
+                self.slot_reset(slot);
+            }
+        }
+    }
+
+    pub fn add(&mut self, message: Message) {
+        match message {
+            Message::Slot(message_slot) => {
+                let _ = self.on_message_slot(message_slot);
+            }
+            Message::Account(message_account) => {
+                self.handle_block_data(Message::Account(message_account));
+            }
+            Message::Transaction(message_transaction) => {
+                self.handle_block_data(Message::Transaction(message_transaction));
+            }
+            Message::Entry(message_entry) => {
+                self.handle_block_data(Message::Entry(message_entry));
+            }
+            Message::BlockMeta(message_block_meta) => self.handle_block_meta(message_block_meta),
+            _ => {
+                // Handle other message types if necessary
+            }
+        }
+        while let Some(output) = self.state.pop_next_unprocess_blockstore_update() {
+            self.on_blockmachine_output(output);
+        }
+
+        while self.state.pop_next_dlq().is_some() {
+            // For now we just log the dlq events, but we may want to handle them in the future if necessary
+        }
+    }
+
+    pub fn pop_ready_block(&mut self) -> Option<(SlotCommitmentStatusUpdate, Arc<FrozenBlock>)> {
+        self.ready_queue.pop_front()
+    }
+
+    pub fn replay_from_slot(&self, slot: u64, min_commitment: CommitmentLevel) -> ReplayIter<'_> {
+        let iter = self.replayed_slot.range(slot..);
+        ReplayIter {
+            storage: self,
+            iter,
+            min_commitment,
+        }
+    }
+
+    pub const fn min_replayable_slot(&self) -> Option<u64> {
+        self.min_slot
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::plugin::message::{
+            MessageAccount, MessageAccountInfo, MessageEntry, MessageSlot, MessageTransaction,
+            MessageTransactionInfo, SlotStatus,
+        },
+        bytes::Bytes,
+        prost_types::Timestamp,
+        solana_hash::Hash,
+        solana_pubkey::Pubkey,
+        solana_signature::Signature,
+        std::{collections::HashSet, sync::OnceLock, time::SystemTime},
+        yellowstone_grpc_proto::geyser::SubscribeUpdateBlockMeta,
+    };
+
+    fn ts() -> Timestamp {
+        Timestamp::from(SystemTime::now())
+    }
+
+    fn make_account_msg(slot: u64, pubkey: Pubkey, write_version: u64) -> Message {
+        Message::Account(MessageAccount {
+            account: Arc::new(MessageAccountInfo {
+                pubkey,
+                lamports: 100,
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+                data: Bytes::new(),
+                write_version,
+                txn_signature: None,
+                pre_encoded: OnceLock::new(),
+            }),
+            slot,
+            is_startup: false,
+            created_at: ts(),
+        })
+    }
+
+    fn make_transaction_msg(slot: u64) -> Message {
+        Message::Transaction(MessageTransaction {
+            transaction: Arc::new(MessageTransactionInfo {
+                signature: Signature::default(),
+                is_vote: false,
+                transaction: Default::default(),
+                meta: Default::default(),
+                index: 0,
+                account_keys: HashSet::new(),
+                pre_encoded: OnceLock::new(),
+            }),
+            slot,
+            created_at: ts(),
+        })
+    }
+
+    fn make_entry_msg(slot: u64, index: usize) -> Message {
+        Message::Entry(Arc::new(MessageEntry {
+            slot,
+            index,
+            num_hashes: 1,
+            hash: Hash::default(),
+            executed_transaction_count: 0,
+            starting_transaction_index: 0,
+            created_at: ts(),
+        }))
+    }
+
+    fn make_slot_msg(slot: u64, parent: Option<u64>, status: SlotStatus) -> Message {
+        Message::Slot(MessageSlot {
+            slot,
+            parent,
+            status,
+            dead_error: None,
+            created_at: ts(),
+        })
+    }
+
+    fn make_block_meta_msg(slot: u64, parent_slot: u64) -> Message {
+        Message::BlockMeta(Arc::new(MessageBlockMeta::from_update_oneof(
+            SubscribeUpdateBlockMeta {
+                slot,
+                parent_slot,
+                blockhash: Hash::new_unique().to_string(),
+                parent_blockhash: String::new(),
+                rewards: None,
+                block_time: None,
+                block_height: None,
+                executed_transaction_count: 0,
+                entries_count: 0,
+            },
+            ts(),
+        )))
+    }
+
+    fn make_block_meta_arc(slot: u64, parent_slot: u64) -> Arc<MessageBlockMeta> {
+        Arc::new(MessageBlockMeta::from_update_oneof(
+            SubscribeUpdateBlockMeta {
+                slot,
+                parent_slot,
+                blockhash: Hash::new_unique().to_string(),
+                parent_blockhash: String::new(),
+                rewards: None,
+                block_time: None,
+                block_height: None,
+                executed_transaction_count: 0,
+                entries_count: 0,
+            },
+            ts(),
+        ))
+    }
+
+    /// Drives a slot through the full FirstShredReceived → Completed → BlockMeta → Processed
+    /// pipeline. Adds a dummy entry so the slot appears in `processing_slots` and thus
+    /// survives into `replayed_slot` after the block is frozen.
+    fn drive_slot_to_processed(storage: &mut BlockMachineStorage, slot: u64, parent: Option<u64>) {
+        storage.add(make_slot_msg(slot, parent, SlotStatus::FirstShredReceived));
+        storage.add(make_slot_msg(slot, parent, SlotStatus::Completed));
+        storage.add(make_entry_msg(slot, 0));
+        storage.add(make_block_meta_msg(slot, parent.unwrap_or(0)));
+        storage.add(make_slot_msg(slot, parent, SlotStatus::Processed));
+    }
+
+    // ─── ProcessingSlot ──────────────────────────────────────────────────────
+
+    #[test]
+    fn processing_slot_tracks_max_write_version_per_pubkey() {
+        let pubkey = Pubkey::new_unique();
+        let mut slot = ProcessingSlot::default();
+
+        slot.add_event(make_account_msg(1, pubkey, 3));
+        slot.add_event(make_account_msg(1, pubkey, 7)); // new max
+        slot.add_event(make_account_msg(1, pubkey, 2)); // below current max, ignored
+
+        assert_eq!(slot.account_write_version_map[&pubkey], 7);
+        // All three messages still buffered (dedup happens in into_block, not here)
+        assert_eq!(slot.original_messages.len(), 3);
+    }
+
+    #[test]
+    fn processing_slot_into_block_keeps_only_highest_write_version() {
+        let pubkey = Pubkey::new_unique();
+        let mut slot = ProcessingSlot::default();
+        slot.add_event(make_account_msg(1, pubkey, 1));
+        slot.add_event(make_account_msg(1, pubkey, 5)); // winner
+
+        let frozen = slot.into_block(make_block_meta_arc(1, 0));
+        let msgs = frozen.messages();
+        let accounts: Vec<_> = msgs
+            .iter()
+            .filter_map(|m| {
+                if let Message::Account(a) = m {
+                    Some(a)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(accounts.len(), 1, "only one account should survive dedup");
+        assert_eq!(accounts[0].account.write_version, 5);
+    }
+
+    #[test]
+    fn processing_slot_into_block_deduplicates_independently_per_pubkey() {
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+        let mut slot = ProcessingSlot::default();
+
+        slot.add_event(make_account_msg(1, pk1, 1));
+        slot.add_event(make_account_msg(1, pk1, 4)); // pk1 winner
+        slot.add_event(make_account_msg(1, pk2, 9)); // pk2 only entry
+
+        let frozen = slot.into_block(make_block_meta_arc(1, 0));
+        let msgs = frozen.messages();
+        let accounts: Vec<_> = msgs
+            .iter()
+            .filter_map(|m| {
+                if let Message::Account(a) = m {
+                    Some(a)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(accounts.len(), 2);
+        let mut versions: Vec<u64> = accounts.iter().map(|a| a.account.write_version).collect();
+        versions.sort_unstable();
+        assert_eq!(versions, [4, 9]);
+    }
+
+    #[test]
+    fn processing_slot_into_block_keeps_all_transactions() {
+        let mut slot = ProcessingSlot::default();
+        slot.add_event(make_transaction_msg(1));
+        slot.add_event(make_transaction_msg(1));
+
+        let frozen = slot.into_block(make_block_meta_arc(1, 0));
+        let tx_count = frozen
+            .messages()
+            .iter()
+            .filter(|m| matches!(m, Message::Transaction(_)))
+            .count();
+        assert_eq!(tx_count, 2);
+    }
+
+    #[test]
+    fn processing_slot_into_block_keeps_all_entries() {
+        let mut slot = ProcessingSlot::default();
+        slot.add_event(make_entry_msg(1, 0));
+        slot.add_event(make_entry_msg(1, 1));
+        slot.add_event(make_entry_msg(1, 2));
+
+        let frozen = slot.into_block(make_block_meta_arc(1, 0));
+        let entry_count = frozen
+            .messages()
+            .iter()
+            .filter(|m| matches!(m, Message::Entry(_)))
+            .count();
+        assert_eq!(entry_count, 3);
+    }
+
+    #[test]
+    fn processing_slot_add_event_ignores_non_block_data() {
+        let mut slot = ProcessingSlot::default();
+        // Slot and Block messages are not block data — add_event should ignore them
+        slot.add_event(make_slot_msg(1, None, SlotStatus::Processed));
+        assert_eq!(slot.original_messages.len(), 0);
+    }
+
+    #[test]
+    fn frozen_block_message_block_reflects_deduplication() {
+        let pubkey = Pubkey::new_unique();
+        let mut slot = ProcessingSlot::default();
+        slot.add_event(make_account_msg(1, pubkey, 2));
+        slot.add_event(make_account_msg(1, pubkey, 8)); // winner
+
+        let frozen = slot.into_block(make_block_meta_arc(1, 0));
+        let mb = frozen.get_message_block();
+        assert_eq!(mb.accounts.len(), 1);
+        assert_eq!(mb.updated_account_count, 1);
+        assert_eq!(mb.accounts[0].write_version, 8);
+    }
+
+    // ─── cmp_commitment_level ────────────────────────────────────────────────
+
+    #[test]
+    fn cmp_commitment_level_total_ordering() {
+        use {solana_commitment_config::CommitmentLevel as CL, std::cmp::Ordering::*};
+
+        assert_eq!(cmp_commitment_level(CL::Processed, CL::Processed), Equal);
+        assert_eq!(cmp_commitment_level(CL::Confirmed, CL::Confirmed), Equal);
+        assert_eq!(cmp_commitment_level(CL::Finalized, CL::Finalized), Equal);
+
+        assert_eq!(cmp_commitment_level(CL::Processed, CL::Confirmed), Less);
+        assert_eq!(cmp_commitment_level(CL::Processed, CL::Finalized), Less);
+        assert_eq!(cmp_commitment_level(CL::Confirmed, CL::Finalized), Less);
+
+        assert_eq!(cmp_commitment_level(CL::Confirmed, CL::Processed), Greater);
+        assert_eq!(cmp_commitment_level(CL::Finalized, CL::Processed), Greater);
+        assert_eq!(cmp_commitment_level(CL::Finalized, CL::Confirmed), Greater);
+    }
+
+    // ─── BlockMachineStorage ─────────────────────────────────────────────────
+
+    #[test]
+    fn block_machine_storage_starts_with_no_min_slot_and_empty_queue() {
+        let mut storage = BlockMachineStorage::new(10);
+        assert!(storage.min_replayable_slot().is_none());
+        assert!(storage.pop_ready_block().is_none());
+    }
+
+    #[test]
+    fn block_machine_storage_full_lifecycle_to_processed() {
+        let mut storage = BlockMachineStorage::new(10);
+        drive_slot_to_processed(&mut storage, 1, None);
+
+        let (status, _frozen) = storage.pop_ready_block().expect("block should be ready");
+        assert_eq!(status.slot, 1);
+        assert_eq!(status.commitment, CommitmentLevel::Processed);
+        assert!(storage.pop_ready_block().is_none(), "no more ready blocks");
+        assert_eq!(storage.min_replayable_slot(), Some(1));
+    }
+
+    #[test]
+    fn block_machine_storage_account_deduplication_end_to_end() {
+        let pubkey = Pubkey::new_unique();
+        let mut storage = BlockMachineStorage::new(10);
+
+        storage.add(make_slot_msg(1, None, SlotStatus::FirstShredReceived));
+        storage.add(make_slot_msg(1, None, SlotStatus::Completed));
+        storage.add(make_account_msg(1, pubkey, 2));
+        storage.add(make_account_msg(1, pubkey, 9)); // winner
+        storage.add(make_block_meta_msg(1, 0));
+        storage.add(make_slot_msg(1, None, SlotStatus::Processed));
+
+        let (_, frozen) = storage.pop_ready_block().expect("ready block");
+        let msgs = frozen.messages();
+        let accounts: Vec<_> = msgs
+            .iter()
+            .filter_map(|m| {
+                if let Message::Account(a) = m {
+                    Some(a)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].account.write_version, 9);
+    }
+
+    #[test]
+    fn block_machine_storage_fills_missing_commitment_levels() {
+        // Jump straight to Finalized without prior Processed/Confirmed.
+        // BlocksStateMachine must synthesize Processed → Confirmed → Finalized.
+        let mut storage = BlockMachineStorage::new(10);
+
+        storage.add(make_slot_msg(1, None, SlotStatus::FirstShredReceived));
+        storage.add(make_slot_msg(1, None, SlotStatus::Completed));
+        storage.add(make_entry_msg(1, 0));
+        storage.add(make_block_meta_msg(1, 0));
+        storage.add(make_slot_msg(1, None, SlotStatus::Finalized));
+
+        let expected = [
+            CommitmentLevel::Processed,
+            CommitmentLevel::Confirmed,
+            CommitmentLevel::Finalized,
+        ];
+        for expected_cl in expected {
+            let (status, _) = storage.pop_ready_block().expect("ready block");
+            assert_eq!(
+                status.commitment, expected_cl,
+                "expected {expected_cl:?} but got {:?}",
+                status.commitment
+            );
+        }
+        assert!(storage.pop_ready_block().is_none());
+    }
+
+    #[test]
+    fn block_machine_storage_replay_excludes_slots_below_min_commitment() {
+        let mut storage = BlockMachineStorage::new(10);
+        drive_slot_to_processed(&mut storage, 1, None);
+        // Drain the ready queue
+        storage.pop_ready_block();
+
+        // Slot 1 only reached Processed; min_commitment=Confirmed should exclude it
+        let replayed: Vec<_> = storage
+            .replay_from_slot(1, CommitmentLevel::Confirmed)
+            .collect();
+        assert!(
+            replayed.is_empty(),
+            "Processed-only slot must not appear when replaying at Confirmed"
+        );
+    }
+
+    #[test]
+    fn block_machine_storage_replay_includes_slot_at_exact_commitment() {
+        let mut storage = BlockMachineStorage::new(10);
+        drive_slot_to_processed(&mut storage, 1, None);
+        storage.pop_ready_block();
+
+        let replayed: Vec<_> = storage
+            .replay_from_slot(1, CommitmentLevel::Processed)
+            .collect();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(
+            replayed[0].slot_status_messages[0].commitment,
+            CommitmentLevel::Processed
+        );
+    }
+
+    #[test]
+    fn block_machine_storage_replay_includes_finalized_slot_when_min_is_confirmed() {
+        let mut storage = BlockMachineStorage::new(10);
+
+        // Drive slot 1 all the way to Finalized (gap-filling gives Processed+Confirmed+Finalized)
+        storage.add(make_slot_msg(1, None, SlotStatus::FirstShredReceived));
+        storage.add(make_slot_msg(1, None, SlotStatus::Completed));
+        storage.add(make_entry_msg(1, 0));
+        storage.add(make_block_meta_msg(1, 0));
+        storage.add(make_slot_msg(1, None, SlotStatus::Finalized));
+        // Drain ready queue
+        while storage.pop_ready_block().is_some() {}
+
+        // Even though we asked for Confirmed minimum, a Finalized slot satisfies it
+        let replayed: Vec<_> = storage
+            .replay_from_slot(1, CommitmentLevel::Confirmed)
+            .collect();
+        assert_eq!(replayed.len(), 1);
+    }
+
+    #[test]
+    fn block_machine_storage_entry_messages_preserved_in_frozen_block() {
+        let mut storage = BlockMachineStorage::new(10);
+
+        storage.add(make_slot_msg(1, None, SlotStatus::FirstShredReceived));
+        storage.add(make_slot_msg(1, None, SlotStatus::Completed));
+        storage.add(make_entry_msg(1, 0));
+        storage.add(make_entry_msg(1, 1));
+        storage.add(make_block_meta_msg(1, 0));
+        storage.add(make_slot_msg(1, None, SlotStatus::Processed));
+
+        let (_, frozen) = storage.pop_ready_block().expect("ready block");
+        let entry_count = frozen
+            .messages()
+            .iter()
+            .filter(|m| matches!(m, Message::Entry(_)))
+            .count();
+        assert_eq!(entry_count, 2);
+    }
+}

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -737,6 +737,8 @@ impl GrpcService {
         const PROCESSED_MESSAGES_MAX: usize = 31;
 
         let mut processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
+        let mut confirmed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
+        let mut finalized_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
 
         let (_tx, rx) = mpsc::channel(1);
         let mut replay_stored_slots_rx = replay_stored_slots_rx.unwrap_or(rx);
@@ -763,18 +765,21 @@ impl GrpcService {
                         metrics::message_queue_size_dec();
 
                         buffered_messages.push(message);
-
                         if buffered_messages.len() >= PROCESSED_MESSAGES_MAX {
                             break;
                         }
                     }
-                    let mut confirmed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-                    let mut finalized_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
 
                     for message in buffered_messages.drain(..) {
                         block_machine.add(message.clone());
 
-                        match &message {
+                        if let Some(blocks_meta_tx) = &blocks_meta_tx {
+                            if matches!(&message, Message::Slot(_) | Message::BlockMeta(_)) {
+                                let _ = blocks_meta_tx.send(message.clone());
+                            }
+                        }
+
+                        match message {
                             Message::Slot(slot_message) => {
                                 metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
                                 // Only match on slot lifecycle update not commitment update, as
@@ -787,35 +792,33 @@ impl GrpcService {
                                 ) {
                                     processed_messages.push(Message::Slot(slot_message.clone()));
                                     confirmed_messages.push(Message::Slot(slot_message.clone()));
-                                    finalized_messages.push(Message::Slot(slot_message.clone()));
+                                    finalized_messages.push(Message::Slot(slot_message));
                                 }
                             }
                             Message::Account(_) | Message::BlockMeta(_) | Message::Transaction(_) | Message::Entry(_) => {
-                                processed_messages.push(message.clone());
+                                processed_messages.push(message);
                             }
                             Message::Block(_) => {
                                unreachable!("Block message should not be sent by plugin directly, it is constructed in geyser loop after receiving all necessary messages for the slot and then broadcasted to subscribers");
                             }
                         }
-                        if let Some(blocks_meta_tx) = &blocks_meta_tx {
-                            if matches!(&message, Message::Slot(_) | Message::BlockMeta(_)) {
-                                let _ = blocks_meta_tx.send(message.clone());
-                            }
-                        }
                     }
-
-                    encode_messages(&processed_messages);
-
 
                     if !processed_messages.is_empty() {
+                        encode_messages(&processed_messages);
                         GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
-                        let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(std::mem::take(&mut processed_messages))));
+                        let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(processed_messages)));
+                        processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
                     }
-                    for message in confirmed_messages {
-                        let _ = broadcast_tx.send((CommitmentLevel::Confirmed, Arc::new(vec![message])));
+
+                    if !confirmed_messages.is_empty() {
+                        let _ = broadcast_tx.send((CommitmentLevel::Confirmed, Arc::new(confirmed_messages)));
+                        confirmed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
                     }
-                    for message in finalized_messages {
-                        let _ = broadcast_tx.send((CommitmentLevel::Finalized, Arc::new(vec![message])));
+
+                    if !finalized_messages.is_empty() {
+                        let _ = broadcast_tx.send((CommitmentLevel::Finalized, Arc::new(finalized_messages)));
+                        finalized_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
                     }
 
                     while let Some((slot_update, frozen_block)) = block_machine.pop_ready_block() {

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -16,8 +16,8 @@ use {
                 Filter,
             },
             message::{
-                CommitmentLevel, Message, MessageBlock, MessageBlockMeta, MessageEntry,
-                MessageSlot, MessageTransactionInfo, SlotStatus,
+                CommitmentLevel, Message, MessageBlockMeta,
+                MessageSlot, SlotStatus,
             },
             proto::geyser_server::{Geyser, GeyserServer},
         },
@@ -29,11 +29,9 @@ use {
     bytesize::ByteSize,
     log::{error, info},
     prost_types::Timestamp,
-    smallvec::SmallVec,
     solana_clock::{Slot, MAX_RECENT_BLOCKHASHES},
-    solana_pubkey::Pubkey,
     std::{
-        collections::{BTreeMap, HashMap},
+        collections::HashMap,
         net::SocketAddr,
         os::unix::fs::PermissionsExt,
         path::PathBuf,

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        block_reconstruction::BlockMachineStorage,
         config::{ConfigGrpc, GrpcAddress},
         metered::MeteredLayer,
         metrics::{
@@ -60,14 +61,12 @@ use {
         Request, Response, Result as TonicResult, Status, Streaming,
     },
     tonic_health::{pb::health_server::HealthServer, server::health_reporter},
-    yellowstone_grpc_proto::{
-        prelude::{
-            CommitmentLevel as CommitmentLevelProto, GetBlockHeightRequest, GetBlockHeightResponse,
-            GetLatestBlockhashRequest, GetLatestBlockhashResponse, GetSlotRequest, GetSlotResponse,
-            GetVersionRequest, GetVersionResponse, IsBlockhashValidRequest,
-            IsBlockhashValidResponse, PingRequest, PongResponse, SubscribeDeshredRequest,
-            SubscribeReplayInfoRequest, SubscribeReplayInfoResponse, SubscribeRequest,
-        },
+    yellowstone_grpc_proto::prelude::{
+        CommitmentLevel as CommitmentLevelProto, GetBlockHeightRequest, GetBlockHeightResponse,
+        GetLatestBlockhashRequest, GetLatestBlockhashResponse, GetSlotRequest, GetSlotResponse,
+        GetVersionRequest, GetVersionResponse, IsBlockhashValidRequest, IsBlockhashValidResponse,
+        PingRequest, PongResponse, SubscribeDeshredRequest, SubscribeReplayInfoRequest,
+        SubscribeReplayInfoResponse, SubscribeRequest,
     },
 };
 
@@ -276,84 +275,10 @@ impl BlockMetaStorage {
     }
 }
 
-#[derive(Debug, Default)]
-struct MessageId {
-    id: u64,
-}
-
-impl MessageId {
-    const fn next(&mut self) -> u64 {
-        self.id = self.id.checked_add(1).expect("message id overflow");
-        self.id
-    }
-}
-
-#[derive(Debug, Default)]
-struct SlotMessages {
-    messages: Vec<Option<(u64, Message)>>, // Option is used for accounts with low write_version
-    messages_slots: Vec<(u64, Message)>,
-    block_meta: Option<Arc<MessageBlockMeta>>,
-    transactions: Vec<Arc<MessageTransactionInfo>>,
-    accounts_dedup: HashMap<Pubkey, (u64, usize)>, // (write_version, message_index)
-    entries: Vec<Arc<MessageEntry>>,
-    sealed: bool,
-    entries_count: usize,
-    confirmed_at: Option<usize>,
-    finalized_at: Option<usize>,
-    parent_slot: Option<Slot>,
-    confirmed: bool,
-    finalized: bool,
-}
-
-impl SlotMessages {
-    pub fn try_seal(&mut self, msgid_gen: &mut MessageId) -> Option<(u64, Message)> {
-        if !self.sealed {
-            if let Some(block_meta) = &self.block_meta {
-                let executed_transaction_count = block_meta.executed_transaction_count as usize;
-                let entries_count = block_meta.entries_count as usize;
-
-                // Additional check `entries_count == 0` due to bug of zero entries on block produced by validator
-                // See GitHub issue: https://github.com/solana-labs/solana/issues/33823
-                if self.transactions.len() == executed_transaction_count
-                    && (entries_count == 0 || self.entries.len() == entries_count)
-                {
-                    let transactions = std::mem::take(&mut self.transactions);
-                    let mut entries = std::mem::take(&mut self.entries);
-                    if entries_count == 0 {
-                        entries.clear();
-                    }
-
-                    let mut accounts = Vec::with_capacity(self.messages.len());
-                    for item in self.messages.iter().flatten() {
-                        if let (_msgid, Message::Account(account)) = item {
-                            accounts.push(Arc::clone(&account.account));
-                        }
-                    }
-
-                    let message_block = Message::Block(Arc::new(MessageBlock::new(
-                        Arc::clone(block_meta),
-                        transactions,
-                        accounts,
-                        entries,
-                    )));
-                    let message = (msgid_gen.next(), message_block);
-                    self.messages.push(Some(message.clone()));
-
-                    self.sealed = true;
-                    self.entries_count = entries_count;
-                    return Some(message);
-                }
-            }
-        }
-
-        None
-    }
-}
-
-type BroadcastedMessage = (CommitmentLevel, Arc<Vec<(u64, Message)>>);
+type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
 
 enum ReplayedResponse {
-    Messages(Vec<(u64, Message)>),
+    Messages(Vec<Message>),
     Lagged(Slot),
 }
 
@@ -736,6 +661,73 @@ impl GrpcService {
         Ok((snapshot_tx, messages_tx))
     }
 
+    /// Core message routing loop that reconstructs Solana blocks from raw Geyser plugin events
+    /// and fans them out to subscribers at the correct commitment levels.
+    ///
+    /// # Slot status semantics
+    ///
+    /// Slot messages come in two categories with different routing rules:
+    ///
+    /// **Lifecycle statuses** (`FirstShredReceived`, `Completed`, `CreatedBank`, `Dead`):
+    /// Broadcast immediately to **all three** commitment levels (Processed, Confirmed, Finalized).
+    /// These are not commitment signals — they describe the physical state of the slot and must
+    /// reach every subscriber regardless of the commitment level they subscribed at, so they can
+    /// track slot lifecycle and detect skipped slots.
+    ///
+    /// **Commitment statuses** (`Processed`, `Confirmed`, `Finalized`):
+    /// Never broadcast directly when received from the plugin. They are fed into `BlockMachineStorage`
+    /// which holds them until the block is fully assembled. Once the block is frozen, the synthetic
+    /// slot message is broadcast to **all three** commitment levels. This guarantees that no
+    /// subscriber sees a commitment status before the block content for that slot.
+    ///
+    /// # Block content delivery
+    ///
+    /// When a block becomes ready at commitment level C (`pop_ready_block`):
+    /// 1. If C is Confirmed or Finalized: `frozen_block.messages()` (the complete, deduplicated
+    ///    set of Account/Transaction/Entry messages for that slot) is sent at level C first.
+    ///    This is omitted at Processed because those messages were already delivered individually
+    ///    as they arrived.
+    /// 2. `Message::Block` (the precomputed block summary) is sent at level C.
+    /// 3. The synthetic Processed/Confirmed/Finalized slot status message is sent to all three
+    ///    commitment levels.
+    ///
+    /// This ordering guarantee — block content before `Message::Block` before slot status — must
+    /// be preserved so that subscribers always observe a complete block before the commitment signal.
+    ///
+    /// # Account deduplication
+    ///
+    /// Within a slot, if multiple updates arrive for the same account pubkey, only the update with
+    /// the highest `write_version` is retained in the frozen block. This is handled internally by
+    /// `BlockMachineStorage` / `ProcessingSlot` and must not be bypassed.
+    ///
+    /// # Missing commitment level gap-filling
+    ///
+    /// If a higher commitment level arrives without a prior lower one (e.g. Finalized before
+    /// Confirmed), `BlocksStateMachine` synthesizes the missing levels in order
+    /// (Processed → Confirmed → Finalized). Each synthesized level causes a separate
+    /// `pop_ready_block` entry and a separate fan-out.
+    ///
+    /// # Ancestor slot propagation
+    ///
+    /// When a descendant slot is finalized, `BlocksStateMachine` retroactively finalizes all
+    /// ancestor slots that were not yet finalized. This mirrors the parent-chain walk that
+    /// `geyser_loop` performs manually. It must not be short-circuited.
+    ///
+    /// # Batching and metrics
+    ///
+    /// Up to `PROCESSED_MESSAGES_MAX` messages are drained from `messages_rx` per iteration
+    /// to amortise channel overhead. Before each Processed broadcast, `encode_messages` pre-encodes
+    /// Account and Transaction payloads (stored in a `OnceLock` on the shared `Arc`) so that
+    /// per-client serialisation is avoided. `GEYSER_BATCH_SIZE` is observed for each Processed
+    /// broadcast.
+    ///
+    /// # Side channels
+    ///
+    /// - `blocks_meta_tx`: receives every `Slot` and `BlockMeta` message verbatim for external
+    ///   consumers that track block metadata independently of the main broadcast.
+    /// - `replay_stored_slots_rx`: services replay requests from newly-connected subscribers.
+    ///   `replay_first_available_slot` is updated after every batch to reflect the oldest slot
+    ///   still available in the replay buffer, and is exposed via `subscribe_first_available_slot`.
     async fn geyser_loop(
         mut messages_rx: mpsc::UnboundedReceiver<Message>,
         blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
@@ -746,18 +738,18 @@ impl GrpcService {
     ) {
         const PROCESSED_MESSAGES_MAX: usize = 31;
 
-        /// Slots retained beyond replay buffer for parent chain status propagation
-        /// and late-arriving block_meta messages.
-        const FINALIZATION_SAFETY_BUFFER: u64 = 10;
-
-        let mut msgid_gen = MessageId::default();
-        let mut messages: BTreeMap<u64, SlotMessages> = Default::default();
         let mut processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-        let mut processed_first_slot = None;
+
         let (_tx, rx) = mpsc::channel(1);
         let mut replay_stored_slots_rx = replay_stored_slots_rx.unwrap_or(rx);
         let mut buffered_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
 
+        let mut block_machine = BlockMachineStorage::new(replay_stored_slots as usize);
+        const ALL_COMMITMENT_LEVELS: [CommitmentLevel; 3] = [
+            CommitmentLevel::Processed,
+            CommitmentLevel::Confirmed,
+            CommitmentLevel::Finalized,
+        ];
         loop {
             tokio::select! {
                 maybe = messages_rx.recv() => {
@@ -766,332 +758,149 @@ impl GrpcService {
                         break;
                     };
                     metrics::message_queue_size_dec();
-                    let msgid = msgid_gen.next();
 
-                    buffered_messages.push((msgid, message));
+                    buffered_messages.push(message);
 
                     while let Ok(message) = messages_rx.try_recv() {
                         metrics::message_queue_size_dec();
 
-                        let msgid = msgid_gen.next();
-                        buffered_messages.push((msgid, message));
+                        buffered_messages.push(message);
 
                         if buffered_messages.len() >= PROCESSED_MESSAGES_MAX {
                             break;
                         }
                     }
+                    let mut confirmed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
+                    let mut finalized_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
 
-                    let batch_length = buffered_messages.len();
-                    for (index, (msgid, message)) in buffered_messages.drain(..).enumerate() {
+                    for message in buffered_messages.drain(..) {
+                        block_machine.add(message.clone());
 
-                        // Update metrics
-                        if let Message::Slot(slot_message) = &message {
-                            metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
+                        match &message {
+                            Message::Slot(slot_message) => {
+                                metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
+                                // Only match on slot lifecycle update not commitment update, as
+                                // we must go through the block machine to make sure users sees block content before any commitment update.
+                                if matches!(slot_message.status,
+                                    SlotStatus::FirstShredReceived |
+                                    SlotStatus::Completed |
+                                    SlotStatus::CreatedBank |
+                                    SlotStatus::Dead
+                                ) {
+                                    processed_messages.push(Message::Slot(slot_message.clone()));
+                                    confirmed_messages.push(Message::Slot(slot_message.clone()));
+                                    finalized_messages.push(Message::Slot(slot_message.clone()));
+                                }
+                            }
+                            Message::Account(_) | Message::BlockMeta(_) | Message::Transaction(_) | Message::Entry(_) => {
+                                processed_messages.push(message.clone());
+                            }
+                            Message::Block(_) => {
+                               unreachable!("Block message should not be sent by plugin directly, it is constructed in geyser loop after receiving all necessary messages for the slot and then broadcasted to subscribers");
+                            }
                         }
-
-                        // Update blocks info
                         if let Some(blocks_meta_tx) = &blocks_meta_tx {
                             if matches!(&message, Message::Slot(_) | Message::BlockMeta(_)) {
                                 let _ = blocks_meta_tx.send(message.clone());
                             }
                         }
+                    }
 
-                        // Remove outdated block reconstruction info
-                        match &message {
-                            // On startup we can receive multiple Confirmed/Finalized slots without BlockMeta message
-                            // With saved first Processed slot we can ignore errors caused by startup process
-                            Message::Slot(msg) if processed_first_slot.is_none() && msg.status == SlotStatus::Processed => {
-                                processed_first_slot = Some(msg.slot);
-                            }
-                            Message::Slot(msg) if msg.status == SlotStatus::Finalized => {
-                                // keep extra 10 slots + slots for replay
-                                if let Some(msg_slot) = msg.slot.checked_sub(FINALIZATION_SAFETY_BUFFER + replay_stored_slots) {
-                                    loop {
-                                        match messages.keys().next().cloned() {
-                                            Some(slot) if slot < msg_slot => {
-                                                if let Some(slot_messages) = messages.remove(&slot) {
-                                                    match processed_first_slot {
-                                                        Some(processed_first) if slot <= processed_first => continue,
-                                                        None => continue,
-                                                        _ => {}
-                                                    }
+                    encode_messages(&processed_messages);
 
-                                                    if !slot_messages.sealed && slot_messages.finalized_at.is_some() {
-                                                        let mut reasons = vec![];
-                                                        if let Some(block_meta) = slot_messages.block_meta {
-                                                            let block_txn_count = block_meta.executed_transaction_count as usize;
-                                                            let msg_txn_count = slot_messages.transactions.len();
-                                                            if block_txn_count != msg_txn_count {
-                                                                reasons.push("InvalidTxnCount");
-                                                                error!("failed to reconstruct #{slot} -- tx count: {block_txn_count} vs {msg_txn_count}");
-                                                            }
-                                                            let block_entries_count = block_meta.entries_count as usize;
-                                                            let msg_entries_count = slot_messages.entries.len();
-                                                            if block_entries_count != msg_entries_count {
-                                                                reasons.push("InvalidEntriesCount");
-                                                                error!("failed to reconstruct #{slot} -- entries count: {block_entries_count} vs {msg_entries_count}");
-                                                            }
-                                                        } else {
-                                                            reasons.push("NoBlockMeta");
-                                                        }
-                                                        let reason = reasons.join(",");
 
-                                                        metrics::update_invalid_blocks(format!("failed reconstruct {reason}"));
-                                                    }
-                                                }
-                                            }
-                                            _ => break,
-                                        }
-                                    }
-                                    if let Some(stored) = &replay_first_available_slot {
-                                        if let Some(slot) = messages.keys().next().copied() {
-                                            stored.store(slot, Ordering::Relaxed);
-                                        }
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
+                    if !processed_messages.is_empty() {
+                        GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
+                        let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(std::mem::take(&mut processed_messages))));
+                    }
+                    for message in confirmed_messages {
+                        let _ = broadcast_tx.send((CommitmentLevel::Confirmed, Arc::new(vec![message])));
+                    }
+                    for message in finalized_messages {
+                        let _ = broadcast_tx.send((CommitmentLevel::Finalized, Arc::new(vec![message])));
+                    }
 
-                        // Update block reconstruction info
-                        let slot_messages = messages.entry(message.get_slot()).or_default();
-                        if let Message::Slot(msg) = &message {
-                            match msg.status {
-                                SlotStatus::Processed => {
-                                    slot_messages.parent_slot = msg.parent;
-                                },
-                                SlotStatus::Confirmed => {
-                                    slot_messages.confirmed = true;
-                                },
-                                SlotStatus::Finalized => {
-                                    slot_messages.finalized = true;
-                                },
-                                _ => {}
-                            }
-                        }
-                        if matches!(&message, Message::Slot(_)) {
-                            slot_messages.messages_slots.push((msgid, message.clone()));
-                        } else {
-                            slot_messages.messages.push(Some((msgid, message.clone())));
-
-                            // If we already build Block message, new message will be a problem
-                            if slot_messages.sealed && !(matches!(&message, Message::Entry(_)) && slot_messages.entries_count == 0) {
-                                let kind = match &message {
-                                    Message::Slot(_) => "Slot",
-                                    Message::Account(_) => "Account",
-                                    Message::Transaction(_) => "Transaction",
-                                    Message::Entry(_) => "Entry",
-                                    Message::BlockMeta(_) => "BlockMeta",
-                                    Message::Block(_) => "Block",
-                                };
-                                metrics::update_invalid_blocks(format!("unexpected message {kind}"));
-                            }
-                        }
-                        let mut sealed_block_msg = None;
-                        match &message {
-                            Message::BlockMeta(msg) => {
-                                if slot_messages.block_meta.is_some() {
-                                    metrics::update_invalid_blocks("unexpected message: BlockMeta (duplicate)");
-                                }
-                                slot_messages.block_meta = Some(Arc::clone(msg));
-                                sealed_block_msg = slot_messages.try_seal(&mut msgid_gen);
-                            }
-                            Message::Transaction(msg) => {
-                                slot_messages.transactions.push(Arc::clone(&msg.transaction));
-                                sealed_block_msg = slot_messages.try_seal(&mut msgid_gen);
-                            }
-                            // Dedup accounts by max write_version
-                            Message::Account(msg) => {
-                                metrics::observe_geyser_account_update_received(msg.account.data.len());
-                                let write_version = msg.account.write_version;
-                                let msg_index = slot_messages.messages.len() - 1;
-                                if let Some(entry) = slot_messages.accounts_dedup.get_mut(&msg.account.pubkey) {
-                                    if entry.0 < write_version {
-                                        // We can replace the message, but in this case we will lose the order
-                                        slot_messages.messages[entry.1] = None;
-                                        *entry = (write_version, msg_index);
-                                    } else {
-                                        // If the new write_version is lower than the latest one, we need to drop this message
-                                        // because we would have more than 1 image in slot_messages.messages
-                                        slot_messages.messages[msg_index] = None;
-                                    }
-                                } else {
-                                    slot_messages.accounts_dedup.insert(msg.account.pubkey, (write_version, msg_index));
-                                }
-                            }
-                            Message::Entry(msg) => {
-                                slot_messages.entries.push(Arc::clone(msg));
-                                sealed_block_msg = slot_messages.try_seal(&mut msgid_gen);
-                            }
-                            _ => {}
-                        }
-
-                        // Send messages to filter (and to clients)
-                        let mut messages_vec = SmallVec::<[(u64, Message); 4]>::new();
-                        if let Some(sealed_block_msg) = sealed_block_msg {
-                            messages_vec.push(sealed_block_msg);
-                        }
-                        let slot_status = if let Message::Slot(msg) = &message {
-                            Some((msg.slot, msg.status))
-                        } else {
-                            None
+                    while let Some((slot_update, frozen_block)) = block_machine.pop_ready_block() {
+                        let commitment_level = match slot_update.commitment {
+                            solana_commitment_config::CommitmentLevel::Processed => CommitmentLevel::Processed,
+                            solana_commitment_config::CommitmentLevel::Confirmed => CommitmentLevel::Confirmed,
+                            solana_commitment_config::CommitmentLevel::Finalized => CommitmentLevel::Finalized,
                         };
-                        messages_vec.push((msgid, message));
-
-                        // sometimes we do not receive all statuses
-                        if let Some((slot, status)) = slot_status {
-                            let mut current_slot = Some(slot);
-                            while let Some((parent, Some(entry))) = current_slot
-                                .take()
-                                .and_then(|slot| messages.get(&slot))
-                                .and_then(|entry| entry.parent_slot)
-                                .map(|parent| (parent, messages.get_mut(&parent)))
-                            {
-                                if (status == SlotStatus::Confirmed && !entry.confirmed) ||
-                                    (status == SlotStatus::Finalized && !entry.finalized)
-                                {
-                                    if status == SlotStatus::Confirmed {
-                                        entry.confirmed = true;
-                                    } else if status == SlotStatus::Finalized {
-                                        entry.finalized = true;
-                                    }
-
-                                    current_slot = Some(parent);
-                                    let message_slot = Message::Slot(MessageSlot {
-                                        slot: parent,
-                                        parent: entry.parent_slot,
-                                        status,
-                                        dead_error: None,
-                                        created_at: Timestamp::from(SystemTime::now())
-                                    });
-                                    messages_vec.push((msgid_gen.next(), message_slot));
-                                    metrics::missed_status_message_inc(status);
-                                }
-                            }
+                        // Processed must be sent differently, since processed geyser event were individually sent,
+                        // we only need to send Message::Block for block subscriber downstream.
+                        // While, confirmed,finalized must be sent in the two flavors: as a stream of individual events and block.
+                        if commitment_level != CommitmentLevel::Processed {
+                            let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
                         }
-
-                        for message in messages_vec.into_iter().rev() {
-                            if let Message::Slot(slot) = &message.1 {
-                                let (mut confirmed_messages, mut finalized_messages) = match slot.status {
-                                    SlotStatus::Processed | SlotStatus::FirstShredReceived | SlotStatus::Completed | SlotStatus::CreatedBank | SlotStatus::Dead => {
-                                        (Vec::with_capacity(1), Vec::with_capacity(1))
-                                    }
-                                    SlotStatus::Confirmed => {
-                                        if let Some(slot_messages) = messages.get_mut(&slot.slot) {
-                                            if !slot_messages.sealed {
-                                                slot_messages.confirmed_at = Some(slot_messages.messages.len());
-                                            }
-                                        }
-
-                                        let vec = messages
-                                            .get(&slot.slot)
-                                            .map(|slot_messages| slot_messages.messages.iter().flatten().cloned().collect())
-                                            .unwrap_or_default();
-                                        (vec, Vec::with_capacity(1))
-                                    }
-                                    SlotStatus::Finalized => {
-                                        if let Some(slot_messages) = messages.get_mut(&slot.slot) {
-                                            if !slot_messages.sealed {
-                                                slot_messages.finalized_at = Some(slot_messages.messages.len());
-                                            }
-                                        }
-
-                                        let vec = messages
-                                            .get_mut(&slot.slot)
-                                            .map(|slot_messages| slot_messages.messages.iter().flatten().cloned().collect())
-                                            .unwrap_or_default();
-                                        (Vec::with_capacity(1), vec)
-                                    }
-                                };
-
-                                // processed
-                                processed_messages.push(message.clone());
-                                GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
-                                encode_messages(&processed_messages);
-                                let _ =
-                                    broadcast_tx.send((CommitmentLevel::Processed, processed_messages.into()));
-                                processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-
-                                // confirmed
-                                confirmed_messages.push(message.clone());
-                                let _ =
-                                    broadcast_tx.send((CommitmentLevel::Confirmed, confirmed_messages.into()));
-
-                                // finalized
-                                finalized_messages.push(message);
-                                let _ =
-                                    broadcast_tx.send((CommitmentLevel::Finalized, finalized_messages.into()));
-                            } else {
-                                let mut confirmed_messages = vec![];
-                                let mut finalized_messages = vec![];
-                                if matches!(&message.1, Message::Block(_)) {
-                                    if let Some(slot_messages) = messages.get(&message.1.get_slot()) {
-                                        if let Some(confirmed_at) = slot_messages.confirmed_at {
-                                            confirmed_messages.extend(
-                                                slot_messages.messages.as_slice()[confirmed_at..].iter().filter_map(|x| x.clone())
-                                            );
-                                        }
-                                        if let Some(finalized_at) = slot_messages.finalized_at {
-                                            finalized_messages.extend(
-                                                slot_messages.messages.as_slice()[finalized_at..].iter().filter_map(|x| x.clone())
-                                            );
-                                        }
-                                    }
-                                }
-
-                                processed_messages.push(message);
-
-                                if confirmed_messages.is_empty() && finalized_messages.is_empty() && index != batch_length - 1 {
-                                    // If we have buffered messages, we can wait for them to be processed in the same batch, so we can send bigger batches to clients and reduce the number of messages.
-                                    continue;
-                                }
-
-                                GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
-                                encode_messages(&processed_messages);
-                                let _ = broadcast_tx
-                                    .send((CommitmentLevel::Processed, processed_messages.into()));
-                                processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-
-                                if !confirmed_messages.is_empty() {
-                                    let _ =
-                                        broadcast_tx.send((CommitmentLevel::Confirmed, confirmed_messages.into()));
-                                }
-
-                                if !finalized_messages.is_empty() {
-                                    let _ =
-                                        broadcast_tx.send((CommitmentLevel::Finalized, finalized_messages.into()));
-                                }
-                            }
+                        let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
+                        let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block])));
+                        let slot_message = Message::Slot(MessageSlot {
+                            slot: slot_update.slot,
+                            parent: slot_update.parent_slot,
+                            status: match slot_update.commitment {
+                                solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
+                                solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
+                                solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
+                            },
+                            dead_error: None,
+                            created_at: Timestamp::from(SystemTime::now())
+                        });
+                        let slot_message_singleton_vec = Arc::new(vec![slot_message.clone()]);
+                        for commitment_level in ALL_COMMITMENT_LEVELS {
+                            let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
                         }
                     }
-                }
+                    let min_replayable_slot = block_machine.min_replayable_slot();
+                    if let (Some(min_slot), Some(replay_first_available_slot)) = (min_replayable_slot, replay_first_available_slot.as_ref()) {
+                        replay_first_available_slot.store(min_slot, Ordering::Relaxed);
+                    }
+                },
                 Some((commitment, replay_slot, tx)) = replay_stored_slots_rx.recv() => {
-                    if let Some((slot, _)) = messages.first_key_value() {
-                        if replay_slot < *slot {
-                            let _ = tx.send(ReplayedResponse::Lagged(*slot));
+
+                    if let Some(slot) = block_machine.min_replayable_slot() {
+                        if replay_slot < slot {
+                            let _ = tx.send(ReplayedResponse::Lagged(slot));
                             continue;
                         }
                     }
+                    let min_solana_commitment = match commitment {
+                        CommitmentLevel::Processed => solana_commitment_config::CommitmentLevel::Processed,
+                        CommitmentLevel::Confirmed => solana_commitment_config::CommitmentLevel::Confirmed,
+                        CommitmentLevel::Finalized => solana_commitment_config::CommitmentLevel::Finalized,
+                    };
 
                     let mut replayed_messages = Vec::with_capacity(32_768);
-                    for (slot, messages) in messages.iter() {
-                        if *slot >= replay_slot {
-                            replayed_messages.extend_from_slice(&messages.messages_slots);
-                            if commitment == CommitmentLevel::Processed
-                                || (commitment == CommitmentLevel::Finalized && messages.finalized)
-                                || (commitment == CommitmentLevel::Confirmed && messages.confirmed)
-                            {
-                                replayed_messages.extend(messages.messages.iter().filter_map(|v| v.clone()));
-                            }
-                        }
+                    let replayed_slot_iter = block_machine.replay_from_slot(replay_slot, min_solana_commitment);
+
+                    for replayed_slot in replayed_slot_iter {
+                        let xs = replayed_slot
+                            .slot_status_messages
+                            .iter()
+                            .map(|s| {
+                                Message::Slot(MessageSlot {
+                                    slot: s.slot,
+                                    parent: None,
+                                    status: match s.commitment {
+                                        solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
+                                        solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
+                                        solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
+                                    },
+                                    dead_error: None,
+                                    created_at: Timestamp::from(SystemTime::now())
+                                })
+                            });
+                        replayed_messages.extend(xs);
+                        replayed_messages.extend(replayed_slot.frozen_block.messages().iter().cloned());
                     }
                     let _ = tx.send(ReplayedResponse::Messages(replayed_messages));
                 }
-                else => break,
+                else => {
+                    // No new messages and replay request channel closed, can only happen on shutdown
+                    info!("Geyser loop: replay_stored_slots channel closed");
+                    break;
+                }
             }
         }
-
-        info!("Geyser loop exiting");
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1205,7 +1014,7 @@ impl GrpcService {
                                     break 'outer;
                                 }
 
-                                let mut messages = match rx.await {
+                                let messages = match rx.await {
                                     Ok(ReplayedResponse::Messages(messages)) => messages,
                                     Ok(ReplayedResponse::Lagged(slot)) => {
                                         info!("client #{id}: broadcast from {from_slot} is not available");
@@ -1228,8 +1037,7 @@ impl GrpcService {
                                     }
                                 };
 
-                                messages.sort_by_key(|msg| msg.0);
-                                for (_msgid, message) in messages.iter() {
+                                for message in messages.iter() {
                                     for message in session.filter.get_updates(message, Some(commitment)) {
                                         match stream_tx.send(Ok(message)).await {
                                             Ok(()) => {
@@ -1273,7 +1081,7 @@ impl GrpcService {
                     };
 
                     if commitment == session.filter.get_commitment_level() {
-                        for (_msgid, message) in messages.iter() {
+                        for message in messages.iter() {
                             for message in session.filter.get_updates(message, Some(commitment)) {
                                 match stream_tx.try_send(Ok(message)) {
                                     Ok(()) => {
@@ -1299,7 +1107,7 @@ impl GrpcService {
 
                     if commitment == CommitmentLevel::Processed && session.debug_client_tx.is_some() {
                         for message in messages.iter() {
-                            if let Message::Slot(slot_message) = &message.1 {
+                            if let Message::Slot(slot_message) = &message {
                                 DebugClientMessage::maybe_send(&session.debug_client_tx, || DebugClientMessage::UpdateSlot { id, slot: slot_message.slot });
                             }
                         }
@@ -1903,7 +1711,7 @@ mod tests {
             dead_error: None,
             created_at: Timestamp::from(SystemTime::now()),
         });
-        let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(vec![(1, msg)])));
+        let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(vec![msg])));
 
         tokio::time::timeout(Duration::from_secs(2), handle)
             .await

--- a/yellowstone-grpc-geyser/src/lib.rs
+++ b/yellowstone-grpc-geyser/src/lib.rs
@@ -1,3 +1,4 @@
+mod block_reconstruction;
 pub mod config;
 pub mod grpc;
 pub mod metered;

--- a/yellowstone-grpc-geyser/src/plugin/filter/encoder.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/encoder.rs
@@ -134,8 +134,8 @@ impl AccountEncoder {
     }
 }
 
-pub fn encode_messages(messages: &Vec<(u64, Message)>) {
-    for (_, msg) in messages {
+pub fn encode_messages(messages: &Vec<Message>) {
+    for msg in messages {
         match msg {
             Message::Transaction(tx) => {
                 if tx.transaction.pre_encoded.get().is_none() {


### PR DESCRIPTION
This PR remove most of the legacy code around rebuilding block and managing rooted tree, it is now entirely done using yellowstone-block-machine crate + `block_reconstruction.rs`.

The PR also make sure the `geyser_loop` preserves the ordering guarantee as the old version. A detailed docstring is present that explain every edge case.

It also removes some Arc clones and vector scans on each commitment promotion.

This PR is part of a bigger initiative to optimize the plugin, and this PR role is to simplify as much as possible the geyser loop to enable more aggressive optimization and code-reshaping.



