### PR TITLE
Declare missing protoc dependency

### DIFF
--- a/yellowstone-grpc-client-nodejs/package.json
+++ b/yellowstone-grpc-client-nodejs/package.json
@@ -60,7 +60,8 @@
     "ts-jest": "^29.4.5",
     "ts-proto": "^2.8.3",
     "typescript": "=5.9.3",
-    "@types/node": "25.0.3"
+    "@types/node": "25.0.3",
+    "protoc": "^25.9.0"
   },
   "napi": {
     "name": "yellowstone-grpc-napi",


### PR DESCRIPTION
## Summary
Declares the missing `protoc` dependency.

## Problem reproduction
The candidate reports a missing-module failure. Running `npm run build` reproduced or confirmed the missing `protoc` dependency path.

## Fix
Added `protoc` to devDependencies with the current npm version.

## Validation
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm run build`

## Known limitations
None for the scoped fix.

## Safety
This change uses only public repository/package metadata, public source files, and local validation commands.