### PR TITLE
str-587: prevent gc block too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,19 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Fixes
 
 - missing Confirmed/Finalized message when `replay_capacity` was set to 0 [#809](https://github.com/rpcpool/yellowstone-grpc/pull/809)
+- missing `parent` value field in `SubscribeSlotUpdate` [#809](https://github.com/rpcpool/yellowstone-grpc/pull/809)
+- fixed some edge cases in block reconstruction where bank-reset or forks detection did not properly refresh min slot.
+- added new e2e tests in `yellowstone-grpc-e2e-tools` around message ordering guarantees.
+- fixed missing `BlockMeta` in `confirmed/finalized` subscription
 
 ### Features
 
 - in-plugin authentication resolution [#795](https://github.com/rpcpool/yellowstone-grpc/pull/795)
+
+### Related PRs
+
+- [#809](https://github.com/rpcpool/yellowstone-grpc/pull/809)
+    - imports changes from [#810](https://github.com/rpcpool/yellowstone-grpc/pull/810)
 
 ## 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## 2026-07-03
+
+- yellowstone-grpc-geyser 14.1.0
+
+### Fixes
+
+- missing Confirmed/Finalized message when `replay_capacity` was set to 0 [#809](https://github.com/rpcpool/yellowstone-grpc/pull/809)
+
+### Features
+
+- in-plugin authentication resolution [#795](https://github.com/rpcpool/yellowstone-grpc/pull/795)
+
 ## 2026-07-02
 
 - yellowstone-grpc-geyser 14.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0-rc3"
+version = "14.1.0"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0"
+version = "14.1.0-rc2"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "14.0.0"
+version = "14.1.0"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0-rc2"
+version = "14.1.0-rc3"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0-rc2" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.0.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0-rc3" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.1.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0-rc2" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0-rc3" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
+++ b/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
@@ -7,11 +7,10 @@ use {
         any_commitment_level_of_subscription_should_return_all_possible_values, init_log,
         it_should_subscribe_to_all_transaction_include_token_ata_to_an_owner,
         it_should_support_replay, it_should_verifies_geyser_event_ordering_is_correct,
-        scenario_description, subscribe_should_filter_accounts,
-        subscribe_should_only_returns_sysvarclock_account,
+        it_should_verify_replay_ordering_matches_live_path, scenario_description,
+        subscribe_should_filter_accounts, subscribe_should_only_returns_sysvarclock_account,
         subscribe_should_receive_block_where_sysvarclock1111_account_has_been_updated,
         subscribe_should_receive_full_blocks, subscribe_should_receive_no_slot_duplicates,
-        it_should_verify_replay_ordering_matches_live_path,
         test_subscribe_deshred, RunConfig,
     },
 };
@@ -204,7 +203,9 @@ async fn run_scenario(scenario: &Scenario, config: &RunConfig) -> Result<()> {
             Scenario::Ordering => it_should_verifies_geyser_event_ordering_is_correct(config).await,
             Scenario::FilterAccounts => subscribe_should_filter_accounts(config).await,
             Scenario::SlotDuplicate => subscribe_should_receive_no_slot_duplicates(config).await,
-            Scenario::ReplayOrdering => it_should_verify_replay_ordering_matches_live_path(config).await
+            Scenario::ReplayOrdering => {
+                it_should_verify_replay_ordering_matches_live_path(config).await
+            }
         }
     });
     let mut interval = time::interval(Duration::from_millis(120));

--- a/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
+++ b/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
@@ -11,6 +11,7 @@ use {
         subscribe_should_only_returns_sysvarclock_account,
         subscribe_should_receive_block_where_sysvarclock1111_account_has_been_updated,
         subscribe_should_receive_full_blocks, subscribe_should_receive_no_slot_duplicates,
+        it_should_verify_replay_ordering_matches_live_path,
         test_subscribe_deshred, RunConfig,
     },
 };
@@ -27,6 +28,7 @@ enum Scenario {
     Ordering,
     FilterAccounts,
     SlotDuplicate,
+    ReplayOrdering,
 }
 
 impl Scenario {
@@ -42,6 +44,7 @@ impl Scenario {
             Self::Ordering => "event-ordering",
             Self::FilterAccounts => "filter-accounts",
             Self::SlotDuplicate => "slot-duplicate",
+            Self::ReplayOrdering => "replay-ordering",
         }
     }
 
@@ -201,6 +204,7 @@ async fn run_scenario(scenario: &Scenario, config: &RunConfig) -> Result<()> {
             Scenario::Ordering => it_should_verifies_geyser_event_ordering_is_correct(config).await,
             Scenario::FilterAccounts => subscribe_should_filter_accounts(config).await,
             Scenario::SlotDuplicate => subscribe_should_receive_no_slot_duplicates(config).await,
+            Scenario::ReplayOrdering => it_should_verify_replay_ordering_matches_live_path(config).await
         }
     });
     let mut interval = time::interval(Duration::from_millis(120));
@@ -253,6 +257,7 @@ async fn run(cli: Cli) -> Result<()> {
             Scenario::Deshred,
             Scenario::AnyCommitment,
             Scenario::TokenOwnerBalanceChanged,
+            Scenario::ReplayOrdering,
         ];
 
         for scenario in scenarios {
@@ -286,6 +291,7 @@ async fn run(cli: Cli) -> Result<()> {
                 Scenario::Ordering,
                 Scenario::FilterAccounts,
                 Scenario::SlotDuplicate,
+                Scenario::ReplayOrdering,
             ];
 
             for scenario in scenarios {

--- a/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
+++ b/yellowstone-grpc-e2e-test/src/bin/yellowstone-e2e.rs
@@ -8,7 +8,8 @@ use {
         it_should_subscribe_to_all_transaction_include_token_ata_to_an_owner,
         it_should_support_replay, it_should_verifies_geyser_event_ordering_is_correct,
         it_should_verify_replay_ordering_matches_live_path, scenario_description,
-        subscribe_should_filter_accounts, subscribe_should_only_returns_sysvarclock_account,
+        slot_status_should_have_parent, subscribe_should_filter_accounts,
+        subscribe_should_only_returns_sysvarclock_account,
         subscribe_should_receive_block_where_sysvarclock1111_account_has_been_updated,
         subscribe_should_receive_full_blocks, subscribe_should_receive_no_slot_duplicates,
         test_subscribe_deshred, RunConfig,
@@ -28,6 +29,7 @@ enum Scenario {
     FilterAccounts,
     SlotDuplicate,
     ReplayOrdering,
+    SlotStatusParentPresent,
 }
 
 impl Scenario {
@@ -44,6 +46,7 @@ impl Scenario {
             Self::FilterAccounts => "filter-accounts",
             Self::SlotDuplicate => "slot-duplicate",
             Self::ReplayOrdering => "replay-ordering",
+            Self::SlotStatusParentPresent => "slot-status-parent-present",
         }
     }
 
@@ -206,6 +209,7 @@ async fn run_scenario(scenario: &Scenario, config: &RunConfig) -> Result<()> {
             Scenario::ReplayOrdering => {
                 it_should_verify_replay_ordering_matches_live_path(config).await
             }
+            Scenario::SlotStatusParentPresent => slot_status_should_have_parent(config).await,
         }
     });
     let mut interval = time::interval(Duration::from_millis(120));
@@ -293,6 +297,7 @@ async fn run(cli: Cli) -> Result<()> {
                 Scenario::FilterAccounts,
                 Scenario::SlotDuplicate,
                 Scenario::ReplayOrdering,
+                Scenario::SlotStatusParentPresent,
             ];
 
             for scenario in scenarios {

--- a/yellowstone-grpc-e2e-test/src/scenarios.rs
+++ b/yellowstone-grpc-e2e-test/src/scenarios.rs
@@ -1075,3 +1075,157 @@ pub async fn subscribe_should_receive_no_slot_duplicates(config: &RunConfig) -> 
 
     Ok(())
 }
+
+/// Verifies replay message ordering matches the live broadcast path:
+/// block data (Account/Transaction/Entry) before Block before BlockMeta before slot status.
+#[test_helper(name = "replay-ordering")]
+pub async fn it_should_verify_replay_ordering_matches_live_path(config: &RunConfig) -> Result<()> {
+    let mut client = new_client(config).await?;
+
+    let resp = client.get_slot(None).await.context("get_slot")?;
+    let tip = resp.slot;
+    let from_slot = tip.saturating_sub(10);
+
+    let subscription = SubscribeRequest {
+        slots: HashMap::from([(
+            "test".to_string(),
+            SubscribeRequestFilterSlots {
+                interslot_updates: Some(true),
+                ..Default::default()
+            },
+        )]),
+        blocks: HashMap::from([(
+            "test".to_string(),
+            SubscribeRequestFilterBlocks {
+                include_accounts: Some(true),
+                include_transactions: Some(true),
+                include_entries: Some(true),
+                ..Default::default()
+            },
+        )]),
+        blocks_meta: HashMap::from([("test".to_string(), Default::default())]),
+        accounts: HashMap::from([(
+            "test".to_string(),
+            SubscribeRequestFilterAccounts {
+                account: vec![],
+                ..Default::default()
+            },
+        )]),
+        transactions: HashMap::from([("test".to_string(), Default::default())]),
+        entry: HashMap::from([("test".to_string(), Default::default())]),
+        from_slot: Some(from_slot),
+        commitment: Some(1),
+        ..Default::default()
+    };
+
+    let mut stream = client
+        .subscribe_once(subscription)
+        .await
+        .context("subscription should succeed")?;
+
+    log::info!(
+        "current tip slot is {}, subscribing from slot {}",
+        tip,
+        from_slot
+    );
+
+    // Track message ordering per slot
+    #[derive(Default)]
+    struct SlotOrdering {
+        last_data_seq: Option<usize>,
+        block_seq: Option<usize>,
+        blockmeta_seq: Option<usize>,
+        first_status_seq: Option<usize>,
+    }
+
+    let mut slot_orderings: HashMap<u64, SlotOrdering> = HashMap::new();
+    let mut seq: usize = 0;
+    let mut validated_slots = 0usize;
+    const TARGET_VALIDATED_SLOTS: usize = 3;
+
+    while let Some(update) = stream.next().await {
+        if validated_slots >= TARGET_VALIDATED_SLOTS {
+            break;
+        }
+        let update = update.context("stream should yield updates without error")?;
+        let Some(update_oneof) = update.update_oneof else {
+            continue;
+        };
+
+        match update_oneof {
+            UpdateOneof::Account(ev) => {
+                let ordering = slot_orderings.entry(ev.slot).or_default();
+                ordering.last_data_seq = Some(seq);
+                seq += 1;
+            }
+            UpdateOneof::Transaction(ev) => {
+                let ordering = slot_orderings.entry(ev.slot).or_default();
+                ordering.last_data_seq = Some(seq);
+                seq += 1;
+            }
+            UpdateOneof::Entry(ev) => {
+                let ordering = slot_orderings.entry(ev.slot).or_default();
+                ordering.last_data_seq = Some(seq);
+                seq += 1;
+            }
+            UpdateOneof::Block(ev) => {
+                let ordering = slot_orderings.entry(ev.slot).or_default();
+                ordering.block_seq = Some(seq);
+                seq += 1;
+            }
+            UpdateOneof::BlockMeta(ev) => {
+                let ordering = slot_orderings.entry(ev.slot).or_default();
+                ordering.blockmeta_seq = Some(seq);
+                seq += 1;
+
+                // BlockMeta is the last content message before slot status.
+                // Validate ordering for this slot if we have all phases.
+                let ordering = slot_orderings.get(&ev.slot).unwrap();
+                if let (Some(last_data), Some(block), Some(blockmeta)) =
+                    (ordering.last_data_seq, ordering.block_seq, ordering.blockmeta_seq)
+                {
+                    ensure!(
+                        last_data < block,
+                        "slot {}: block data (seq {last_data}) must arrive before Block (seq {block})",
+                        ev.slot
+                    );
+                    ensure!(
+                        block < blockmeta,
+                        "slot {}: Block (seq {block}) must arrive before BlockMeta (seq {blockmeta})",
+                        ev.slot
+                    );
+                    validated_slots += 1;
+                    log::info!(
+                        "slot {}: ordering verified {validated_slots}/{TARGET_VALIDATED_SLOTS}",
+                        ev.slot
+                    );
+                }
+            }
+            UpdateOneof::Slot(ev) => {
+                let ordering = slot_orderings.entry(ev.slot).or_default();
+                if ordering.first_status_seq.is_none() {
+                    ordering.first_status_seq = Some(seq);
+
+                    // If we already have blockmeta, verify status comes after
+                    if let Some(blockmeta) = ordering.blockmeta_seq {
+                        ensure!(
+                            blockmeta < seq,
+                            "slot {}: BlockMeta (seq {blockmeta}) must arrive before slot status (seq {seq})",
+                            ev.slot
+                        );
+                    }
+                }
+                seq += 1;
+            }
+            UpdateOneof::Ping(_) | UpdateOneof::Pong(_) => continue,
+            _ => continue,
+        }
+    }
+
+    ensure!(
+        validated_slots >= TARGET_VALIDATED_SLOTS,
+        "should have validated ordering for at least {TARGET_VALIDATED_SLOTS} slots, got {validated_slots}"
+    );
+
+    Ok(())
+}

--- a/yellowstone-grpc-e2e-test/src/scenarios.rs
+++ b/yellowstone-grpc-e2e-test/src/scenarios.rs
@@ -1181,9 +1181,11 @@ pub async fn it_should_verify_replay_ordering_matches_live_path(config: &RunConf
                 // BlockMeta is the last content message before slot status.
                 // Validate ordering for this slot if we have all phases.
                 let ordering = slot_orderings.get(&ev.slot).unwrap();
-                if let (Some(last_data), Some(block), Some(blockmeta)) =
-                    (ordering.last_data_seq, ordering.block_seq, ordering.blockmeta_seq)
-                {
+                if let (Some(last_data), Some(block), Some(blockmeta)) = (
+                    ordering.last_data_seq,
+                    ordering.block_seq,
+                    ordering.blockmeta_seq,
+                ) {
                     ensure!(
                         last_data < block,
                         "slot {}: block data (seq {last_data}) must arrive before Block (seq {block})",

--- a/yellowstone-grpc-e2e-test/src/scenarios.rs
+++ b/yellowstone-grpc-e2e-test/src/scenarios.rs
@@ -377,7 +377,7 @@ pub async fn it_should_support_replay(config: &RunConfig) -> Result<()> {
             UpdateOneof::Slot(slot) => {
                 slot_status_received.insert(slot.slot, slot.status());
                 ensure!(
-                    slot.parent.is_some(), 
+                    slot.parent.is_some(),
                     "slot update should have parent slot for replayed slots"
                 );
                 if block_visited.contains(&slot.slot) {
@@ -1256,6 +1256,67 @@ pub async fn it_should_verify_replay_ordering_matches_live_path(config: &RunConf
         validated_slots >= TARGET_VALIDATED_SLOTS,
         "should have validated ordering for at least {TARGET_VALIDATED_SLOTS} slots, got {validated_slots}"
     );
+
+    Ok(())
+}
+
+/// Verifies that slot status updates have a parent slot when applicable.
+#[test_helper(name = "slot-status-parent-present")]
+pub async fn slot_status_should_have_parent(config: &RunConfig) -> Result<()> {
+    let mut client = new_client(config).await?;
+
+    let subscription = SubscribeRequest {
+        slots: HashMap::from([(
+            "test".to_string(),
+            SubscribeRequestFilterSlots {
+                interslot_updates: Some(false),
+                ..Default::default()
+            },
+        )]),
+        commitment: Some(0),
+        ..Default::default()
+    };
+
+    let mut stream = client
+        .subscribe_once(subscription)
+        .await
+        .context("subscription should succeed")?;
+
+    let mut slot_progression: HashMap<u64, Vec<_>> = HashMap::new();
+
+    const ALL_COMMITMENT: [SlotStatus; 3] = [
+        SlotStatus::SlotProcessed,
+        SlotStatus::SlotConfirmed,
+        SlotStatus::SlotFinalized,
+    ];
+    // 64 first slot should have gone through at least one finalized slot
+    const MAX_SLOTS: usize = 500;
+    while let Some(update) = stream.next().await {
+        if slot_progression.len() >= MAX_SLOTS {
+            bail!(
+                "should have received updates for at least {MAX_SLOTS} slots, got {}",
+                slot_progression.len()
+            )
+        }
+        let update = update.context("stream should yield updates without error")?;
+        let Some(UpdateOneof::Slot(ev)) = update.update_oneof else {
+            continue;
+        };
+
+        let slot = ev.slot;
+        ensure!(
+            ev.parent.is_some(),
+            "slot {} with status {:?} should have a parent slot",
+            slot,
+            ev.status()
+        );
+        let status_so_far = slot_progression.entry(slot).or_default();
+        status_so_far.push(ev.status());
+        // We stop the test once we have received all commitment levels for a slot, since we only need to verify that the parent is present for each commitment level.
+        if ALL_COMMITMENT.iter().all(|c| status_so_far.contains(c)) {
+            break;
+        }
+    }
 
     Ok(())
 }

--- a/yellowstone-grpc-e2e-test/src/scenarios.rs
+++ b/yellowstone-grpc-e2e-test/src/scenarios.rs
@@ -344,6 +344,7 @@ pub async fn it_should_support_replay(config: &RunConfig) -> Result<()> {
             },
         )]),
         accounts: HashMap::from([("test".to_string(), account_filter)]),
+        blocks_meta: HashMap::from([("test".to_string(), Default::default())]),
         from_slot: Some(from_slot),
         ..Default::default()
     };
@@ -360,9 +361,11 @@ pub async fn it_should_support_replay(config: &RunConfig) -> Result<()> {
         from_slot
     );
     let mut remaining_slot_to_visit = Vec::from_iter(from_slot..tip);
+    let mut block_visited = HashSet::new();
+    let mut block_meta_received = HashSet::new();
     let mut slot_status_received = HashMap::new();
     while let Some(update) = stream.next().await {
-        if count >= MAX_UPDATES {
+        if remaining_slot_to_visit.is_empty() {
             break;
         }
         let update = update.context("stream should yield updates without error")?;
@@ -373,6 +376,14 @@ pub async fn it_should_support_replay(config: &RunConfig) -> Result<()> {
         match update_oneof {
             UpdateOneof::Slot(slot) => {
                 slot_status_received.insert(slot.slot, slot.status());
+                ensure!(
+                    slot.parent.is_some(), 
+                    "slot update should have parent slot for replayed slots"
+                );
+                if block_visited.contains(&slot.slot) {
+                    count += 1;
+                }
+                remaining_slot_to_visit.retain(|s| *s != slot.slot);
             }
             UpdateOneof::Account(subscribe_update_account) => {
                 let account = subscribe_update_account
@@ -384,11 +395,28 @@ pub async fn it_should_support_replay(config: &RunConfig) -> Result<()> {
                     actual_pubkey == sysvar_clock_pubkey,
                     "received unexpected pubkey"
                 );
-                count += 1;
-                remaining_slot_to_visit.retain(|&slot| slot != subscribe_update_account.slot);
+                block_visited.insert(subscribe_update_account.slot);
+
+                ensure!(
+                    !block_meta_received.contains(&subscribe_update_account.slot),
+                    "block meta should always be last to arrive for a slot, after all account updates have been received"
+                );
+
+                ensure!(
+                    !slot_status_received.contains_key(&subscribe_update_account.slot),
+                    "slot status should always be last to arrive for a slot, after all account updates have been received"
+                );
+
                 log::info!(
                     "received account update for slot {} {count}/{MAX_UPDATES}",
                     subscribe_update_account.slot
+                );
+            }
+            UpdateOneof::BlockMeta(ev) => {
+                block_meta_received.insert(ev.slot);
+                ensure!(
+                    !slot_status_received.contains_key(&ev.slot),
+                    "slot status should always be last to arrive for a slot, after all block meta updates have been received"
                 );
             }
             UpdateOneof::Ping(_) | UpdateOneof::Pong(_) => continue,

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0-rc3"
+version = "14.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "14.0.0"
+version = "14.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0"
+version = "14.1.0-rc2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0-rc2"
+version = "14.1.0-rc3"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -186,6 +186,7 @@ pub struct BlockMachineStorage {
     ready_queue: VecDeque<(SlotCommitmentStatusUpdate, Arc<FrozenBlock>)>,
     state: BlocksStateMachine,
     min_slot: Option<u64>,
+    num_buffered_finalized_slot: usize,
 }
 
 pub struct ReplayIter<'storage> {
@@ -233,6 +234,21 @@ impl<'storage> Iterator for ReplayIter<'storage> {
     }
 }
 
+///
+/// As blocks are frozen, they are added to the `replayed_slot` map.
+///
+/// This map has a maximum capacity, and when that capacity is exceeded, the oldest slots are pruned.
+///
+/// The [`MINIMUM_FINALIZED_SLOT_TO_BUFFER`] constant makes sure we have enough finalized slot in our state to avoid pruning slots
+/// that are still in the process of being finalized, which could lead to missing finalized/confirmed messages for those slots.
+///
+/// See [`BlockMachineStorage::gc`] for more details.
+///
+///
+/// We used to do this in prior to version v13.2.0 of the plugin (before the reconstruction refactor)
+///
+pub const MINIMUM_FINALIZED_SLOT_TO_BUFFER: usize = 10;
+
 impl BlockMachineStorage {
     pub fn new(replayed_capacity: usize) -> Self {
         Self {
@@ -244,6 +260,7 @@ impl BlockMachineStorage {
             ready_queue: VecDeque::new(),
             state: BlocksStateMachine::default(),
             min_slot: None,
+            num_buffered_finalized_slot: 0,
         }
     }
 
@@ -251,7 +268,12 @@ impl BlockMachineStorage {
         self.processing_slots.remove(&slot);
         self.pending_blockmeta.remove(&slot);
         self.replayed_slot.remove(&slot);
-        self.slot_commitment_progression_map.remove(&slot);
+        if let Some(progression) = self.slot_commitment_progression_map.remove(&slot) {
+            if progression.max_commitment == CommitmentLevel::Finalized {
+                self.num_buffered_finalized_slot =
+                    self.num_buffered_finalized_slot.saturating_sub(1);
+            }
+        }
     }
 
     fn slot_reset(&mut self, slot: u64) {
@@ -356,7 +378,9 @@ impl BlockMachineStorage {
     }
 
     fn gc(&mut self) {
-        while self.replayed_slot.len() > self.replayed_capacity {
+        while self.replayed_slot.len() > self.replayed_capacity
+            && self.num_buffered_finalized_slot > MINIMUM_FINALIZED_SLOT_TO_BUFFER
+        {
             if let Some((&oldest_slot, _)) = self.replayed_slot.iter().next() {
                 self.prune_slot(oldest_slot);
             }
@@ -383,9 +407,24 @@ impl BlockMachineStorage {
                 self.slot_commitment_progression_map
                     .entry(slot)
                     .and_modify(|progression| {
-                        progression
+                        // Make sure its not there already
+                        if !progression
                             .commitment
-                            .push(slot_commitment_status_update.clone());
+                            .iter()
+                            .any(|s| s.commitment == slot_commitment_status_update.commitment)
+                        {
+                            progression
+                                .commitment
+                                .push(slot_commitment_status_update.clone());
+
+                            if matches!(
+                                slot_commitment_status_update.commitment,
+                                CommitmentLevel::Finalized
+                            ) {
+                                self.num_buffered_finalized_slot += 1;
+                            }
+                        }
+
                         if cmp_commitment_level(
                             slot_commitment_status_update.commitment,
                             progression.max_commitment,
@@ -394,20 +433,30 @@ impl BlockMachineStorage {
                             progression.max_commitment = slot_commitment_status_update.commitment;
                         }
                     })
-                    .or_insert_with(|| SlotProgression {
-                        commitment: vec![slot_commitment_status_update.clone()],
-                        max_commitment: slot_commitment_status_update.commitment,
+                    .or_insert_with(|| {
+                        if matches!(
+                            slot_commitment_status_update.commitment,
+                            CommitmentLevel::Finalized
+                        ) {
+                            self.num_buffered_finalized_slot += 1;
+                        }
+
+                        SlotProgression {
+                            commitment: vec![slot_commitment_status_update.clone()],
+                            max_commitment: slot_commitment_status_update.commitment,
+                        }
                     });
 
                 let commitment_level = slot_commitment_status_update.commitment;
-                if matches!(commitment_level, CommitmentLevel::Finalized) {
-                    // Only gc on finalized, that should be enough.
-                    self.gc();
-                }
 
                 if let Some(frozen_block) = self.replayed_slot.get(&slot) {
                     self.ready_queue
                         .push_back((slot_commitment_status_update, Arc::clone(frozen_block)));
+                }
+
+                if matches!(commitment_level, CommitmentLevel::Finalized) {
+                    // Only gc on finalized, that should be enough.
+                    self.gc();
                 }
             }
             BlockStateMachineOutput::ForksDetected(fork_detected) => {
@@ -931,5 +980,23 @@ mod tests {
             /* Last message is explicitly sent as BlockMeta, its no longer implicit inside of original_messages */
             assert_eq!(entry_count, 2);
         }
+    }
+
+    #[test]
+    fn block_machine_should_yield_all_block_and_commitment_when_replayed_capacity_set_to_zero() {
+        let mut storage = BlockMachineStorage::new(0);
+        drive_slot_to_processed(&mut storage, 1, None);
+        storage.add(make_slot_msg(1, None, SlotStatus::Confirmed));
+        storage.add(make_slot_msg(1, None, SlotStatus::Finalized));
+
+        // Drain the ready queue
+        let (actual, _block) = storage.pop_ready_block().unwrap();
+        assert!(actual.commitment == CommitmentLevel::Processed);
+
+        let (actual, _block) = storage.pop_ready_block().unwrap();
+        assert!(actual.commitment == CommitmentLevel::Confirmed);
+
+        let (actual, _block) = storage.pop_ready_block().unwrap();
+        assert!(actual.commitment == CommitmentLevel::Finalized);
     }
 }

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -219,7 +219,9 @@ impl<'storage> Iterator for ReplayIter<'storage> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let (slot, block) = self.iter.next()?;
-            let progression = self.storage.slot_commitment_progression_map.get(slot)?;
+            let Some(progression) = self.storage.slot_commitment_progression_map.get(slot) else {
+                continue;
+            };
             let commitment_level = progression.max_commitment;
             if cmp_commitment_level(commitment_level, self.min_commitment)
                 == std::cmp::Ordering::Less
@@ -264,7 +266,11 @@ impl BlockMachineStorage {
         }
     }
 
-    fn prune_slot(&mut self, slot: u64) {
+    fn refresh_min_slot(&mut self) {
+        self.min_slot = self.replayed_slot.keys().next().copied();
+    }
+
+    fn prune_slot(&mut self, slot: u64, refresh_min_slot: bool) {
         self.processing_slots.remove(&slot);
         self.pending_blockmeta.remove(&slot);
         self.replayed_slot.remove(&slot);
@@ -274,10 +280,13 @@ impl BlockMachineStorage {
                     self.num_buffered_finalized_slot.saturating_sub(1);
             }
         }
+        if refresh_min_slot {
+            self.refresh_min_slot();
+        }
     }
 
     fn slot_reset(&mut self, slot: u64) {
-        self.prune_slot(slot);
+        self.prune_slot(slot, true);
         self.ready_queue
             .retain(|(_, block)| block.block_meta.slot != slot);
     }
@@ -372,6 +381,16 @@ impl BlockMachineStorage {
             metrics::incr_geyser_untrack_slot_event_dropped();
             return;
         }
+        // Technically, once a block is sealed and put in the replay queue, we should not NEVER
+        // receive any more block data for that slot.
+        // We still add this line of code to be extra cautious!
+        if self.replayed_slot.contains_key(&slot) {
+            log::error!(
+                "UNEXPECTED: Received block data for slot {} that is already sealed and in the replay queue. Dropping the message.",
+                slot
+            );
+            return;
+        }
         let slot_buf = self.processing_slots.entry(slot).or_default();
         slot_buf.add_event(block_data);
         self.try_seal(slot);
@@ -382,10 +401,12 @@ impl BlockMachineStorage {
             && self.num_buffered_finalized_slot > MINIMUM_FINALIZED_SLOT_TO_BUFFER
         {
             if let Some((&oldest_slot, _)) = self.replayed_slot.iter().next() {
-                self.prune_slot(oldest_slot);
+                // refresh_min_slot is set to false, since we don't want to refresh the min_slot on every prune, but only after the loop is done.
+                self.prune_slot(oldest_slot, false);
             }
         }
-        self.min_slot = self.replayed_slot.keys().min().copied();
+
+        self.refresh_min_slot();
         self.state.gc(None);
     }
 
@@ -460,10 +481,10 @@ impl BlockMachineStorage {
                 }
             }
             BlockStateMachineOutput::ForksDetected(fork_detected) => {
-                self.prune_slot(fork_detected.slot);
+                self.prune_slot(fork_detected.slot, true);
             }
             BlockStateMachineOutput::DeadSlotDetected(dead_block_detected) => {
-                self.prune_slot(dead_block_detected.slot);
+                self.prune_slot(dead_block_detected.slot, true);
             }
             BlockStateMachineOutput::BankCreated(_) => {}
             BlockStateMachineOutput::BankReset(slot) => {
@@ -475,7 +496,11 @@ impl BlockMachineStorage {
     pub fn add(&mut self, message: Message) {
         match message {
             Message::Slot(message_slot) => {
-                let _ = self.on_message_slot(message_slot);
+                if self.on_message_slot(message_slot).is_err() {
+                    // Symmetric with handle_block_data which increments the same metric
+                    // when is_slot_tracked returns false.
+                    metrics::incr_geyser_untrack_slot_event_dropped();
+                }
             }
             Message::Account(message_account) => {
                 self.handle_block_data(Message::Account(message_account));

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1247,7 +1247,7 @@ impl GrpcService {
                             .map(|s| {
                                 Message::Slot(MessageSlot {
                                     slot: s.slot,
-                                    parent: None,
+                                    parent: s.parent_slot,
                                     status: match s.commitment {
                                         solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
                                         solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1241,7 +1241,7 @@ impl GrpcService {
                     let replayed_slot_iter = block_machine.replay_from_slot(replay_slot, min_solana_commitment);
 
                     for replayed_slot in replayed_slot_iter {
-                        let xs = replayed_slot
+                        let slot_messages = replayed_slot
                             .slot_status_messages
                             .iter()
                             .map(|s| {
@@ -1257,8 +1257,12 @@ impl GrpcService {
                                     created_at: Timestamp::from(SystemTime::now())
                                 })
                             });
-                        replayed_messages.extend(xs);
+                        // 1st Put data (account/txn/entries)
                         replayed_messages.extend(replayed_slot.frozen_block.messages().iter().cloned());
+                        // 2nd Put block summary
+                        replayed_messages.push(Message::BlockMeta(replayed_slot.frozen_block.get_block_meta()));
+                        // 3rd Put slot status
+                        replayed_messages.extend(slot_messages);
                     }
                     let _ = tx.send(ReplayedResponse::Messages(replayed_messages));
                 }


### PR DESCRIPTION
Fixed a bug where when `replay_stored_slots` capacity was set to 0 for an RPC node operator, confirmed or finalized messages were not being sent.

The issue was due to GC was pruning blocks in `block_reconstruction::BlockMachineStorage` before they had the change to be emitted to downstream subscribing since the GC's job is to prevent buffering more than what the replay capacity is set to.

After this change we only GC old block if we have at least 10 finalized slot in `BlockMachineStorage` state.

Imported most of the changes from @Ozodimgba's PR [#810](https://github.com/rpcpool/yellowstone-grpc/pull/810):

- Fix missing block meta in replay
- Fixed replay ordering
- fixed missing parent field value (Closes #792)


