### PR TITLE
separating messages from deshred channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## [Triton Extension Patches]
+
+## 2026-06-10
+
+- 13.2.2-triton-ext.1
+
+### misc
+
+- deshred messages are sent directly to the target broadcast channel, avoiding unnecessary hop on geyser_loop
+
 ## 2026-06-03
 
 - yellowstone-grpc-geyser 13.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "13.2.2-triton-ext"
+version = "13.2.2-triton-ext.1"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.2-triton-ext" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.2-triton-ext.1" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.4.0", default-features = false }
 
 [workspace.lints.clippy]

--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -1078,6 +1078,8 @@ async fn geyser_subscribe_deshred(
     let pb_multi = MultiProgress::new();
     let mut pb_txs_c = 0;
     let pb_txs = crate_progress_bar(&pb_multi, ProgressBarTpl::Msg("deshred transactions"))?;
+    let mut pb_slot_c = 0;
+    let pb_slot = crate_progress_bar(&pb_multi, ProgressBarTpl::Msg("deshred slots"))?;
     let mut pb_pp_c = 0;
     let pb_pp = crate_progress_bar(&pb_multi, ProgressBarTpl::Msg("ping/pong"))?;
     let mut pb_total_c = 0;
@@ -1096,7 +1098,7 @@ async fn geyser_subscribe_deshred(
                         Some(DeshredUpdateOneof::DeshredTransaction(_)) => (&mut pb_txs_c, &pb_txs),
                         Some(DeshredUpdateOneof::Ping(_)) => (&mut pb_pp_c, &pb_pp),
                         Some(DeshredUpdateOneof::Pong(_)) => (&mut pb_pp_c, &pb_pp),
-                        Some(DeshredUpdateOneof::Slot(_)) => (&mut pb_pp_c, &pb_pp),
+                        Some(DeshredUpdateOneof::Slot(_)) => (&mut pb_slot_c, &pb_slot),
                         None => {
                             pb_multi.println("update not found in the deshred message")?;
                             break;

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "13.2.2-triton-ext"
+version = "13.2.2-triton-ext.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -286,7 +286,7 @@ type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
 /// Messages broadcast on the deshred channel. Deshred is a pre-execution
 /// stream and has no commitment level: each message is emitted exactly
 /// once, when first received from the geyser plugin.
-type DeshredBroadcastedMessage = Arc<Vec<Message>>;
+type DeshredBroadcastedMessage = Message;
 
 enum ReplayedResponse {
     Messages(Vec<Message>),
@@ -529,6 +529,7 @@ impl GrpcService {
     ) -> anyhow::Result<(
         Option<crossbeam_channel::Sender<Box<Message>>>,
         mpsc::UnboundedSender<Message>,
+        broadcast::Sender<DeshredBroadcastedMessage>,
     )> {
         // Bind all configured addresses (TCP or Unix domain socket)
         let mut listeners = Vec::new();
@@ -691,13 +692,7 @@ impl GrpcService {
         }
 
         task_tracker.spawn(async move {
-            Self::geyser_loop(
-                messages_rx,
-                broadcast_tx,
-                block_reconstruction_tx,
-                deshred_broadcast_tx,
-            )
-            .await;
+            Self::geyser_loop(messages_rx, broadcast_tx, block_reconstruction_tx).await;
         });
 
         // Health check service
@@ -743,7 +738,7 @@ impl GrpcService {
             });
         }
 
-        Ok((snapshot_tx, messages_tx))
+        Ok((snapshot_tx, messages_tx, deshred_broadcast_tx))
     }
 
     /// Core message routing loop that reconstructs Solana blocks from raw Geyser plugin events
@@ -817,7 +812,6 @@ impl GrpcService {
         mut messages_rx: mpsc::UnboundedReceiver<Message>,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
         block_reconstruction_tx: mpsc::UnboundedSender<Message>,
-        deshred_broadcast_tx: broadcast::Sender<DeshredBroadcastedMessage>,
     ) {
         const PROCESSED_MESSAGES_MAX: usize = 31;
         const STATE_MESSAGES_MAX: usize = 4; /* In a reasonable loop, we don't expect to receive more than FirstShredReceived, Completed, CreatedBank, or Finalized messages per iteration */
@@ -826,11 +820,6 @@ impl GrpcService {
         let mut confirmed_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
         let mut finalized_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
 
-        /* In the future, DeshredTransactions should not be received here at all. They are just forwarded to the deshred broadcast channel.
-         * Making a hop here is completely unnecessary
-         */
-        let mut deshred_transaction = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-
         loop {
             tokio::select! {
                 maybe = messages_rx.recv() => {
@@ -838,32 +827,16 @@ impl GrpcService {
                         info!("Geyser loop: messages channel closed");
                         break;
                     };
-                    metrics::message_queue_size_dec();
 
-                    if !matches!(message, Message::DeshredTransaction(_)) {
-                        processed_messages.push(message);
-                    }
-                    else {
-                        deshred_transaction.push(message);
-                    }
+                    metrics::message_queue_size_dec();
+                    processed_messages.push(message);
 
                     while let Ok(message) = messages_rx.try_recv() {
                         metrics::message_queue_size_dec();
 
-                        /* In the future, DeshredTransactions should not be received here at all. They are just forwarded to the deshred broadcast channel.
-                         * In such a case, we wouldn't need to branch out here and end receiving early for one batch.
-                         */
-                        if !matches!(message, Message::DeshredTransaction(_)) {
-                            processed_messages.push(message);
-                            if processed_messages.len() >= PROCESSED_MESSAGES_MAX {
-                                break;
-                            }
-                        }
-                        else {
-                            deshred_transaction.push(message);
-                            if deshred_transaction.len() >= PROCESSED_MESSAGES_MAX {
-                                break;
-                            }
+                        processed_messages.push(message);
+                        if processed_messages.len() >= PROCESSED_MESSAGES_MAX {
+                            break;
                         }
                     }
 
@@ -873,8 +846,6 @@ impl GrpcService {
                         match message {
                             Message::Slot(slot_message) => {
                                 metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
-                                // Deshred transaction subscribers are interested in all slot status updates, as they need to track slot lifecycle.
-                                deshred_transaction.push(Message::Slot(slot_message.clone()));
                                 // Only match on slot lifecycle update not commitment update, as
                                 // we must go through the block machine to make sure users sees block content before any commitment update.
                                 if matches!(slot_message.status,
@@ -896,20 +867,10 @@ impl GrpcService {
                         }
                     }
 
-                    /* In the future, DeshredTransactions should not be received here at all. They are just forwarded to the deshred broadcast channel.
-                     * In such a case, we wouldn't need to check the length of processed_messages here.
-                     */
-                    if !processed_messages.is_empty() {
-                        encode_messages(&processed_messages);
-                        GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
-                        let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(processed_messages)));
-                        processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-                    }
-
-                    if !deshred_transaction.is_empty() {
-                        let _ = deshred_broadcast_tx.send(Arc::new(deshred_transaction));
-                        deshred_transaction = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-                    }
+                    encode_messages(&processed_messages);
+                    GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
+                    let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(processed_messages)));
+                    processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
 
                     if !confirmed_messages.is_empty() {
                         let _ = broadcast_tx.send((CommitmentLevel::Confirmed, Arc::new(confirmed_messages)));
@@ -1489,41 +1450,41 @@ impl GrpcService {
                     }
                 }
                 message = messages_rx.recv() => {
-                    let messages = match message {
-                        Ok(messages) => messages,
+                    let message = match message {
+                        Ok(message) => message,
                         Err(broadcast::error::RecvError::Closed) => {
                             session.disconnect_reason = "broadcast_closed";
                             break 'outer;
                         },
                         Err(broadcast::error::RecvError::Lagged(_)) => {
-                            info!("deshred client #{id}: lagged to receive geyser messages");
+                            info!("deshred client #{id}: lagged to receive deshred messages");
                             session.disconnect_reason = "client_broadcast_lag";
                             task_tracker.spawn(async move {
-                                let _ = stream_tx.send(Err(Status::internal("lagged to receive geyser messages"))).await;
+                                let _ = stream_tx.send(Err(Status::internal("lagged to receive deshred messages"))).await;
                             });
                             break 'outer;
                         }
                     };
 
-                    for message in messages.iter() {
-                        for update in session.filter.get_updates(message, None) {
-                            match stream_tx.try_send(Ok(update)) {
-                                Ok(()) => {
-                                    metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
-                                }
-                                Err(mpsc::error::TrySendError::Full(_)) => {
-                                    error!("deshred client #{id}: lagged to send an update");
-                                    session.disconnect_reason = "client_channel_full";
-                                    task_tracker.spawn(async move {
-                                        let _ = stream_tx.send(Err(Status::internal("lagged to send an update"))).await;
-                                    });
-                                    break 'outer;
-                                }
-                                Err(mpsc::error::TrySendError::Closed(_)) => {
-                                    error!("deshred client #{id}: stream closed");
-                                    session.disconnect_reason = "client_closed";
-                                    break 'outer;
-                                }
+                    metrics::deshred_queue_size_dec();
+
+                    for update in session.filter.get_updates(&message, None) {
+                        match stream_tx.try_send(Ok(update)) {
+                            Ok(()) => {
+                                metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
+                            }
+                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                error!("deshred client #{id}: lagged to send an update");
+                                session.disconnect_reason = "client_channel_full";
+                                task_tracker.spawn(async move {
+                                    let _ = stream_tx.send(Err(Status::internal("lagged to send an update"))).await;
+                                });
+                                break 'outer;
+                            }
+                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                error!("deshred client #{id}: stream closed");
+                                session.disconnect_reason = "client_closed";
+                                break 'outer;
                             }
                         }
                     }
@@ -2135,7 +2096,9 @@ mod tests {
 
         struct Harness {
             messages_tx: mpsc::UnboundedSender<Message>,
+            #[allow(dead_code)]
             broadcast_rx: broadcast::Receiver<BroadcastedMessage>,
+            deshred_tx: broadcast::Sender<DeshredBroadcastedMessage>,
             deshred_rx: broadcast::Receiver<DeshredBroadcastedMessage>,
             handle: tokio::task::JoinHandle<()>,
             handle_reconstruction: tokio::task::JoinHandle<()>,
@@ -2152,7 +2115,6 @@ mod tests {
                     messages_rx,
                     broadcast_tx,
                     block_reconstruction_tx,
-                    deshred_tx,
                 ))
             };
             let handle_reconstruction = tokio::spawn(GrpcService::block_reconstruction_loop(
@@ -2166,33 +2128,20 @@ mod tests {
             Harness {
                 messages_tx,
                 broadcast_rx,
+                deshred_tx,
                 deshred_rx,
                 handle,
                 handle_reconstruction,
             }
         }
 
-        async fn drain_main(
-            rx: &mut broadcast::Receiver<BroadcastedMessage>,
-        ) -> Vec<(CommitmentLevel, Vec<Message>)> {
-            // The processed-messages flush is driven by a 10ms sleep timer;
-            // wait long enough that any pending batch has been emitted.
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            let mut out = Vec::new();
-            while let Ok((commitment, batch)) = rx.try_recv() {
-                let msgs = batch.iter().cloned().collect();
-                out.push((commitment, msgs));
-            }
-            out
-        }
-
         async fn drain_deshred(
             rx: &mut broadcast::Receiver<DeshredBroadcastedMessage>,
-        ) -> Vec<Vec<Message>> {
+        ) -> Vec<Message> {
             tokio::time::sleep(Duration::from_millis(50)).await;
             let mut out = Vec::new();
             while let Ok(batch) = rx.try_recv() {
-                out.push(batch.iter().cloned().collect());
+                out.push(batch);
             }
             out
         }
@@ -2240,64 +2189,16 @@ mod tests {
             })
         }
 
-        fn count_deshred(messages: &[Message]) -> usize {
-            messages
-                .iter()
-                .filter(|m| matches!(m, Message::DeshredTransaction(_)))
-                .count()
-        }
-
-        fn count_slot(messages: &[Message]) -> usize {
-            messages
-                .iter()
-                .filter(|m| matches!(m, Message::Slot(_)))
-                .count()
-        }
-
         #[tokio::test]
         async fn deshred_emitted_once_on_deshred_channel() {
             let mut harness = spawn_loop();
-            harness.messages_tx.send(make_deshred(100, 1)).unwrap();
+            harness.deshred_tx.send(make_deshred(100, 1)).unwrap();
 
             let batches = drain_deshred(&mut harness.deshred_rx).await;
-            let total: usize = batches.iter().map(|b| count_deshred(b)).sum();
+            let total: usize = batches.len();
             assert_eq!(total, 1, "deshred should be emitted exactly once");
 
-            drop(harness.messages_tx);
-            let _ = tokio::time::timeout(Duration::from_secs(1), harness.handle).await;
-            let _ =
-                tokio::time::timeout(Duration::from_secs(1), harness.handle_reconstruction).await;
-        }
-
-        #[tokio::test]
-        async fn deshred_never_appears_on_main_channel() {
-            let mut harness = spawn_loop();
-            harness.messages_tx.send(make_deshred(100, 1)).unwrap();
-            // Drive Slot through Confirmed and Finalized so the main channel
-            // would historically replay any DeshredTransaction we'd stored.
-            harness
-                .messages_tx
-                .send(make_slot(100, SlotStatus::Processed, Some(99)))
-                .unwrap();
-            harness
-                .messages_tx
-                .send(make_slot(100, SlotStatus::Confirmed, None))
-                .unwrap();
-            harness
-                .messages_tx
-                .send(make_slot(100, SlotStatus::Finalized, None))
-                .unwrap();
-
-            let main_batches = drain_main(&mut harness.broadcast_rx).await;
-            for (commitment, batch) in &main_batches {
-                assert_eq!(
-                    count_deshred(batch),
-                    0,
-                    "main channel must never carry DeshredTransaction (commitment={commitment:?})"
-                );
-            }
-
-            drop(harness.messages_tx);
+            drop(harness.deshred_tx);
             let _ = tokio::time::timeout(Duration::from_secs(1), harness.handle).await;
             let _ =
                 tokio::time::timeout(Duration::from_secs(1), harness.handle_reconstruction).await;
@@ -2306,6 +2207,18 @@ mod tests {
         #[tokio::test]
         async fn slot_emitted_once_on_deshred_channel() {
             let mut harness = spawn_loop();
+            harness
+                .deshred_tx
+                .send(make_slot(100, SlotStatus::Processed, Some(99)))
+                .unwrap();
+            harness
+                .deshred_tx
+                .send(make_slot(100, SlotStatus::Confirmed, None))
+                .unwrap();
+            harness
+                .deshred_tx
+                .send(make_slot(100, SlotStatus::Finalized, None))
+                .unwrap();
             harness
                 .messages_tx
                 .send(make_slot(100, SlotStatus::Processed, Some(99)))
@@ -2320,7 +2233,7 @@ mod tests {
                 .unwrap();
 
             let deshred_batches = drain_deshred(&mut harness.deshred_rx).await;
-            let total: usize = deshred_batches.iter().map(|b| count_slot(b)).sum();
+            let total: usize = deshred_batches.len();
             assert_eq!(
                 total, 3,
                 "deshred channel should see each Slot status once (3 statuses sent => 3 emissions)"

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -61,6 +61,10 @@ lazy_static::lazy_static! {
         "message_queue_size", "Size of geyser message queue"
     ).unwrap();
 
+    static ref DESHRED_QUEUE_SIZE: IntGauge = IntGauge::new(
+        "deshred_queue_size", "Size of deshred message queue"
+    ).unwrap();
+
     static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
         "connections_total", "Total number of connections to gRPC service"
     ).unwrap();
@@ -493,8 +497,16 @@ pub fn message_queue_size_inc() {
     MESSAGE_QUEUE_SIZE.inc()
 }
 
+pub fn deshred_queue_size_inc(amount: i64) {
+    DESHRED_QUEUE_SIZE.add(amount);
+}
+
 pub fn message_queue_size_dec() {
     MESSAGE_QUEUE_SIZE.dec()
+}
+
+pub fn deshred_queue_size_dec() {
+    DESHRED_QUEUE_SIZE.dec()
 }
 
 pub fn connections_total_inc() {

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -27,7 +27,7 @@ use {
     },
     tokio::{
         runtime::{Builder, Runtime},
-        sync::mpsc,
+        sync::{broadcast, mpsc},
     },
     tokio_util::{sync::CancellationToken, task::TaskTracker},
 };
@@ -39,6 +39,7 @@ pub struct PluginInner {
     snapshot_channel_closed: AtomicBool,
     filter_limits: FilterLimits,
     grpc_channel: mpsc::UnboundedSender<Message>,
+    deshred_channel: broadcast::Sender<Message>,
     plugin_cancellation_token: CancellationToken,
     plugin_task_tracker: TaskTracker,
 }
@@ -47,6 +48,12 @@ impl PluginInner {
     fn send_message(&self, message: Message) {
         if self.grpc_channel.send(message).is_ok() {
             metrics::message_queue_size_inc();
+        }
+    }
+
+    fn send_deshred_message(&self, message: Message) {
+        if let Ok(count) = self.deshred_channel.send(message) {
+            metrics::deshred_queue_size_inc(count as i64);
         }
     }
 }
@@ -125,7 +132,7 @@ impl GeyserPlugin for Plugin {
             .await
             .map_err(|error| GeyserPluginError::Custom(Box::new(error)))?;
 
-            let (snapshot_channel, grpc_channel) = GrpcService::create(
+            let (snapshot_channel, grpc_channel, deshred_channel) = GrpcService::create(
                 config.grpc,
                 config.debug_clients_http.then_some(debug_client_tx),
                 is_reload,
@@ -134,10 +141,10 @@ impl GeyserPlugin for Plugin {
             )
             .await
             .map_err(|error| GeyserPluginError::Custom(format!("{error:?}").into()))?;
-            Ok::<_, GeyserPluginError>((snapshot_channel, grpc_channel))
+            Ok::<_, GeyserPluginError>((snapshot_channel, grpc_channel, deshred_channel))
         });
 
-        let (snapshot_channel, grpc_channel) = match result {
+        let (snapshot_channel, grpc_channel, deshred_channel) = match result {
             Ok(val) => val,
             Err(e) => {
                 log::error!("failed to start plugin services: {e}");
@@ -153,6 +160,7 @@ impl GeyserPlugin for Plugin {
             snapshot_channel_closed: AtomicBool::new(false),
             filter_limits,
             grpc_channel,
+            deshred_channel,
             plugin_cancellation_token,
             plugin_task_tracker,
         });
@@ -244,7 +252,8 @@ impl GeyserPlugin for Plugin {
     ) -> PluginResult<()> {
         self.with_inner(|inner| {
             let message = Message::Slot(MessageSlot::from_geyser(slot, parent, status));
-            inner.send_message(message);
+            inner.send_message(message.clone());
+            inner.send_deshred_message(message);
             metrics::update_slot_status(status, slot);
             Ok(())
         })
@@ -321,7 +330,7 @@ impl GeyserPlugin for Plugin {
             let message = Message::DeshredTransaction(
                 MessageDeshredTransaction::from_geyser_versioned(transaction, slot),
             );
-            inner.send_message(message);
+            inner.send_deshred_message(message);
 
             Ok(())
         })


### PR DESCRIPTION
In the previous deshred messages implementation, we would forward deshred messages to geyser_loop and then immediately forward them further to deshred_client_loop. To skip the hop of going from message -> geyser_loop -> deshred_client_loop we just directly send to the deshred_client_loop now