### PR TITLE
fix: double slot message

### DIFF
--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -994,9 +994,21 @@ impl GrpcService {
                     };
                     metrics::message_queue_size_dec();
 
-                    if matches!(&message, Message::BlockMeta(_)) {
-                        let _ = block_reconstruction_tx.send(message);
-                        continue;
+                    match &message {
+                        Message::BlockMeta(_) => {
+                            blockmeta_detected.push(message);
+                            continue;
+                        }
+                        Message::Slot(s) if matches!(s.status,
+                            SlotStatus::Processed |
+                            SlotStatus::Confirmed |
+                            SlotStatus::Finalized
+                        ) => {
+                            metrics::update_slot_plugin_status(s.status, s.slot);
+                            blockmeta_detected.push(message);
+                            continue;
+                        }
+                        _ => {}
                     }
 
                     processed_messages.push(message);
@@ -1004,9 +1016,21 @@ impl GrpcService {
                     while let Ok(message) = messages_rx.try_recv() {
                         metrics::message_queue_size_dec();
 
-                        if matches!(&message, Message::BlockMeta(_)) {
-                            blockmeta_detected.push(message);
-                            continue;
+                        match &message {
+                            Message::BlockMeta(_) => {
+                                blockmeta_detected.push(message);
+                                continue;
+                            }
+                            Message::Slot(s) if matches!(s.status,
+                                SlotStatus::Processed |
+                                SlotStatus::Confirmed |
+                                SlotStatus::Finalized
+                            ) => {
+                                metrics::update_slot_plugin_status(s.status, s.slot);
+                                blockmeta_detected.push(message);
+                                continue;
+                            }
+                            _ => {}
                         }
 
                         processed_messages.push(message);


### PR DESCRIPTION
#### Problem

Processed subscribers receive duplicate Confirmed/Finalized slot messages for the same slot with different parent fields. One has parent: null, the other has the real parent. [Duplicate Slot Issue](https://github.com/rpcpool/yellowstone-grpc/issues/792)

#### Fix

All commitment statuses should flow through the block machine, never broadcast directly from geyser_loop. The existing code comment already states this ("we must go through the block machine to make sure users see block content before any commitment update"). Current code breaks this by letting commitment statuses into processed_messages.

Redirect commitment statuses (Processed, Confirmed, Finalized) to block_reconstruction_tx in geyser_loop, same pattern as BlockMeta. 