### PR TITLE
Block reconstruction message batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## 2026-06-26
+
+- yellowstone-grpc-geyser 13.3.1
+
+### Misc
+
+- plugin: Optimize geyser_loop and block_reconstruction_loop, fixed double Slot notifications, fixed Block messages being delayed [#793](https://github.com/rpcpool/yellowstone-grpc/pull/793)
+
 ## 2026-06-23
 
 - yellowstone-grpc-geyser 13.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "13.3.0"
+version = "13.3.1"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.3.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "13.3.1" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
+++ b/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
@@ -10,7 +10,8 @@ use {
         scenario_description, subscribe_should_filter_accounts,
         subscribe_should_only_returns_sysvarclock_account,
         subscribe_should_receive_block_where_sysvarclock1111_account_has_been_updated,
-        subscribe_should_receive_full_blocks, test_subscribe_deshred, RunConfig,
+        subscribe_should_receive_full_blocks, subscribe_should_receive_no_slot_duplicates,
+        test_subscribe_deshred, RunConfig,
     },
 };
 
@@ -25,6 +26,7 @@ enum Scenario {
     TokenOwnerBalanceChanged,
     Ordering,
     FilterAccounts,
+    SlotDuplicate,
 }
 
 impl Scenario {
@@ -39,6 +41,7 @@ impl Scenario {
             Self::TokenOwnerBalanceChanged => "token-owner-balance-changed",
             Self::Ordering => "event-ordering",
             Self::FilterAccounts => "filter-accounts",
+            Self::SlotDuplicate => "slot-duplicate",
         }
     }
 
@@ -180,6 +183,7 @@ async fn run_scenario(scenario: &Scenario, config: &RunConfig) -> Result<()> {
             }
             Scenario::Ordering => it_should_verifies_geyser_event_ordering_is_correct(config).await,
             Scenario::FilterAccounts => subscribe_should_filter_accounts(config).await,
+            Scenario::SlotDuplicate => subscribe_should_receive_no_slot_duplicates(config).await,
         }
     });
     let mut interval = time::interval(Duration::from_millis(120));
@@ -258,6 +262,8 @@ async fn run(cli: Cli) -> Result<()> {
                 Scenario::AnyCommitment,
                 Scenario::TokenOwnerBalanceChanged,
                 Scenario::Ordering,
+                Scenario::FilterAccounts,
+                Scenario::SlotDuplicate,
             ];
 
             for scenario in scenarios {

--- a/yellowstone-grpc-e2e-test/src/scenarios.rs
+++ b/yellowstone-grpc-e2e-test/src/scenarios.rs
@@ -989,3 +989,71 @@ pub async fn subscribe_should_filter_accounts(config: &RunConfig) -> Result<()> 
 
     Ok(())
 }
+
+/// guarantees that one slot message will be received for block + commitment level
+#[test_helper(name = "slot-duplicate")]
+pub async fn subscribe_should_receive_no_slot_duplicates(config: &RunConfig) -> Result<()> {
+    let do_test = async |config: &RunConfig, commitment_level: CommitmentLevel| -> Result<()> {
+        let mut client = new_client(config).await?;
+
+        let subscription = SubscribeRequest {
+            commitment: Some(commitment_level as i32),
+            slots: HashMap::from([(
+                "test".to_string(),
+                SubscribeRequestFilterSlots {
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let mut stream = client
+            .subscribe_once(subscription)
+            .await
+            .context("subscription should succeed")?;
+        const MAX_UPDATES: usize = 5;
+
+        let mut count = 0;
+        let mut slot_received = HashSet::new();
+
+        while let Some(update) = stream.next().await {
+            if count >= MAX_UPDATES {
+                break;
+            }
+            let update = update.context("stream should yield updates without error")?;
+            let Some(update_oneof) = update.update_oneof else {
+                continue;
+            };
+
+            match update_oneof {
+                UpdateOneof::Slot(slot_update) => {
+                    if slot_received.insert((slot_update.slot, slot_update.status)) {
+                        log::info!(
+                            "received slot update for slot {} with status {:?} {count}/{MAX_UPDATES}",
+                            slot_update.slot,
+                            slot_update.status
+                        );
+                        count += 1;
+                    } else {
+                        bail!(
+                            "received duplicate slot update for slot {} with status {:?} on commitment level subscription {:?}",
+                            slot_update.slot,
+                            slot_update.status,
+                            commitment_level
+                        );
+                    }
+                }
+                UpdateOneof::Ping(_) | UpdateOneof::Pong(_) => continue,
+                _ => continue,
+            }
+        }
+
+        Ok(())
+    };
+
+    do_test(config, CommitmentLevel::Finalized).await?;
+    do_test(config, CommitmentLevel::Confirmed).await?;
+    do_test(config, CommitmentLevel::Processed).await?;
+
+    Ok(())
+}

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "13.3.0"
+version = "13.3.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -31,7 +31,6 @@ use {
         pki_types::{pem::PemObject, PrivateKeyDer},
         ServerConfig,
     },
-    smallvec::SmallVec,
     solana_clock::{Slot, MAX_RECENT_BLOCKHASHES},
     std::{
         collections::HashMap,
@@ -809,29 +808,17 @@ impl GrpcService {
 
         {
             let broadcast_tx = broadcast_tx.clone();
-            let completion_token = task_tracker.token();
-            let _ = std::thread::Builder::new()
-                .name("solGrpcBlockReconstruction".to_string())
-                .spawn(move || {
-                    let runtime = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .expect("Failed to create Tokio runtime for BlockReconstruction");
-
-                    runtime.block_on(async move {
-                        Self::block_reconstruction_loop(
-                            block_reconstruction_rx,
-                            blocks_meta_tx,
-                            broadcast_tx,
-                            replay_stored_slots_rx,
-                            replay_first_available_slot,
-                            config.replay_stored_slots,
-                        )
-                        .await;
-                    });
-
-                    drop(completion_token);
-                });
+            task_tracker.spawn(async move {
+                Self::block_reconstruction_loop(
+                    block_reconstruction_rx,
+                    blocks_meta_tx,
+                    broadcast_tx,
+                    replay_stored_slots_rx,
+                    replay_first_available_slot,
+                    config.replay_stored_slots,
+                )
+                .await;
+            });
         }
 
         task_tracker.spawn(async move {
@@ -975,7 +962,7 @@ impl GrpcService {
     async fn geyser_loop(
         mut messages_rx: mpsc::UnboundedReceiver<Message>,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
-        block_reconstruction_tx: mpsc::UnboundedSender<Message>,
+        block_reconstruction_tx: mpsc::UnboundedSender<Arc<Vec<Message>>>,
     ) {
         const PROCESSED_MESSAGES_MAX: usize = 31;
         const STATE_MESSAGES_MAX: usize = 4; /* In a reasonable loop, we don't expect to receive more than FirstShredReceived, Completed, CreatedBank, or Finalized messages per iteration */
@@ -983,8 +970,17 @@ impl GrpcService {
         let mut processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
         let mut confirmed_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
         let mut finalized_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
+        let mut block_reconstruction_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
 
-        let mut blockmeta_detected: SmallVec<[Message; 4]> = SmallVec::new();
+        let is_block_reconstruction_message = |message: &Message| match message {
+            Message::BlockMeta(_) => true,
+            Message::Slot(slot_message) => matches!(
+                slot_message.status,
+                SlotStatus::Processed | SlotStatus::Confirmed | SlotStatus::Finalized
+            ),
+            _ => false,
+        };
+
         loop {
             tokio::select! {
                 maybe = messages_rx.recv() => {
@@ -992,35 +988,33 @@ impl GrpcService {
                         info!("Geyser loop: messages channel closed");
                         break;
                     };
+
                     metrics::message_queue_size_dec();
 
-                    if matches!(&message, Message::BlockMeta(_)) {
-                        let _ = block_reconstruction_tx.send(message);
-                        continue;
+                    if is_block_reconstruction_message(&message) {
+                        block_reconstruction_messages.push(message);
                     }
-
-                    processed_messages.push(message);
+                    else {
+                        processed_messages.push(message);
+                    }
 
                     while let Ok(message) = messages_rx.try_recv() {
                         metrics::message_queue_size_dec();
 
-                        if matches!(&message, Message::BlockMeta(_)) {
-                            blockmeta_detected.push(message);
-                            continue;
+                        if is_block_reconstruction_message(&message) {
+                            block_reconstruction_messages.push(message);
                         }
-
-                        processed_messages.push(message);
-                        if processed_messages.len() >= PROCESSED_MESSAGES_MAX {
-                            break;
+                        else {
+                            processed_messages.push(message);
+                            if processed_messages.len() >= PROCESSED_MESSAGES_MAX {
+                                break;
+                            }
                         }
                     }
 
                     for message in processed_messages.iter() {
-                        let _ = block_reconstruction_tx.send(message.clone());
-
                         match message {
                             Message::Slot(slot_message) => {
-                                metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
                                 // Only match on slot lifecycle update not commitment update, as
                                 // we must go through the block machine to make sure users sees block content before any commitment update.
                                 if matches!(slot_message.status,
@@ -1044,7 +1038,9 @@ impl GrpcService {
 
                     encode_messages(&processed_messages);
                     GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
-                    let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(processed_messages)));
+
+                    let processed_messages_arc = Arc::new(processed_messages);
+                    let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&processed_messages_arc)));
                     processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
 
                     if !confirmed_messages.is_empty() {
@@ -1057,10 +1053,13 @@ impl GrpcService {
                         finalized_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
                     }
 
+                    let _ = block_reconstruction_tx.send(processed_messages_arc);
+
                     // Make sure that blockmeta is always after all kind of other events so the block-machine sees every block
                     // updates.
-                    for blockmeta_message in blockmeta_detected.drain(..) {
-                        let _ = block_reconstruction_tx.send(blockmeta_message);
+                    if !block_reconstruction_messages.is_empty() {
+                        let _ = block_reconstruction_tx.send(Arc::new(block_reconstruction_messages));
+                        block_reconstruction_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
                     }
                 }
             }
@@ -1068,7 +1067,7 @@ impl GrpcService {
     }
 
     async fn block_reconstruction_loop(
-        mut messages_rx: mpsc::UnboundedReceiver<Message>,
+        mut messages_rx: mpsc::UnboundedReceiver<Arc<Vec<Message>>>,
         blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
         replay_stored_slots_rx: Option<mpsc::Receiver<ReplayStoredSlotsRequest>>,
@@ -1085,59 +1084,79 @@ impl GrpcService {
             CommitmentLevel::Finalized,
         ];
 
+        const BUFFERED_MESSAGES_CAPACITY: usize = 32;
+        let mut buffered_messages = Vec::with_capacity(BUFFERED_MESSAGES_CAPACITY);
+
         loop {
             tokio::select! {
                 maybe = messages_rx.recv() => {
-                    let Some(message) = maybe else {
+                    let Some(messages) = maybe else {
                         info!("Geyser loop: messages channel closed");
                         break;
                     };
 
+                    buffered_messages.push(messages);
 
-                    if let Some(blocks_meta_tx) = &blocks_meta_tx {
-                        if matches!(&message, Message::Slot(_) | Message::BlockMeta(_)) {
-                            let _ = blocks_meta_tx.send(message.clone());
+                    while let Ok(messages) = messages_rx.try_recv() {
+                        buffered_messages.push(messages);
+                        if buffered_messages.len() >= BUFFERED_MESSAGES_CAPACITY {
+                            break;
                         }
                     }
 
-                    block_machine.add(message);
+                    for messages in buffered_messages.drain(..) {
+                        for message in messages.iter() {
+                            if let Message::Slot(slot_message) = message {
+                                metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
+                            }
 
-                    while let Some((slot_update, frozen_block)) = block_machine.pop_ready_block() {
-                        let commitment_level = match slot_update.commitment {
-                            solana_commitment_config::CommitmentLevel::Processed => CommitmentLevel::Processed,
-                            solana_commitment_config::CommitmentLevel::Confirmed => CommitmentLevel::Confirmed,
-                            solana_commitment_config::CommitmentLevel::Finalized => CommitmentLevel::Finalized,
-                        };
-                        // Processed must be sent differently, since processed geyser event were individually sent,
-                        // we only need to send Message::Block for block subscriber downstream.
-                        // While, confirmed,finalized must be sent in the two flavors: as a stream of individual events and block.
-                        if commitment_level != CommitmentLevel::Processed {
-                            let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
+                            if let Some(blocks_meta_tx) = &blocks_meta_tx {
+                                if matches!(&message, Message::Slot(_) | Message::BlockMeta(_)) {
+                                    let _ = blocks_meta_tx.send(message.clone());
+                                }
+                            }
+
+                            block_machine.add(message.clone());
+
+                            while let Some((slot_update, frozen_block)) = block_machine.pop_ready_block() {
+                                let commitment_level = match slot_update.commitment {
+                                    solana_commitment_config::CommitmentLevel::Processed => CommitmentLevel::Processed,
+                                    solana_commitment_config::CommitmentLevel::Confirmed => CommitmentLevel::Confirmed,
+                                    solana_commitment_config::CommitmentLevel::Finalized => CommitmentLevel::Finalized,
+                                };
+                                // Processed must be sent differently, since processed geyser event were individually sent,
+                                // we only need to send Message::Block for block subscriber downstream.
+                                // While, confirmed,finalized must be sent in the two flavors: as a stream of individual events and block.
+                                if commitment_level != CommitmentLevel::Processed {
+                                    let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
+                                }
+
+                                let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
+                                let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
+                                let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
+
+                                let slot_message = Message::Slot(MessageSlot {
+                                    slot: slot_update.slot,
+                                    parent: slot_update.parent_slot,
+                                    status: match slot_update.commitment {
+                                        solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
+                                        solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
+                                        solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
+                                    },
+                                    dead_error: None,
+                                    created_at: Timestamp::from(SystemTime::now())
+                                });
+                                let slot_message_singleton_vec = Arc::new(vec![slot_message.clone()]);
+                                for commitment_level in ALL_COMMITMENT_LEVELS {
+                                    let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
+                                }
+                            }
+
+                            let min_replayable_slot = block_machine.min_replayable_slot();
+                            if let (Some(min_slot), Some(replay_first_available_slot)) = (min_replayable_slot, replay_first_available_slot.as_ref()) {
+                                replay_first_available_slot.store(min_slot, Ordering::Relaxed);
+                            }
                         }
-
-                        let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
-                        let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
-                        let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
-
-                        let slot_message = Message::Slot(MessageSlot {
-                            slot: slot_update.slot,
-                            parent: slot_update.parent_slot,
-                            status: match slot_update.commitment {
-                                solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
-                                solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
-                                solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
-                            },
-                            dead_error: None,
-                            created_at: Timestamp::from(SystemTime::now())
-                        });
-                        let slot_message_singleton_vec = Arc::new(vec![slot_message.clone()]);
-                        for commitment_level in ALL_COMMITMENT_LEVELS {
-                            let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
-                        }
-                    }
-                    let min_replayable_slot = block_machine.min_replayable_slot();
-                    if let (Some(min_slot), Some(replay_first_available_slot)) = (min_replayable_slot, replay_first_available_slot.as_ref()) {
-                        replay_first_available_slot.store(min_slot, Ordering::Relaxed);
                     }
                 },
                 Some((commitment, replay_slot, tx)) = replay_stored_slots_rx.recv() => {


### PR DESCRIPTION
Batching messages which we are forwarding to the block reconstruction loop allows us to both reduce the latency of processed messages as well as the latency and throughput of block reconstruction