### PR TITLE
blockmeta ordering fixes + prometheus invalid block transactions log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- client: reverted to 13.1.0 from 13.1.1
+- plugin: changed order of sent messages to client such that block_meta arrives after block message
+
+## 2026-06-16
+
+- yellowstone-grpc-geyser 13.2.4
+
+### Fixes
+
 - client: only quarantine slots pending replay verification, not live-sealed slots
 - plugin: changed order of sent messages to client such that block_meta arrives 1 index before block message
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "13.1.1"
+version = "13.1.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "13.2.3"
+version = "13.2.4"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ spl-token-2022-interface = "2.1.0"
 
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
-yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.1" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.3" }
+yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.4" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.4.0", default-features = false }
 
 [workspace.lints.clippy]

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "13.1.1"
+version = "13.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Simple Client"

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -30,7 +30,6 @@ pub(crate) enum Observation {
 struct SealedSlot {
     blockhash: Option<String>,
     statuses: HashSet<i32>,
-    awaiting_replay: bool,
 }
 
 struct ReplayBuffer<T> {
@@ -271,13 +270,9 @@ impl DedupState {
                 // across the reconnect. If no blockhash is stored (slot was partial
                 // when we disconnected), treat as changed and flush always.
                 if let Some(sealed) = self.sealed.get_mut(&slot) {
-                    if sealed.awaiting_replay {
-                        let same = sealed.blockhash.as_ref() == Some(&blockhash);
-                        sealed.blockhash = Some(blockhash);
-                        sealed.awaiting_replay = false;
-                        return Observation::ReplayComplete { same };
-                    }
-                    return Observation::Duplicate;
+                    let same = sealed.blockhash.as_ref() == Some(&blockhash);
+                    sealed.blockhash = Some(blockhash);
+                    return Observation::ReplayComplete { same };
                 }
 
                 // First BlockMeta for this slot: seal it. The SlotState is destroyed;
@@ -288,7 +283,6 @@ impl DedupState {
                     SealedSlot {
                         blockhash: Some(blockhash),
                         statuses: state.statuses,
-                        awaiting_replay: false,
                     },
                 );
                 self.prune();
@@ -297,21 +291,10 @@ impl DedupState {
 
             // Accounts, transactions, entries, blocks, etc.
             payload => {
-                // Sealed slot: three cases depending on state.
-                // 1. Awaiting replay verification: quarantine until replayed BlockMeta verdict.
-                // 2. Block message on live path: arrives after seal, forward to user.
-                // 3. Everything else: already delivered before seal, drop as duplicate.
-                if let Some(sealed) = self.sealed.get(&slot) {
-                    if sealed.awaiting_replay {
-                        return Observation::Replay;
-                    }
-                    // Block is assembled after BlockMeta seals the slot and is never
-                    // part of replay. Forward it; other payloads were already delivered
-                    // before seal and are genuine duplicates.
-                    if matches!(payload, DedupKey::Block(_)) {
-                        return Observation::New;
-                    }
-                    return Observation::Duplicate;
+                // Sealed slot: hold for quarantine. The verdict comes when the
+                // replayed BlockMeta arrives; until then we buffer without deduping.
+                if self.sealed.contains_key(&slot) {
+                    return Observation::Replay;
                 }
 
                 let state = self.slot_mut(slot);
@@ -342,19 +325,12 @@ impl DedupState {
     /// Replayed content for these slots will be quarantined and flushed at
     /// BlockMeta (no stored blockhash to compare, so always flush).
     pub(crate) fn prepare_for_replay(&mut self) {
-        // Mark all already-sealed slots for verification
-        for sealed in self.sealed.values_mut() {
-            sealed.awaiting_replay = true;
-        }
-
-        // Promote inflight slots to sealed-without-blockhash
         for (slot, state) in self.inflight.drain() {
             self.sealed.insert(
                 slot,
                 SealedSlot {
                     blockhash: None,
                     statuses: state.statuses,
-                    awaiting_replay: true,
                 },
             );
         }
@@ -606,8 +582,6 @@ mod tests {
         observe(&mut dedup, &make_slot_msg(300, 0));
         observe(&mut dedup, &make_block_meta_msg(300));
 
-        dedup.prepare_for_replay(); // simulate reconnect
-
         // a replayed account for a sealed slot should be quarantined
         let account_msg = make_account_msg(300);
         assert!(matches!(
@@ -624,8 +598,6 @@ mod tests {
         observe(&mut dedup, &make_slot_msg(400, 0));
         observe(&mut dedup, &make_block_meta_msg_with_hash(400, "abc"));
 
-        dedup.prepare_for_replay();
-
         // replayed BlockMeta with same hash: same block, discard
         assert!(matches!(
             observe(&mut dedup, &make_block_meta_msg_with_hash(400, "abc")),
@@ -640,8 +612,6 @@ mod tests {
         // seal slot 500 with blockhash "block_a"
         observe(&mut dedup, &make_slot_msg(500, 0));
         observe(&mut dedup, &make_block_meta_msg_with_hash(500, "block_a"));
-
-        dedup.prepare_for_replay();
 
         // replayed BlockMeta with different hash: block changed, flush
         assert!(matches!(

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "13.2.3"
+version = "13.2.4"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -1,7 +1,10 @@
 use {
-    crate::plugin::message::{
-        Message, MessageAccountInfo, MessageBlock, MessageBlockMeta, MessageEntry, MessageSlot,
-        MessageTransactionInfo, SlotStatus,
+    crate::{
+        metrics,
+        plugin::message::{
+            Message, MessageAccountInfo, MessageBlock, MessageBlockMeta, MessageEntry, MessageSlot,
+            MessageTransactionInfo, SlotStatus,
+        },
     },
     solana_commitment_config::CommitmentLevel,
     solana_hash::Hash,
@@ -75,7 +78,7 @@ impl ProcessingSlot {
             })
             .collect::<Vec<_>>();
         // Yet another clone of all the messages, but that prevents from doing this later on anyway, while making iterator code easier to implement.
-        let mut dedup_messages = self
+        let dedup_messages = self
             .original_messages
             .into_iter()
             .filter_map(|message| {
@@ -94,9 +97,15 @@ impl ProcessingSlot {
             })
             .collect::<Vec<_>>();
 
-        // We absolutely need to add blockmeta add the add of the message list, so when we replay from the beginning to the end
-        // we get: all the accounts/transactions/entries + the blockmeta at the end.
-        dedup_messages.push(Message::BlockMeta(Arc::clone(&block_meta)));
+        if self.transactions.len() != block_meta.executed_transaction_count as usize {
+            metrics::incr_geyser_block_mismatch_transaction();
+            log::warn!(
+                "Block meta transaction count {} does not match actual transaction count {} for slot {}",
+                block_meta.executed_transaction_count,
+                self.transactions.len(),
+                block_meta.slot
+            );
+        }
 
         let pre_computed_message_block = MessageBlock::new(
             Arc::clone(&block_meta),
@@ -104,6 +113,7 @@ impl ProcessingSlot {
             account_info_vec,
             self.entries,
         );
+
         FrozenBlock {
             original_messages: Arc::new(dedup_messages),
             block_meta,
@@ -825,11 +835,7 @@ mod tests {
             .filter(|m| matches!(m, Message::Entry(_)))
             .count();
 
-        let last_message = messages.last().unwrap();
-        assert!(
-            matches!(last_message, Message::BlockMeta(_)),
-            "last message should be BlockMeta"
-        );
+        /* Last message is explicitly sent as BlockMeta, its no longer implicit inside of original_messages */
         assert_eq!(entry_count, 2);
     }
 
@@ -867,11 +873,7 @@ mod tests {
                 .iter()
                 .filter(|m| matches!(m, Message::Entry(_)))
                 .count();
-            let last_message = messages.last().unwrap();
-            assert!(
-                matches!(last_message, Message::BlockMeta(_)),
-                "last message should be BlockMeta"
-            );
+            /* Last message is explicitly sent as BlockMeta, its no longer implicit inside of original_messages */
             assert_eq!(entry_count, 2);
         }
     }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -889,12 +889,11 @@ impl GrpcService {
                         if commitment_level != CommitmentLevel::Processed {
                             let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
                         }
-                        else {
-                            let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
-                            let _ = broadcast_tx.send((commitment_level, Arc::new(vec![block_meta])));
-                        }
+
+                        let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
                         let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
-                        let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block])));
+                        let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
+
                         let slot_message = Message::Slot(MessageSlot {
                             slot: slot_update.slot,
                             parent: slot_update.parent_slot,

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -169,13 +169,16 @@ lazy_static::lazy_static! {
         &["subscriber_id", "uri_path"]
     ).unwrap();
 
-
     static ref GEYSER_EVENT_DROPPED: IntCounterVec = IntCounterVec::new(
         Opts::new(
             "geyser_event_dropped_total",
             "Total number of events dropped in the plugin due to drop_list"
         ),
         &["event"]
+    ).unwrap();
+
+    static ref GEYSER_BLOCK_MISMATCH_TRANSACTION: IntGauge = IntGauge::new(
+        "geyser_block_mismatch_transaction", "Number of block mismatch transactions encountered in the plugin"
     ).unwrap();
 }
 
@@ -337,6 +340,7 @@ impl PrometheusService {
             register!(GRPC_SUBSCRIPTION_LIMIT_EXCEEDED);
             register!(GRPC_SERVICE_OUTBOUND_BYTES);
             register!(GEYSER_EVENT_DROPPED);
+            register!(GEYSER_BLOCK_MISMATCH_TRANSACTION);
 
             VERSION
                 .with_label_values(&[
@@ -462,6 +466,10 @@ pub fn incr_geyser_event_dropped<S: AsRef<str>>(event: S) {
     GEYSER_EVENT_DROPPED
         .with_label_values(&[event.as_ref()])
         .inc();
+}
+
+pub fn incr_geyser_block_mismatch_transaction() {
+    GEYSER_BLOCK_MISMATCH_TRANSACTION.inc();
 }
 
 pub fn incr_grpc_message_sent_counter<S: AsRef<str>>(remote_id: S) {
@@ -652,6 +660,7 @@ pub fn reset_metrics() {
     PRE_ENCODED_CACHE_MISS.reset();
 
     GEYSER_EVENT_DROPPED.reset();
+    GEYSER_BLOCK_MISMATCH_TRANSACTION.set(0);
 
     // Note: VERSION and GEYSER_ACCOUNT_UPDATE_RECEIVED are intentionally not reset
     // - VERSION contains build info set once on startup


### PR DESCRIPTION
In 13.2.3, a wrong assumption has been made in the ordering of Block/BlockMeta which caused an unnecessary client patch. 
This patch will correct this assumption.

Additionally, we've added a metric to track blocks which contain an invalid amount of transactions.

Close #STR-560