### PR TITLE
Blockmeta ordering fixing block reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- client: only quarantine slots pending replay verification, not live-sealed slots
+- plugin: changed order of sent messages to client such that block_meta arrives 1 index before block message
+
+## 2026-06-15
+
+- yellowstone-grpc-geyser 13.2.3
+
+### Fixes
+
 - client: auto-reconnect now quarantines replayed slots and compares blockhashes to handle the equivocation problem, preventing silent data loss when reconnecting to a node with different block content for the same slot.
 
 ## 2026-06-03

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "13.2.2"
+version = "13.2.3"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.1" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.2" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.3" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.4.0", default-features = false }
 
 [workspace.lints.clippy]

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -346,14 +346,17 @@ impl DedupState {
         for sealed in self.sealed.values_mut() {
             sealed.awaiting_replay = true;
         }
-        
+
         // Promote inflight slots to sealed-without-blockhash
         for (slot, state) in self.inflight.drain() {
-            self.sealed.insert(slot, SealedSlot {
-                blockhash: None,
-                statuses: state.statuses,
-                awaiting_replay: true,
-            });
+            self.sealed.insert(
+                slot,
+                SealedSlot {
+                    blockhash: None,
+                    statuses: state.statuses,
+                    awaiting_replay: true,
+                },
+            );
         }
     }
 

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -30,6 +30,7 @@ pub(crate) enum Observation {
 struct SealedSlot {
     blockhash: Option<String>,
     statuses: HashSet<i32>,
+    awaiting_replay: bool,
 }
 
 struct ReplayBuffer<T> {
@@ -270,9 +271,13 @@ impl DedupState {
                 // across the reconnect. If no blockhash is stored (slot was partial
                 // when we disconnected), treat as changed and flush always.
                 if let Some(sealed) = self.sealed.get_mut(&slot) {
-                    let same = sealed.blockhash.as_ref() == Some(&blockhash);
-                    sealed.blockhash = Some(blockhash);
-                    return Observation::ReplayComplete { same };
+                    if sealed.awaiting_replay {
+                        let same = sealed.blockhash.as_ref() == Some(&blockhash);
+                        sealed.blockhash = Some(blockhash);
+                        sealed.awaiting_replay = false;
+                        return Observation::ReplayComplete { same };
+                    }
+                    return Observation::Duplicate;
                 }
 
                 // First BlockMeta for this slot: seal it. The SlotState is destroyed;
@@ -283,6 +288,7 @@ impl DedupState {
                     SealedSlot {
                         blockhash: Some(blockhash),
                         statuses: state.statuses,
+                        awaiting_replay: false,
                     },
                 );
                 self.prune();
@@ -291,10 +297,21 @@ impl DedupState {
 
             // Accounts, transactions, entries, blocks, etc.
             payload => {
-                // Sealed slot: hold for quarantine. The verdict comes when the
-                // replayed BlockMeta arrives; until then we buffer without deduping.
-                if self.sealed.contains_key(&slot) {
-                    return Observation::Replay;
+                // Sealed slot: three cases depending on state.
+                // 1. Awaiting replay verification: quarantine until replayed BlockMeta verdict.
+                // 2. Block message on live path: arrives after seal, forward to user.
+                // 3. Everything else: already delivered before seal, drop as duplicate.
+                if let Some(sealed) = self.sealed.get(&slot) {
+                    if sealed.awaiting_replay {
+                        return Observation::Replay;
+                    }
+                    // Block is assembled after BlockMeta seals the slot and is never
+                    // part of replay. Forward it; other payloads were already delivered
+                    // before seal and are genuine duplicates.
+                    if matches!(payload, DedupKey::Block(_)) {
+                        return Observation::New;
+                    }
+                    return Observation::Duplicate;
                 }
 
                 let state = self.slot_mut(slot);
@@ -325,14 +342,18 @@ impl DedupState {
     /// Replayed content for these slots will be quarantined and flushed at
     /// BlockMeta (no stored blockhash to compare, so always flush).
     pub(crate) fn prepare_for_replay(&mut self) {
+        // Mark all already-sealed slots for verification
+        for sealed in self.sealed.values_mut() {
+            sealed.awaiting_replay = true;
+        }
+        
+        // Promote inflight slots to sealed-without-blockhash
         for (slot, state) in self.inflight.drain() {
-            self.sealed.insert(
-                slot,
-                SealedSlot {
-                    blockhash: None,
-                    statuses: state.statuses,
-                },
-            );
+            self.sealed.insert(slot, SealedSlot {
+                blockhash: None,
+                statuses: state.statuses,
+                awaiting_replay: true,
+            });
         }
     }
 
@@ -582,6 +603,8 @@ mod tests {
         observe(&mut dedup, &make_slot_msg(300, 0));
         observe(&mut dedup, &make_block_meta_msg(300));
 
+        dedup.prepare_for_replay(); // simulate reconnect
+
         // a replayed account for a sealed slot should be quarantined
         let account_msg = make_account_msg(300);
         assert!(matches!(
@@ -598,6 +621,8 @@ mod tests {
         observe(&mut dedup, &make_slot_msg(400, 0));
         observe(&mut dedup, &make_block_meta_msg_with_hash(400, "abc"));
 
+        dedup.prepare_for_replay();
+
         // replayed BlockMeta with same hash: same block, discard
         assert!(matches!(
             observe(&mut dedup, &make_block_meta_msg_with_hash(400, "abc")),
@@ -612,6 +637,8 @@ mod tests {
         // seal slot 500 with blockhash "block_a"
         observe(&mut dedup, &make_slot_msg(500, 0));
         observe(&mut dedup, &make_block_meta_msg_with_hash(500, "block_a"));
+
+        dedup.prepare_for_replay();
 
         // replayed BlockMeta with different hash: block changed, flush
         assert!(matches!(

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "13.2.2"
+version = "13.2.3"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -126,6 +126,10 @@ impl FrozenBlock {
     pub fn messages(&self) -> Arc<Vec<Message>> {
         Arc::clone(&self.original_messages)
     }
+
+    pub fn get_block_meta(&self) -> Arc<MessageBlockMeta> {
+        Arc::clone(&self.block_meta)
+    }
 }
 
 pub struct SlotProgression {

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -775,10 +775,20 @@ impl GrpcService {
                     };
                     metrics::message_queue_size_dec();
 
+                    if matches!(&message, Message::BlockMeta(_)) {
+                        let _ = block_reconstruction_tx.send(message);
+                        continue;
+                    }
+
                     processed_messages.push(message);
 
                     while let Ok(message) = messages_rx.try_recv() {
                         metrics::message_queue_size_dec();
+
+                        if matches!(&message, Message::BlockMeta(_)) {
+                            let _ = block_reconstruction_tx.send(message);
+                            continue;
+                        }
 
                         processed_messages.push(message);
                         if processed_messages.len() >= PROCESSED_MESSAGES_MAX {
@@ -878,6 +888,10 @@ impl GrpcService {
                         // While, confirmed,finalized must be sent in the two flavors: as a stream of individual events and block.
                         if commitment_level != CommitmentLevel::Processed {
                             let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
+                        }
+                        else {
+                            let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
+                            let _ = broadcast_tx.send((commitment_level, Arc::new(vec![block_meta])));
                         }
                         let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
                         let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block])));


### PR DESCRIPTION
The current code does not properly order BlockMeta messages, and as such we are breaking client compatibility