### PR TITLE
str-565: custom TLS supports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1013,20 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2007,6 +2066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,12 +2179,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2137,6 +2222,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2190,10 +2284,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "oid-registry"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2871,6 +2974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,12 +3310,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5448,7 +5560,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5457,16 +5569,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5484,31 +5587,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5518,22 +5604,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5542,22 +5616,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5566,22 +5628,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5590,22 +5640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5715,6 +5753,23 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "yellowstone-block-machine"
@@ -5827,6 +5882,7 @@ dependencies = [
  "prost-types 0.14.3",
  "protoc-bin-vendored",
  "rayon",
+ "rustls",
  "serde",
  "serde_json",
  "smallvec",
@@ -5850,6 +5906,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -5861,6 +5918,7 @@ dependencies = [
  "vergen",
  "yellowstone-block-machine",
  "yellowstone-grpc-proto",
+ "yellowstone-grpc-tools",
 ]
 
 [[package]]
@@ -5939,6 +5997,31 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+]
+
+[[package]]
+name = "yellowstone-grpc-tools"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "bytesize 2.3.1",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "log",
+ "pin-project",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tonic",
+ "tower-layer",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,9 @@ members = [
     "yellowstone-grpc-client-nodejs/napi", # 0.2.0
     "yellowstone-grpc-e2e-macros", # 0.1.0
     "yellowstone-grpc-geyser", # 13.1.0
-    "yellowstone-grpc-proto", # 12.4.0
+    "yellowstone-grpc-proto", # 12.5.0
     "yellowstone-grpc-e2e-test", # 0.1.0
+    "yellowstone-grpc-tools"
 ]
 
 [workspace.package]
@@ -64,6 +65,7 @@ parking_lot = "0.12"
 prometheus = "0.14.0"
 pin-project = "1.1.10"
 proc-macro2 = "1"
+pin-project-lite = "0.2.0"
 prost = "0.14.0"
 prost-types = "0.14.0"
 prost_011 = { package = "prost", version = "0.11.9" }
@@ -71,10 +73,11 @@ protoc-bin-vendored = "3.2.0"
 quote = "1"
 rand = "0.8"
 rayon = "1.11.0"
-rustls = "0.23"
+rustls = "0.23.0"
 serde = "1.0.145"
 serde_json = "1.0.86"
 siphasher = "1"
+socket2 = "0.6.4"
 smallvec = "1.15.1"
 syn = { version = "2", features = ["full"] }
 thiserror = "2.0.16"
@@ -123,6 +126,12 @@ yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0"
 yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.2.5" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
+yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }
+
+# tokio-grpc-tools
+tokio-rustls = "0.26.0"
+x509-parser = "0.18.0"
+
 
 [workspace.lints.clippy]
 clone_on_ref_ptr = "deny"

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -16,6 +16,10 @@ crate-type = ["cdylib", "rlib"]
 [[bin]]
 name = "config-check"
 
+[features]
+default = []
+bench = ["dep:prost_011", "dep:solana-storage-proto"]
+
 [dependencies]
 tikv-jemallocator = { version = "0.6.1", features = ["disable_initial_exec_tls"] }
 
@@ -41,11 +45,13 @@ prometheus = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rayon = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tokio-util = { workspace = true, features = ["rt"]}
+tokio-rustls = { workspace = true }
 tokio-stream = { workspace = true }
 tower-layer = { workspace = true }
 tonic = { workspace = true, features = ["gzip", "zstd", "tls-native-roots"] }
@@ -81,6 +87,7 @@ prost_011 = { workspace = true, optional = true }
 # Yellowstone
 yellowstone-grpc-proto = { workspace = true, features = ["tonic", "account-data-as-bytes"] }
 yellowstone-block-machine = { workspace = true, default-features = false }
+yellowstone-grpc-tools = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 # wrapped in mod cpu_core_affinity
@@ -91,8 +98,6 @@ name = "encode"
 harness = false
 required-features = ["bench"]
 
-[features]
-bench = ["dep:prost_011", "dep:solana-storage-proto"]
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -317,26 +317,23 @@ impl BlockMachineStorage {
             return;
         };
 
-        match outcome {
-            Ok(()) => {
-                // We cannot seal the same slot twice, so we won't update the state machine twice.
-                let block_meta = self
-                    .processing_slots
-                    .get(&slot)
-                    .unwrap()
-                    .blockmeta
-                    .as_ref()
-                    .unwrap();
-                let block_summary = BlockReplayEvent::BlockSummary(BlockSummary {
-                    slot: block_meta.slot,
-                    parent_slot: block_meta.parent_slot,
-                    blockhash: Hash::from_str(&block_meta.blockhash).expect("blockhash format"),
-                    entry_count: block_meta.entries_count,
-                    executed_transaction_count: block_meta.executed_transaction_count,
-                });
-                let _ = self.state.process_replay_event(block_summary);
-            }
-            Err(_) => {}
+        if outcome.is_ok() {
+            // We cannot seal the same slot twice, so we won't update the state machine twice.
+            let block_meta = self
+                .processing_slots
+                .get(&slot)
+                .unwrap()
+                .blockmeta
+                .as_ref()
+                .unwrap();
+            let block_summary = BlockReplayEvent::BlockSummary(BlockSummary {
+                slot: block_meta.slot,
+                parent_slot: block_meta.parent_slot,
+                blockhash: Hash::from_str(&block_meta.blockhash).expect("blockhash format"),
+                entry_count: block_meta.entries_count,
+                executed_transaction_count: block_meta.executed_transaction_count,
+            });
+            let _ = self.state.process_replay_event(block_summary);
         };
     }
 

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -152,6 +152,15 @@ pub struct GrpcAddresses {
     pub inner: Vec<GrpcAddress>,
 }
 
+impl IntoIterator for GrpcAddresses {
+    type Item = GrpcAddress;
+    type IntoIter = std::vec::IntoIter<GrpcAddress>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
 impl<'de> Deserialize<'de> for GrpcAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -259,9 +268,9 @@ impl<'de> Deserialize<'de> for GrpcAddresses {
 #[serde(deny_unknown_fields)]
 pub struct ConfigGrpc {
     /// Multiple addresses of Grpc service.
-    pub address: GrpcAddresses,
+    pub address: Option<GrpcAddresses>,
     /// TLS config
-    pub tls_config: Option<ConfigGrpcServerTls>,
+    pub tls_config: Option<TlsIdentityPair>,
     /// Possible compression options
     #[serde(default)]
     pub compression: ConfigGrpcCompression,
@@ -352,6 +361,32 @@ pub struct ConfigGrpc {
     ///
     #[serde(default)]
     pub traffic_reporting_byte_threhsold: Option<ByteSize>,
+
+    ///
+    /// Optional directory to load TLS certificates for gRPC server. If set, the server will start in TLS mode and load certificates from the provided directory.
+    ///
+    /// This option is mutually exclusive with `tls_config`. If both are set, the server will prioritize `cert_dir`.
+    #[serde(default)]
+    pub cert_dir: Option<PathBuf>,
+
+    #[serde(default)]
+    pub listen: Option<Vec<ListenConfig>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum GrpcTlsConfig {
+    /// A pair of private-key and cert file paths
+    IdentityPair { identity: TlsIdentityPair },
+    /// HAPROXY-like cert directory with `*.pem` files containing the certs and private keys.
+    CertDir { cert_dir: PathBuf },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListenConfig {
+    pub address: GrpcAddress,
+    pub tls: Option<GrpcTlsConfig>,
 }
 
 impl ConfigGrpc {
@@ -398,7 +433,7 @@ impl ConfigGrpc {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ConfigGrpcServerTls {
+pub struct TlsIdentityPair {
     pub cert_path: String,
     pub key_path: String,
 }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         block_reconstruction::BlockMachineStorage,
-        config::{ConfigGrpc, GrpcAddress},
+        config::{ConfigGrpc, GrpcAddress, GrpcTlsConfig},
         metered::MeteredLayer,
         metrics::{
             self, incr_grpc_method_call_count, set_subscriber_queue_size,
@@ -22,37 +22,45 @@ use {
         util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
         version::GrpcVersionInfo,
     },
-    anyhow::Context,
-    bytesize::ByteSize,
+    anyhow::Context as _,
+    futures::Stream,
     log::{error, info},
     prost_types::Timestamp,
+    rustls::{
+        pki_types::{pem::PemObject, PrivateKeyDer},
+        ServerConfig,
+    },
     smallvec::SmallVec,
     solana_clock::{Slot, MAX_RECENT_BLOCKHASHES},
     std::{
         collections::HashMap,
+        io,
         net::SocketAddr,
         os::unix::fs::PermissionsExt,
         path::PathBuf,
+        pin::Pin,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
             Arc, LazyLock, Mutex as StdMutex,
         },
+        task::{Context, Poll},
         time::SystemTime,
     },
     tokio::{
-        fs,
+        io::{AsyncRead, AsyncWrite},
         net::UnixListener,
         sync::{broadcast, mpsc, oneshot, Mutex, RwLock, Semaphore},
         time::{sleep, Duration},
     },
+    tokio_rustls::TlsAcceptor,
     tokio_stream::wrappers::UnixListenerStream,
     tokio_util::{sync::CancellationToken, task::TaskTracker},
     tonic::{
         metadata::AsciiMetadataValue,
         service::interceptor,
         transport::{
-            server::{Server, TcpConnectInfo, TcpIncoming, TlsConnectInfo},
-            Identity, ServerTlsConfig,
+            server::{Connected, Server, TcpConnectInfo, TlsConnectInfo},
+            CertificateDer,
         },
         Request, Response, Result as TonicResult, Status, Streaming,
     },
@@ -63,6 +71,10 @@ use {
         GetVersionRequest, GetVersionResponse, IsBlockhashValidRequest, IsBlockhashValidResponse,
         PingRequest, PongResponse, SubscribeDeshredRequest, SubscribeReplayInfoRequest,
         SubscribeReplayInfoResponse, SubscribeRequest,
+    },
+    yellowstone_grpc_tools::server::{
+        tcp::{TcpConfiguration, TcpIncoming as TritonTcpIncoming},
+        tls::{build_sni_resolver_from_cert_dir, HotResolvesServerCertUsingSni, TlsIncoming},
     },
 };
 
@@ -426,9 +438,43 @@ impl Drop for ClientSession {
     }
 }
 
+struct AutoClosableUnixListenerStream {
+    path_to_remove: PathBuf,
+    listener: UnixListenerStream,
+}
+
+impl Stream for AutoClosableUnixListenerStream {
+    type Item = io::Result<tokio::net::UnixStream>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match Pin::new(&mut this.listener).poll_next(cx) {
+            Poll::Ready(Some(Ok(stream))) => Poll::Ready(Some(Ok(stream))),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for AutoClosableUnixListenerStream {
+    fn drop(&mut self) {
+        if let Err(err) = std::fs::remove_file(&self.path_to_remove) {
+            error!(
+                "failed to remove Unix socket file {}: {}",
+                self.path_to_remove.display(),
+                err
+            );
+        } else {
+            info!("removed Unix socket file {}", self.path_to_remove.display());
+        }
+    }
+}
+
 enum Listener {
-    Tcp(TcpIncoming),
-    Unix(PathBuf, UnixListenerStream), // path needed to remove the socket file on exit
+    Tcp(TritonTcpIncoming),
+    Tls(TlsIncoming),
+    Unix(AutoClosableUnixListenerStream), // path needed to remove the socket file on exit
 }
 
 #[derive(Clone)]
@@ -469,6 +515,49 @@ pub struct GrpcService {
     task_tracker: TaskTracker,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum TlsConfigLoadError {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Rustls(#[from] rustls::Error),
+    #[error(transparent)]
+    PemError(#[from] rustls::pki_types::pem::Error),
+}
+
+///
+/// Loads TLS server configuration from the given `GrpcTlsConfig`. This is used for both the legacy `tls_config` field and the new `listen[].tls` field in the configuration. The `listen[].tls` field takes precedence over the legacy `tls_config` if both are set.
+///
+fn load_server_config_from_tls_config(
+    tls_config: &GrpcTlsConfig,
+) -> Result<ServerConfig, TlsConfigLoadError> {
+    match tls_config {
+        GrpcTlsConfig::IdentityPair { identity } => {
+            let cert_pem = std::fs::read(&identity.cert_path)?;
+            let key = std::fs::read(&identity.key_path)?;
+
+            let cert_der = CertificateDer::from_pem_slice(&cert_pem)?;
+            let key_der = PrivateKeyDer::from_pem_slice(&key)?;
+            let mut server_config = ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert_der], key_der)?;
+            // gRPC over TLS requires ALPN negotiation for HTTP/2.
+            server_config.alpn_protocols = vec![b"h2".to_vec()];
+            Ok(server_config)
+        }
+        GrpcTlsConfig::CertDir { cert_dir } => {
+            let resolver = build_sni_resolver_from_cert_dir(cert_dir.clone())?;
+            let hot_resolver = HotResolvesServerCertUsingSni::from(resolver);
+            let mut server_config = ServerConfig::builder()
+                .with_no_client_auth()
+                .with_cert_resolver(Arc::new(hot_resolver));
+            // gRPC over TLS requires ALPN negotiation for HTTP/2.
+            server_config.alpn_protocols = vec![b"h2".to_vec()];
+            Ok(server_config)
+        }
+    }
+}
+
 impl GrpcService {
     #[allow(clippy::type_complexity)]
     pub async fn create(
@@ -483,32 +572,147 @@ impl GrpcService {
     )> {
         // Bind all configured addresses (TCP or Unix domain socket)
         let mut listeners = Vec::new();
-        for addr in &config.address.inner {
-            let listener = match addr {
-                GrpcAddress::Tcp(addr) => {
-                    let incoming = TcpIncoming::bind(*addr)?
-                        .with_nodelay(Some(true))
-                        .with_keepalive(Some(Duration::from_secs(20)));
-                    Listener::Tcp(incoming)
-                }
-                GrpcAddress::Unix { path, mode } => {
-                    if config.tls_config.is_some() {
-                        log::warn!(
-                            "TLS config is ignored for Unix domain socket: {}",
+
+        // This is the LEGACY way of configuring the listen address, which is still supported for backward compatibility but will be removed in the future. The new way is to use the `listen` field which supports multiple addresses and TLS configuration per address.
+        if let Some(addresses) = config.address.clone() {
+            log::warn!("The 'address' field is deprecated; please use the 'listen' field with an array of addresses instead");
+            if config.tls_config.is_some() && config.cert_dir.is_some() {
+                log::warn!("Both tls_config and cert_dir are set; cert_dir will take precedence and tls_config will be ignored");
+            }
+            let mut maybe_tls_server_config = if let Some(tls) = &config.tls_config {
+                let cert_pem = std::fs::read(&tls.cert_path)
+                    .context("failed to read TLS cert file")
+                    .unwrap();
+                let key = std::fs::read(&tls.key_path)
+                    .context("failed to read TLS key file")
+                    .unwrap();
+
+                let cert_der =
+                    CertificateDer::from_pem_slice(&cert_pem).context("tls cert_path")?;
+                let key_der = PrivateKeyDer::from_pem_slice(&key).context("tls key_path")?;
+                let mut server_config = ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_single_cert(vec![cert_der], key_der)?;
+                // gRPC over TLS requires ALPN negotiation for HTTP/2.
+                server_config.alpn_protocols = vec![b"h2".to_vec()];
+                Some(server_config)
+            } else {
+                None
+            };
+
+            // Cert-dir has precedence over tls_config if both are set.
+            // TODO: supports hot reload via sighub signal and watching cert_dir changes
+            if let Some(cert_dir) = &config.cert_dir {
+                let resolver = build_sni_resolver_from_cert_dir(cert_dir.clone())?;
+                let hot_resolver = HotResolvesServerCertUsingSni::from(resolver);
+                let mut server_config = ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_cert_resolver(Arc::new(hot_resolver));
+                // gRPC over TLS requires ALPN negotiation for HTTP/2.
+                server_config.alpn_protocols = vec![b"h2".to_vec()];
+                let _ = maybe_tls_server_config.replace(server_config);
+            }
+
+            log::warn!("The 'address' field is deprecated; please use the 'listen' field with an array of addresses instead");
+            for address in addresses {
+                match address {
+                    GrpcAddress::Tcp(addr) => {
+                        let incoming = TritonTcpIncoming::bind_with_config(
+                            addr,
+                            TcpConfiguration::default()
+                                .with_nodelay(Some(true))
+                                .with_keepalive(Some(Duration::from_secs(20))),
+                        )
+                        .await?;
+                        log::info!(
+                            "binding gRPC server to TCP socket: {}",
+                            incoming.local_addr()?
+                        );
+                        listeners.push(Listener::Tcp(incoming));
+                    }
+                    GrpcAddress::Unix { path, mode } => {
+                        if config.tls_config.is_some() || config.cert_dir.is_some() {
+                            log::warn!(
+                                "TLS config is ignored for Unix domain socket: {}",
+                                path.display()
+                            );
+                        }
+                        if let Err(e) = std::fs::remove_file(&path) {
+                            if e.kind() != std::io::ErrorKind::NotFound {
+                                return Err(e.into());
+                            }
+                        }
+                        log::info!(
+                            "binding gRPC server to Unix domain socket: {}",
                             path.display()
                         );
+                        let uds = UnixListener::bind(&path)?;
+                        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode))?;
+                        let uds = UnixListenerStream::new(uds);
+                        let uds = AutoClosableUnixListenerStream {
+                            path_to_remove: path,
+                            listener: uds,
+                        };
+                        listeners.push(Listener::Unix(uds));
                     }
-                    if let Err(e) = std::fs::remove_file(path) {
-                        if e.kind() != std::io::ErrorKind::NotFound {
-                            return Err(e.into());
-                        }
-                    }
-                    let uds = UnixListener::bind(path)?;
-                    std::fs::set_permissions(path, std::fs::Permissions::from_mode(*mode))?;
-                    Listener::Unix(path.clone(), UnixListenerStream::new(uds))
                 }
-            };
-            listeners.push(listener);
+            }
+        }
+
+        if let Some(listen_configs) = config.listen.clone() {
+            for listen_config in listen_configs {
+                let address = listen_config.address;
+                let tls_config = listen_config.tls;
+                match address {
+                    GrpcAddress::Tcp(addr) => {
+                        let incoming = TritonTcpIncoming::bind_with_config(
+                            addr,
+                            TcpConfiguration::default()
+                                .with_nodelay(Some(true))
+                                .with_keepalive(Some(Duration::from_secs(20))),
+                        )
+                        .await?;
+                        log::info!(
+                            "binding gRPC server to TCP socket: {}",
+                            incoming.local_addr()?
+                        );
+                        let listener = if let Some(tls) = tls_config {
+                            let server_config = load_server_config_from_tls_config(&tls)
+                                .context("failed to load TLS server config")?;
+                            let tls_acceptor = TlsAcceptor::from(Arc::new(server_config));
+                            Listener::Tls(TlsIncoming::new(incoming, tls_acceptor))
+                        } else {
+                            Listener::Tcp(incoming)
+                        };
+                        listeners.push(listener);
+                    }
+                    GrpcAddress::Unix { path, mode } => {
+                        if tls_config.is_some() {
+                            log::warn!(
+                                "TLS config is ignored for Unix domain socket: {}",
+                                path.display()
+                            );
+                        }
+                        if let Err(e) = std::fs::remove_file(&path) {
+                            if e.kind() != std::io::ErrorKind::NotFound {
+                                return Err(e.into());
+                            }
+                        }
+                        log::info!(
+                            "binding gRPC server to Unix domain socket: {}",
+                            path.display()
+                        );
+                        let uds = UnixListener::bind(&path)?;
+                        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode))?;
+                        let uds = UnixListenerStream::new(uds);
+                        let uds = AutoClosableUnixListenerStream {
+                            path_to_remove: path,
+                            listener: uds,
+                        };
+                        listeners.push(Listener::Unix(uds));
+                    }
+                }
+            }
         }
 
         // Snapshot channel
@@ -542,21 +746,10 @@ impl GrpcService {
                 (Some(Arc::new(AtomicU64::new(u64::MAX))), Some(tx), Some(rx))
             };
 
-        // Read TLS identity once (async, before per-listener loop)
-        let tls_identity = match &config.tls_config {
-            Some(tls) => {
-                let (cert, key) =
-                    tokio::try_join!(fs::read(&tls.cert_path), fs::read(&tls.key_path))
-                        .context("failed to load tls_config files")?;
-                Some(Identity::from_pem(cert, key))
-            }
-            None => None,
-        };
-
         // Capture traffic reporting threshold before config is moved
         let traffic_reporting_threshold = config
             .traffic_reporting_byte_threhsold
-            .unwrap_or_else(|| ByteSize::b(DEFAULT_TRAFFIC_REPORTING_THRESHOLD));
+            .unwrap_or(DEFAULT_TRAFFIC_REPORTING_THRESHOLD);
 
         // Save HTTP/2 settings (all Copy) for use inside spawned tasks
         let http2_adaptive_window = config.server_http2_adaptive_window;
@@ -654,31 +847,49 @@ impl GrpcService {
 
         let shutdown_grpc = service_cancellation_token.child_token();
 
+        // The most "elegant" way would be to implement Stream for Listener and a MixedIO type that can handle all three variants.
+        // However, that adds complexity in the IO implementa has every read/write would need an extra match-expression to dispatch to the correct underlying type.
+        // Having this ugly macros is the most efficient approach and makes the code shorter when calling `serve_listener`.
+        macro_rules! with_listener {
+            ($listener:expr, |$incoming:ident| $body:expr) => {{
+                match $listener {
+                    Listener::Tcp($incoming) => $body,
+                    Listener::Unix($incoming) => $body,
+                    Listener::Tls($incoming) => $body,
+                }
+            }};
+        }
+
         // Spawn one server task per listener
         for listener in listeners {
             let shutdown = shutdown_grpc.clone();
-            let tls_identity = tls_identity.clone();
             let x_token = x_token.clone();
             let health_service = health_service.clone();
             let service = service.clone();
 
             task_tracker.spawn(async move {
-                if let Err(e) = GrpcService::serve_listener(
-                    listener,
-                    tls_identity,
-                    http2_adaptive_window,
-                    http2_keepalive_interval,
-                    http2_keepalive_timeout,
-                    initial_connection_window_size,
-                    initial_stream_window_size,
-                    x_token,
-                    health_service,
-                    service,
-                    traffic_reporting_threshold,
-                    shutdown.clone(),
-                )
-                .await
-                {
+                if let Err(e) = with_listener!(listener, |incoming| {
+                    let spy_incoming = SpyIncoming::new(
+                        incoming,
+                        SpyIncomingConfig {
+                            traffic_reporting_threshold,
+                        },
+                    );
+
+                    GrpcService::serve_listener(
+                        spy_incoming,
+                        http2_adaptive_window,
+                        http2_keepalive_interval,
+                        http2_keepalive_timeout,
+                        initial_connection_window_size,
+                        initial_stream_window_size,
+                        x_token,
+                        health_service,
+                        service,
+                        shutdown.clone(),
+                    )
+                    .await
+                }) {
                     error!("gRPC listener failed: {e}");
                     shutdown.cancel();
                 }
@@ -1263,9 +1474,8 @@ impl GrpcService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn serve_listener<H>(
-        listener: Listener,
-        tls_identity: Option<Identity>,
+    async fn serve_listener<H, I, IO>(
+        incoming: I,
         http2_adaptive_window: Option<bool>,
         http2_keepalive_interval: Option<Duration>,
         http2_keepalive_timeout: Option<Duration>,
@@ -1274,22 +1484,14 @@ impl GrpcService {
         x_token: Option<AsciiMetadataValue>,
         health_service: HealthServer<H>,
         service: GeyserServer<GrpcService>,
-        traffic_reporting_threshold: ByteSize,
         shutdown: CancellationToken,
     ) -> anyhow::Result<()>
     where
+        I: Stream<Item = io::Result<IO>> + Send + 'static,
+        IO: Connected + AsyncRead + AsyncWrite + Unpin + Send + 'static,
         H: tonic_health::pb::health_server::Health,
     {
         let mut builder = Server::builder();
-
-        // TLS only applies to TCP — UDS is local IPC, no encryption needed
-        if matches!(listener, Listener::Tcp(_)) {
-            if let Some(identity) = tls_identity {
-                builder = builder
-                    .tls_config(ServerTlsConfig::new().identity(identity))
-                    .context("failed to apply tls_config")?;
-            }
-        }
 
         if let Some(enabled) = http2_adaptive_window {
             builder = builder.http2_adaptive_window(Some(enabled));
@@ -1306,56 +1508,16 @@ impl GrpcService {
         if let Some(sz) = initial_stream_window_size {
             builder = builder.initial_stream_window_size(sz);
         }
-
-        let router = builder
+        builder
             .layer(MeteredLayer::new())
             .layer(interceptor::InterceptorLayer::new(XTokenInterceptor {
                 x_token,
             }))
             .add_service(health_service)
-            .add_service(service);
-
-        // Capture address before match consumes listener
-        let addr = match &listener {
-            Listener::Tcp(incoming) => incoming
-                .local_addr()
-                .map(|a| a.to_string())
-                .unwrap_or_else(|_| "unknown".to_owned()),
-            Listener::Unix(path, _) => format!("unix://{}", path.display()),
-        };
-
-        info!("gRPC server listening on {addr}");
-
-        let result = match listener {
-            Listener::Tcp(incoming) => {
-                let spy = SpyIncoming::new(
-                    incoming,
-                    SpyIncomingConfig {
-                        traffic_reporting_threshold,
-                    },
-                );
-                router
-                    .serve_with_incoming_shutdown(spy, shutdown.cancelled())
-                    .await
-                    .context("TCP listener error")
-            }
-            Listener::Unix(path, incoming) => {
-                let result = router
-                    .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
-                    .await
-                    .context("UDS listener error");
-
-                if let Err(e) = std::fs::remove_file(&path) {
-                    if e.kind() != std::io::ErrorKind::NotFound {
-                        log::warn!("failed to remove socket file {}: {e}", path.display());
-                    }
-                }
-                result
-            }
-        };
-
-        info!("gRPC server on {addr} shut down with result: {result:?}");
-        result
+            .add_service(service)
+            .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/yellowstone-grpc-geyser/src/transport.rs
+++ b/yellowstone-grpc-geyser/src/transport.rs
@@ -97,7 +97,7 @@ pub struct SpyIncoming<I, IO> {
     _io: PhantomData<IO>,
 }
 
-pub const DEFAULT_TRAFFIC_REPORTING_THRESHOLD: u64 = 64 * 1024; // 64 KiB
+pub const DEFAULT_TRAFFIC_REPORTING_THRESHOLD: ByteSize = ByteSize::b(64 * 1024); // 64 KiB
 
 /// Runtime options for [`SpyIncoming`].
 pub struct SpyIncomingConfig {
@@ -108,7 +108,7 @@ pub struct SpyIncomingConfig {
 impl Default for SpyIncomingConfig {
     fn default() -> Self {
         Self {
-            traffic_reporting_threshold: ByteSize::b(DEFAULT_TRAFFIC_REPORTING_THRESHOLD),
+            traffic_reporting_threshold: DEFAULT_TRAFFIC_REPORTING_THRESHOLD,
         }
     }
 }

--- a/yellowstone-grpc-tools/Cargo.toml
+++ b/yellowstone-grpc-tools/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "yellowstone-grpc-tools"
+version = "0.1.0"
+authors = { workspace = true }
+edition = { workspace = true }
+description = "Yellowstone gRPC Tools"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+keywords = { workspace = true }
+publish = { workspace = true }
+
+[dependencies]
+arc-swap = { workspace = true }
+bytes = { workspace = true }
+bytesize = { workspace = true }
+log = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+pin-project = { workspace = true }
+pin-project-lite = { workspace = true }
+tower-layer = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio-stream = { workspace = true }
+tonic = { workspace = true, features = ["gzip", "zstd", "tls-native-roots"] }
+tokio-rustls = { workspace = true }
+x509-parser = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+socket2 = { workspace = true }

--- a/yellowstone-grpc-tools/src/lib.rs
+++ b/yellowstone-grpc-tools/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod server;

--- a/yellowstone-grpc-tools/src/server/mod.rs
+++ b/yellowstone-grpc-tools/src/server/mod.rs
@@ -1,0 +1,2 @@
+pub mod tcp;
+pub mod tls;

--- a/yellowstone-grpc-tools/src/server/tcp.rs
+++ b/yellowstone-grpc-tools/src/server/tcp.rs
@@ -1,0 +1,219 @@
+use {
+    futures::Stream,
+    socket2::TcpKeepalive,
+    std::{
+        io,
+        pin::Pin,
+        task::{Context, Poll},
+        time::Duration,
+    },
+    tokio::net::{TcpListener, TcpStream},
+    tokio_stream::wrappers::TcpListenerStream,
+};
+
+/// Configuration applied to accepted TCP sockets.
+#[derive(Default, Debug)]
+pub struct TcpConfiguration {
+    /// Optional TCP_NODELAY setting.
+    pub nodelay: Option<bool>,
+    /// Optional TCP keepalive parameters.
+    pub keepalive: Option<TcpKeepalive>,
+}
+
+impl TcpConfiguration {
+    /// Sets optional TCP_NODELAY for accepted sockets.
+    pub fn with_nodelay(mut self, nodelay: Option<bool>) -> Self {
+        self.nodelay = nodelay;
+        self
+    }
+
+    /// Sets optional TCP keepalive time for accepted sockets.
+    pub fn with_keepalive(mut self, keepalive: Option<Duration>) -> Self {
+        self.keepalive = keepalive.and_then(|k| make_keepalive(Some(k), None, None));
+        self
+    }
+}
+
+/// Stream of accepted TCP connections.
+#[derive(Debug)]
+pub struct TcpIncoming {
+    listener: TcpListenerStream,
+    nodelay: Option<bool>,
+    keepalive: Option<TcpKeepalive>,
+}
+
+impl TcpIncoming {
+    /// Binds a new listener with default socket options.
+    pub async fn bind(addr: impl tokio::net::ToSocketAddrs) -> io::Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        Ok(Self {
+            listener: TcpListenerStream::new(listener),
+            nodelay: None,
+            keepalive: None,
+        })
+    }
+
+    /// Binds a new listener with custom accepted-socket options.
+    pub async fn bind_with_config(
+        addr: impl tokio::net::ToSocketAddrs,
+        config: TcpConfiguration,
+    ) -> io::Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        Ok(Self {
+            listener: TcpListenerStream::new(listener),
+            nodelay: config.nodelay,
+            keepalive: config.keepalive,
+        })
+    }
+
+    /// Returns listener local address.
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.listener.as_ref().local_addr()
+    }
+}
+
+impl Stream for TcpIncoming {
+    type Item = io::Result<TcpStream>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let polled = Pin::new(&mut self.listener).poll_next(cx);
+
+        if let Poll::Ready(Some(Ok(stream))) = &polled {
+            set_accepted_socket_options(stream, self.nodelay, &self.keepalive);
+        }
+
+        polled
+    }
+}
+
+// Consistent with hyper-0.14, this function does not return an error.
+fn set_accepted_socket_options(
+    stream: &TcpStream,
+    nodelay: Option<bool>,
+    keepalive: &Option<TcpKeepalive>,
+) {
+    if let Some(nodelay) = nodelay {
+        if let Err(e) = stream.set_nodelay(nodelay) {
+            log::warn!("error trying to set TCP_NODELAY: {e}");
+        }
+    }
+
+    if let Some(keepalive) = keepalive {
+        let sock_ref = socket2::SockRef::from(&stream);
+        if let Err(e) = sock_ref.set_tcp_keepalive(keepalive) {
+            log::warn!("error trying to set TCP_KEEPALIVE: {e}");
+        }
+    }
+}
+
+fn make_keepalive(
+    keepalive_time: Option<Duration>,
+    keepalive_interval: Option<Duration>,
+    keepalive_retries: Option<u32>,
+) -> Option<TcpKeepalive> {
+    let mut dirty = false;
+    let mut keepalive = TcpKeepalive::new();
+    if let Some(t) = keepalive_time {
+        keepalive = keepalive.with_time(t);
+        dirty = true;
+    }
+
+    #[cfg(
+        // See https://docs.rs/socket2/0.5.8/src/socket2/lib.rs.html#511-525
+        any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "visionos",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "windows",
+        )
+    )]
+    if let Some(t) = keepalive_interval {
+        keepalive = keepalive.with_interval(t);
+        dirty = true;
+    }
+
+    #[cfg(
+        // See https://docs.rs/socket2/0.5.8/src/socket2/lib.rs.html#557-570
+        any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "visionos",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "tvos",
+            target_os = "watchos",
+        )
+    )]
+    if let Some(r) = keepalive_retries {
+        keepalive = keepalive.with_retries(r);
+        dirty = true;
+    }
+
+    // avoid clippy errors for targets that do not use these fields.
+    let _ = keepalive_retries;
+    let _ = keepalive_interval;
+
+    dirty.then_some(keepalive)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, tokio::net::TcpStream, tokio_stream::StreamExt};
+
+    #[test]
+    fn tcp_configuration_builder_sets_fields() {
+        let cfg = TcpConfiguration::default()
+            .with_nodelay(Some(true))
+            .with_keepalive(Some(Duration::from_secs(5)));
+
+        assert_eq!(cfg.nodelay, Some(true));
+        assert!(cfg.keepalive.is_some());
+    }
+
+    #[test]
+    fn make_keepalive_returns_none_without_inputs() {
+        let keepalive = make_keepalive(None, None, None);
+        assert!(keepalive.is_none());
+    }
+
+    #[tokio::test]
+    async fn bind_with_config_applies_nodelay_to_accepted_stream() {
+        let mut incoming = TcpIncoming::bind_with_config(
+            "127.0.0.1:0",
+            TcpConfiguration::default().with_nodelay(Some(true)),
+        )
+        .await
+        .expect("listener should bind");
+
+        let addr = incoming
+            .local_addr()
+            .expect("listener should expose address");
+        let client = tokio::spawn(async move { TcpStream::connect(addr).await });
+
+        let accepted = incoming
+            .next()
+            .await
+            .expect("stream should yield connection")
+            .expect("accept should succeed");
+
+        let _client = client
+            .await
+            .expect("client task should complete")
+            .expect("client should connect");
+        assert!(accepted.nodelay().expect("reading nodelay should succeed"));
+    }
+}

--- a/yellowstone-grpc-tools/src/server/tls.rs
+++ b/yellowstone-grpc-tools/src/server/tls.rs
@@ -1,0 +1,748 @@
+use {
+    crate::server::tcp::TcpIncoming,
+    arc_swap::ArcSwap,
+    futures::Stream,
+    std::{
+        collections::{HashMap, HashSet},
+        fmt,
+        fs::{self},
+        io::{self, ErrorKind},
+        net::SocketAddr,
+        path::Path,
+        pin::Pin,
+        sync::Arc,
+        task::{Context, Poll},
+    },
+    tokio::{
+        io::{AsyncRead, AsyncWrite, ReadBuf},
+        net::TcpStream,
+        task::JoinSet,
+    },
+    tokio_rustls::{
+        rustls::{
+            crypto::aws_lc_rs::sign::any_supported_type,
+            pki_types::{
+                pem::{Error as PemError, PemObject},
+                PrivateKeyDer,
+            },
+            server::{ClientHello, ResolvesServerCert},
+            sign::CertifiedKey,
+        },
+        server::TlsStream,
+        TlsAcceptor,
+    },
+    tonic::transport::{server::Connected, CertificateDer},
+    x509_parser::{extensions::GeneralName, parse_x509_certificate},
+};
+
+///
+/// A certificate resolver that supports both exact SNI names and wildcard patterns.
+#[derive(Default)]
+pub struct SniResolver {
+    exact: HashMap<String, Arc<CertifiedKey>>,
+    wildcard: Vec<(String, Arc<CertifiedKey>)>,
+}
+
+impl SniResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, name: &str, certified_key: CertifiedKey) -> io::Result<()> {
+        let name = name.to_ascii_lowercase();
+        let cert = Arc::new(certified_key);
+
+        if let Some(suffix) = name.strip_prefix("*.") {
+            let suffix = format!(".{suffix}");
+            if self
+                .wildcard
+                .iter()
+                .any(|(existing, _)| existing == &suffix)
+            {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("duplicate wildcard SNI name: {name}"),
+                ));
+            }
+            self.wildcard.push((suffix, cert));
+            return Ok(());
+        }
+
+        if self.exact.insert(name.clone(), cert).is_some() {
+            return Err(io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("duplicate SNI name: {name}"),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn resolve_by_name(&self, server_name: &str) -> Option<Arc<CertifiedKey>> {
+        let server_name = server_name.to_ascii_lowercase();
+        if let Some(cert) = self.exact.get(&server_name) {
+            return Some(Arc::clone(cert));
+        }
+
+        let mut best_match: Option<(&str, Arc<CertifiedKey>)> = None;
+        for (suffix, cert) in &self.wildcard {
+            if !server_name.ends_with(suffix) {
+                continue;
+            }
+
+            let prefix = &server_name[..server_name.len().saturating_sub(suffix.len())];
+            if prefix.is_empty() || prefix.contains('.') {
+                continue;
+            }
+
+            match best_match {
+                Some((best_suffix, _)) if best_suffix.len() >= suffix.len() => {}
+                _ => best_match = Some((suffix.as_str(), Arc::clone(cert))),
+            }
+        }
+
+        best_match.map(|(_, cert)| cert)
+    }
+}
+
+impl fmt::Debug for SniResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SniResolver")
+            .field("exact_names", &self.exact.len())
+            .field("wildcard_names", &self.wildcard.len())
+            .finish()
+    }
+}
+
+impl ResolvesServerCert for SniResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        let server_name = client_hello.server_name()?;
+        self.resolve_by_name(server_name)
+    }
+}
+
+/// A wrapper around [`SniResolver`] that allows hot-swapping the underlying cert resolver at runtime.
+///
+pub struct HotResolvesServerCertUsingSni {
+    inner: Arc<ArcSwap<SniResolver>>,
+}
+
+impl Default for HotResolvesServerCertUsingSni {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HotResolvesServerCertUsingSni {
+    ///
+    /// Creates a new [`HotResolvesServerCertUsingSni`] with an empty [`SniResolver`] as the initial resolver.
+    ///
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(SniResolver::new())),
+        }
+    }
+
+    ///
+    /// Swaps the underlying [`SniResolver`] with a new one at runtime.
+    ///
+    pub fn swap(&self, new_resolver: SniResolver) {
+        self.inner.store(Arc::new(new_resolver));
+    }
+}
+
+impl From<SniResolver> for HotResolvesServerCertUsingSni {
+    fn from(resolver: SniResolver) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(resolver)),
+        }
+    }
+}
+
+impl fmt::Debug for HotResolvesServerCertUsingSni {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl ResolvesServerCert for HotResolvesServerCertUsingSni {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        self.inner.load().resolve(client_hello)
+    }
+}
+
+///
+/// Builds an [`SniResolver`] by loading all PEM files in the given directory.
+///
+/// Each PEM file must contain at least one certificate and a private key.
+/// The same cert/key pair will be registered for each DNS name found in the cert's SAN and CN fields.
+///
+pub fn build_sni_resolver_from_cert_dir<D: AsRef<Path>>(dir: D) -> Result<SniResolver, io::Error> {
+    let mut resolver = SniResolver::new();
+    let mut loaded_bundle_count = 0usize;
+    let dir_path = dir.as_ref();
+
+    if !dir_path.is_dir() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("--cert-dir path is not a directory: {dir_path:?}"),
+        ));
+    }
+
+    for entry in fs::read_dir(dir_path)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() || !is_pem_like_file(&path) {
+            continue;
+        }
+
+        let certs = CertificateDer::pem_file_iter(&path)
+            .map_err(|err| {
+                io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("failed to open PEM file {}: {err}", path.display()),
+                )
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| {
+                io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("failed to parse certificate in {}: {err}", path.display()),
+                )
+            })?;
+        if certs.is_empty() {
+            continue;
+        }
+
+        let key = match PrivateKeyDer::from_pem_file(&path) {
+            Ok(key) => key,
+            Err(PemError::NoItemsFound) => continue,
+            Err(err) => {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("failed to parse key in {}: {err}", path.display()),
+                ));
+            }
+        };
+
+        let names = extract_cert_names(&certs[0])?;
+        if names.is_empty() {
+            return Err(io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("no DNS names found in certificate file {}", path.display()),
+            ));
+        }
+
+        let signing_key = any_supported_type(&key).map_err(|err| {
+            io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("failed to parse key in {}: {err}", path.display()),
+            )
+        })?;
+
+        for name in names {
+            let certified_key = CertifiedKey::new(certs.clone(), signing_key.clone());
+            resolver.add(&name, certified_key).map_err(|err| {
+                io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!(
+                        "failed to register SNI cert from {} for host '{}': {err}",
+                        path.display(),
+                        name
+                    ),
+                )
+            })?;
+        }
+
+        loaded_bundle_count += 1;
+    }
+
+    if loaded_bundle_count == 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "no usable PEM bundles found in {dir_path:?} (each file needs cert(s) and private key)"
+            ),
+        ));
+    }
+
+    Ok(resolver)
+}
+
+fn is_pem_like_file(path: &Path) -> bool {
+    matches!(path.extension().and_then(|ext| ext.to_str()), Some("pem"))
+}
+
+fn extract_cert_names(cert: &CertificateDer<'_>) -> Result<Vec<String>, io::Error> {
+    let (_, parsed) = parse_x509_certificate(cert.as_ref()).map_err(|err| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            format!("failed to parse certificate for SAN/CN extraction: {err}"),
+        )
+    })?;
+
+    let mut names = HashSet::new();
+
+    if let Ok(Some(san)) = parsed.subject_alternative_name() {
+        for general_name in &san.value.general_names {
+            if let GeneralName::DNSName(dns) = general_name {
+                names.insert(dns.to_ascii_lowercase());
+            }
+        }
+    }
+
+    for cn_attr in parsed.subject().iter_common_name() {
+        if let Ok(cn) = cn_attr.as_str() {
+            names.insert(cn.to_ascii_lowercase());
+        }
+    }
+
+    let mut out: Vec<String> = names.into_iter().collect();
+    out.sort();
+    Ok(out)
+}
+
+#[derive(Clone, Debug)]
+pub struct TlsConnectInfo {
+    /// Returns the local address of this connection.
+    pub local_addr: Option<SocketAddr>,
+    /// Returns the remote (peer) address of this connection.
+    pub remote_addr: Option<SocketAddr>,
+    /// Returns the SNI hostname of the server certificate used for this connection, if any.
+    pub sni: Option<String>,
+}
+
+pin_project_lite::pin_project! {
+    pub struct TlsIO {
+        #[pin]
+        inner: TlsStream<TcpStream>,
+        connect_info: TlsConnectInfo,
+    }
+}
+
+impl Connected for TlsIO {
+    type ConnectInfo = TlsConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        self.connect_info.clone()
+    }
+}
+
+impl AsyncRead for TlsIO {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for TlsIO {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().inner.poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+}
+
+pub struct TlsIncoming {
+    incoming: TcpIncoming,
+    acceptor: TlsAcceptor,
+    tasks: JoinSet<Result<TlsIO, io::Error>>,
+}
+
+impl TlsIncoming {
+    pub fn new(incoming: TcpIncoming, acceptor: TlsAcceptor) -> Self {
+        Self {
+            incoming,
+            acceptor,
+            tasks: JoinSet::new(),
+        }
+    }
+}
+
+impl Stream for TlsIncoming {
+    type Item = Result<TlsIO, io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            let mut task_pending = false;
+            match Pin::new(&mut this.tasks).poll_join_next(cx) {
+                Poll::Ready(Some(Ok(Ok(stream)))) => return Poll::Ready(Some(Ok(stream))),
+                Poll::Ready(Some(Ok(Err(err)))) => {
+                    log::error!("TLS handshake error: {err}");
+                    continue;
+                }
+                Poll::Ready(Some(Err(err))) => {
+                    return Poll::Ready(Some(Err(io::Error::other(format!(
+                        "TLS handshake task failed: {err}"
+                    )))));
+                }
+                Poll::Ready(None) => {}
+                Poll::Pending => {
+                    task_pending = true;
+                }
+            }
+
+            match Pin::new(&mut this.incoming).poll_next(cx) {
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Ok(tcp_stream))) => {
+                    let remote_addr = tcp_stream.peer_addr().ok();
+                    let acceptor = this.acceptor.clone();
+                    let local_addr = tcp_stream.local_addr().ok();
+                    this.tasks.spawn(async move {
+                        let tls_stream = acceptor.accept(tcp_stream).await.map_err(|err| {
+                            io::Error::new(
+                                ErrorKind::InvalidData,
+                                format!("({remote_addr:?}) {err}"),
+                            )
+                        })?;
+
+                        let sni = tls_stream
+                            .get_ref()
+                            .1
+                            .server_name()
+                            .map(std::string::ToString::to_string);
+
+                        Ok(TlsIO {
+                            inner: tls_stream,
+                            connect_info: TlsConnectInfo {
+                                local_addr,
+                                remote_addr,
+                                sni,
+                            },
+                        })
+                    });
+                }
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
+                Poll::Pending => {
+                    if task_pending || this.tasks.is_empty() {
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::{
+            fs::{self, File},
+            io::{ErrorKind, Write},
+            path::PathBuf,
+            sync::{
+                atomic::{AtomicU64, Ordering},
+                Once,
+            },
+            time::{Duration, SystemTime, UNIX_EPOCH},
+        },
+        tokio::io::AsyncWriteExt,
+        tokio_rustls::{
+            rustls::{
+                self,
+                pki_types::{PrivateKeyDer, ServerName},
+            },
+            TlsConnector,
+        },
+        tokio_stream::StreamExt,
+    };
+
+    const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIDQzCCAiugAwIBAgIUP+5U3MPBWVZe2aUrw4AoHZnWf7swDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDYxMTE3NTkzMVoXDTI3MDYx
+MTE3NTkzMVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAuGyyR/6nFgBoxF0UUEaXQcYnrYA0GxKTgV4ZeTIBzlEX
+fBYplTucli39dl/BwSEUaW/9QiwL/lKjlpUhki3QCQQvuXWy935xuiIZPcmEpvd1
+BA7y9qPBizDZm7amBrnLMU0zluePfQ71dFbIp73a4fo2SpibDtofZtqTWKcfOoIn
+37OfsgMd+NmAC+yB39aFozLgV1RGlhaGBmYh0Pjy1IPzuTe+O3A7JaJc9rTvqqMe
+/WWU1cokQN1mJnPZzRgTWR7Q+WgF4FXXxmx8c3Cgwk5Wfzo1ht0bvV+yd9LdSAol
+nd5/Gzv2VCOJOC7IIRXl8u2HWICunX0ZLskCOvDMUQIDAQABo4GMMIGJMB0GA1Ud
+DgQWBBSir783lBGxEjmbV0EnZwrj/DE+0jAfBgNVHSMEGDAWgBSir783lBGxEjmb
+V0EnZwrj/DE+0jAUBgNVHREEDTALgglsb2NhbGhvc3QwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDQYJKoZIhvcNAQEL
+BQADggEBAFs3lXmt+QbWpmsS60FssKAZtjgVh/ZhNBBzTrKsVIncHQlp0hj6VJCH
+cLY15/ZDWKJguf3bc9kLNu9ESOQRR/1dI9RL0EZhjZFYhY2XJFo/mEpf0eZNSZVd
++TRz4wrQkzheTNqtXkHZrAjZP2sx7HUSaPNlEHs0mj/9Ji6JWkmzn7v+QcsoYZF0
+NeIzn1zMo7p9tZu8e5J86GKWy9w/apoqx8PaSMq3MuDpoIH3EJYSpG9fPidqjwPS
+MV3NjIpQ4ZbFjlGGSTahcXNyucDyTMIN0rPFeBMsAbeXzxVt72PngdWWuKfQVXLt
+tLwey6svT+9G/HwV9WmoFYPQjNOcRoI=
+-----END CERTIFICATE-----
+";
+
+    const TEST_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC4bLJH/qcWAGjE
+XRRQRpdBxietgDQbEpOBXhl5MgHOURd8FimVO5yWLf12X8HBIRRpb/1CLAv+UqOW
+lSGSLdAJBC+5dbL3fnG6Ihk9yYSm93UEDvL2o8GLMNmbtqYGucsxTTOW5499DvV0
+Vsinvdrh+jZKmJsO2h9m2pNYpx86giffs5+yAx342YAL7IHf1oWjMuBXVEaWFoYG
+ZiHQ+PLUg/O5N747cDslolz2tO+qox79ZZTVyiRA3WYmc9nNGBNZHtD5aAXgVdfG
+bHxzcKDCTlZ/OjWG3Ru9X7J30t1ICiWd3n8bO/ZUI4k4LsghFeXy7YdYgK6dfRku
+yQI68MxRAgMBAAECggEAS20tNxO322A8eP8GhVRxnVWBOc0CwoXE7TaCnZYttedl
+fvsDc8TnJGbX0HeWYzn3wq2qO0uPdirvO/FvQv1Ypa9gI243TVCaC8HRZ/tItQ7k
+/U1t4iCUUiye+zfmzD5lk5ra/B9liIS7L6MkurID2MNAPB8Q37CnAiZn9+yV8ZPD
+JFMZbzeCSaTApBFTvspiDVWJ1mL1REMPkrMXAwGiRuB8MYUVZCOKMtvNbfRsgVg7
+KcMV5/OjAKQlsWMopjkTaCMOf0OohEyxjO5FCE97y7Ewl6hf/O0bOzh1e47yoRw+
+zG2QLgV2q3fhJMPwFXB1v9Sr1nYRk8cyKMHaDqy5dwKBgQDbOaTG+TMf1xKAhAvn
+digTbBcS4USwU7IIpp7tfTG+0rEnIsQnviCc3WFPk/Z/2GK3zmPQFtKJGr1HbAGf
+UGFmnjn76YNywQQI1aik2v+SNDZGCb/JApsTO/uHHbEq9447TFSiot35BcHqWGri
+jwxd9bQYjnQn9xnvJng+Dk0gWwKBgQDXXJWuIsRV7sjB8pwoZFdY7oUsGQ9gF/RQ
+ntd/EoivNv3F73WW8iE9f4ywSPPtcWNP1hbukv1ASaYhrxsW8vUc88GMtJpez9zk
+LkLCyHkxeznlXcSoV1a24mJyvt3ZamRuJ2pKFNIQzOcgyQh4NAbCdlsFoa68IJ5L
+g5DvuMwlwwKBgQCkyaTKCGJcqb93qUqFd3TSfKqvf3Oxk4g9JnpKjJQLG7cccu69
+7RX4tBREzDU7jn1OKy8uKSmi892ZxV9G0RYWHBP7/2DWrq4IsgptuUzpKqQta4Cl
+aXcGM010GGanpKRegJcSFZkDakeEj2fw25RxQJNa7iH0NLNi6Cj0hK2HBwKBgFz2
+yF4M//egReUC10nQVqw6+h2ZC7wNWxdaGefuljYcZNuGjJoGFzc20gJe230Jzzbt
+UaTWqp+PqzkrH2R+qDRBPLGCXIjE7bNKDOOMKlSjvtA18+g/G12Cx8CEh7uMY6Hx
+Pb6Q0kUSTksmvJM20hwrfwslSgpHgk1Sk8QHX4iFAoGAQZuzUAw1hbPVq3Tp806E
+ckQJqLtNW/scI6/+HqERbClf0O/aC2TAd0wMcDZA3w2oi6tnhz5jlOg4QFJNK4QK
+sF+HCDt5QXFY9Up3hhtWqKee6Sfd+kGC2cUKNhTZ2Q5VAc4uzJ7TpBU/DX6W+DU0
++fvPCcdQG5i45xzBEPLOHf8=
+-----END PRIVATE KEY-----
+";
+
+    static TEST_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    static CRYPTO_PROVIDER_INIT: Once = Once::new();
+
+    fn init_crypto_provider() {
+        CRYPTO_PROVIDER_INIT.call_once(|| {
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        });
+    }
+
+    struct TempDirGuard {
+        path: PathBuf,
+    }
+
+    impl TempDirGuard {
+        fn new(prefix: &str) -> Self {
+            let unique = TEST_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time should be monotonic after epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "triton-grpc-tools-{prefix}-{}-{nanos}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("temporary test directory should be created");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn is_pem_like_file_matches_expected_extensions() {
+        assert!(is_pem_like_file(Path::new("cert.pem")));
+        assert!(!is_pem_like_file(Path::new("cert.crt")));
+        assert!(!is_pem_like_file(Path::new("cert.key")));
+        assert!(!is_pem_like_file(Path::new("cert.pem.key")));
+        assert!(!is_pem_like_file(Path::new("cert")));
+    }
+
+    #[test]
+    fn extract_cert_names_returns_error_for_invalid_der() {
+        let invalid = CertificateDer::from(vec![1, 2, 3, 4]);
+        let error = extract_cert_names(&invalid).expect_err("invalid DER should fail parsing");
+
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn build_sni_resolver_fails_for_non_directory() {
+        let dir = TempDirGuard::new("non-dir");
+        let file_path = dir.path.join("bundle.pem");
+        fs::write(&file_path, b"not a directory").expect("test file should be written");
+
+        let error = build_sni_resolver_from_cert_dir(&file_path)
+            .expect_err("passing a file path should fail");
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn build_sni_resolver_fails_when_no_usable_pem_bundle_exists() {
+        let dir = TempDirGuard::new("empty-bundles");
+
+        // Non-PEM files are ignored by the loader.
+        let mut txt = File::create(dir.path.join("ignore.txt")).expect("text file should exist");
+        txt.write_all(b"ignored")
+            .expect("text file should be writable");
+
+        let error = build_sni_resolver_from_cert_dir(&dir.path)
+            .expect_err("directory without PEM bundles should fail");
+
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("no usable PEM bundles found"));
+    }
+
+    #[test]
+    fn hot_resolver_swap_preserves_debug_and_no_panic() {
+        let resolver = HotResolvesServerCertUsingSni::new();
+        resolver.swap(SniResolver::new());
+
+        let debug = format!("{resolver:?}");
+        assert!(!debug.is_empty());
+    }
+
+    fn make_test_certified_key() -> CertifiedKey {
+        init_crypto_provider();
+        let (certs, key) = load_test_cert_and_key();
+        let signing_key = any_supported_type(&key).expect("test key should parse");
+        CertifiedKey::new(certs, signing_key)
+    }
+
+    #[test]
+    fn sni_resolver_wildcard_matches_exactly_one_label() {
+        let mut resolver = SniResolver::new();
+        resolver
+            .add("*.rpcpool.com", make_test_certified_key())
+            .expect("wildcard should register");
+
+        assert!(resolver.resolve_by_name("api.rpcpool.com").is_some());
+        assert!(resolver.resolve_by_name("rpcpool.com").is_none());
+        assert!(resolver.resolve_by_name("foo.api.rpcpool.com").is_none());
+    }
+
+    #[test]
+    fn sni_resolver_prefers_more_specific_wildcard() {
+        let mut resolver = SniResolver::new();
+        resolver
+            .add("*.rpcpool.com", make_test_certified_key())
+            .expect("broad wildcard should register");
+        resolver
+            .add("*.mainnet.rpcpool.com", make_test_certified_key())
+            .expect("specific wildcard should register");
+
+        let selected = resolver
+            .resolve_by_name("api.mainnet.rpcpool.com")
+            .expect("matching wildcard should resolve");
+        let broad = resolver
+            .resolve_by_name("api.rpcpool.com")
+            .expect("broad wildcard should resolve");
+
+        assert!(
+            !Arc::ptr_eq(&selected, &broad),
+            "more specific wildcard should select a different certificate"
+        );
+    }
+
+    fn load_test_cert_and_key() -> (
+        Vec<rustls::pki_types::CertificateDer<'static>>,
+        PrivateKeyDer<'static>,
+    ) {
+        let certs = CertificateDer::pem_slice_iter(TEST_CERT_PEM.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("test cert PEM should parse into certificates");
+
+        let key = PrivateKeyDer::from_pem_slice(TEST_KEY_PEM.as_bytes())
+            .expect("test key PEM should contain one private key");
+
+        (certs, key)
+    }
+
+    fn build_test_tls_acceptor() -> TlsAcceptor {
+        init_crypto_provider();
+        let (certs, key) = load_test_cert_and_key();
+
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .expect("server cert and key should build server TLS config");
+
+        TlsAcceptor::from(Arc::new(server_config))
+    }
+
+    fn build_test_tls_connector() -> TlsConnector {
+        init_crypto_provider();
+        let (certs, _key) = load_test_cert_and_key();
+        let mut roots = rustls::RootCertStore::empty();
+        roots
+            .add(certs[0].clone())
+            .expect("root store should accept test certificate");
+
+        let client_config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+
+        TlsConnector::from(Arc::new(client_config))
+    }
+
+    #[tokio::test]
+    async fn tls_incoming_skips_failed_handshake_and_yields_successful_tls_stream() {
+        let tcp_incoming = TcpIncoming::bind("127.0.0.1:0")
+            .await
+            .expect("tcp listener should bind");
+        let addr = tcp_incoming
+            .local_addr()
+            .expect("tcp listener should have local addr");
+        let mut tls_incoming = TlsIncoming::new(tcp_incoming, build_test_tls_acceptor());
+
+        let bad_client = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr)
+                .await
+                .expect("bad client should connect");
+            stream
+                .write_all(b"not-tls")
+                .await
+                .expect("bad client should write plaintext bytes");
+        });
+
+        let good_connector = build_test_tls_connector();
+        let good_client = tokio::spawn(async move {
+            let stream = TcpStream::connect(addr)
+                .await
+                .expect("good client should connect");
+            let server_name = ServerName::try_from("localhost")
+                .expect("localhost should be a valid TLS server name");
+
+            good_connector
+                .connect(server_name, stream)
+                .await
+                .expect("TLS handshake should succeed");
+        });
+
+        let accepted = tokio::time::timeout(Duration::from_secs(5), async {
+            match tls_incoming.next().await {
+                Some(Ok(io)) => io,
+                Some(Err(err)) => panic!("unexpected stream error: {err}"),
+                None => panic!("tls incoming ended unexpectedly"),
+            }
+        })
+        .await
+        .expect("TlsIncoming should yield a successful stream in time");
+
+        bad_client
+            .await
+            .expect("bad client task should complete without panic");
+        good_client
+            .await
+            .expect("good client task should complete without panic");
+
+        let connect_info = accepted.connect_info();
+        assert!(connect_info.local_addr.is_some());
+        assert!(connect_info.remote_addr.is_some());
+        assert_eq!(connect_info.sni.as_deref(), Some("localhost"));
+    }
+}


### PR DESCRIPTION
This part of the initiative to run a secure yellowstone-grpc server instance without the need of a proxy.
In order to do that, we need to support:

- wildcard SAN certificate
- haproxy's style certification directory : a folder of pem files, each containing a unique cert/key pair.
- multi SNI resolution.

This PR re-implement the TCP and TLS incoming from scratch to circumvent limitation in the tonic framework where as tonic's ServerTlsConfig does not allow us to inject a customer Certificate Resolver, only single identity certificate is supported in tonic which forces us to both reimplement TLS and TCP as tonic coupled the two together.
