### PR TITLE
str-594: add filter complexity monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## 2026-07-08
+
+- yellowstone-grpc-geyser 14.2.0
+
+### Features
+
+- Added new set of `yellowstone_grpc_filter_stats` metrics to monitor the size and complexity of a filters.
+
+### Fixes
+
+- Added proper subscription tracking for deshred subscription: no ratelimiting was imposed.
+- Fixed a subtil bug where updating the subscription tracker counter maps could leak a decrement if the future/thread panic before `ClientSession` is created. Now subscription tracking acquision and release is done via proper RAII struct that implements `Drop`.
+
+### Breaking
+
+- Prefixed all prometheus metrics with `yellowstone_grpc` to set a convention that is what we found in OTel metrics framework.
+- Removed `/debug_clients` endpoint from the auxiliary sidecar server.
+- Change the client loop logs to include subscription for better monitoring/troubleshooting.
+- Changed `yellowstone_grpc_subscriber_queue_size` from `IntGaugeVec` to `HistogramVec` since many subscription may exists for the same subscriber at the same time.
+
 ## 2026-07-03
 
 - yellowstone-grpc-geyser 14.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6299,7 +6299,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0"
+version = "14.2.0"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ spl-token-2022-interface = "2.1.0"
 
 # Yellowstone
 yellowstone-block-machine = { version = "0.8.0", default-features = false }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.1.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.2.0" }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.2.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "14.1.0"
+version = "14.2.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/config.rs
+++ b/yellowstone-grpc-geyser/src/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub prometheus: Option<ConfigPrometheus>,
     /// Collect client filters, processed slot and make it available on prometheus port `/debug_clients`
     #[serde(default)]
+    #[deprecated(note = "This option is deprecated and will be removed in future versions.")]
     pub debug_clients_http: bool,
 }
 
@@ -317,7 +318,7 @@ pub struct ConfigGrpc {
         default = "ConfigGrpc::subscription_limit_default",
         deserialize_with = "deserialize_int_str"
     )]
-    pub subscription_limit: usize,
+    pub subscription_limit: NonZeroUsize,
     /// When false (default), exceeding the subscription limit only logs
     /// and emits metrics without rejecting the connection. Set to true
     /// to start rejecting with RESOURCE_EX2AUSTED.
@@ -552,8 +553,8 @@ impl ConfigGrpc {
         Semaphore::MAX_PERMITS
     }
 
-    const fn subscription_limit_default() -> usize {
-        1000
+    const fn subscription_limit_default() -> NonZeroUsize {
+        NonZeroUsize::new(1000).unwrap()
     }
 
     const fn default_filter_name_size_limit() -> usize {

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -8,8 +8,8 @@ use {
         config::{AuthConfig, AuthKind, ConfigGrpc, GrpcAddress, GrpcTlsConfig},
         metered::PrometheusMeteredManager,
         metrics::{
-            self, incr_grpc_method_call_count, set_subscriber_queue_size,
-            subscription_limit_exceeded_inc, DebugClientMessage, GEYSER_BATCH_SIZE,
+            self, incr_grpc_method_call_count, observe_subscriber_queue_size,
+            subscription_limit_exceeded_inc, GEYSER_BATCH_SIZE,
         },
         plugin::{
             filter::{
@@ -39,13 +39,13 @@ use {
     std::{
         collections::HashMap,
         io,
-        net::SocketAddr,
+        num::NonZeroUsize,
         os::unix::fs::PermissionsExt,
         path::PathBuf,
         pin::Pin,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
-            Arc, LazyLock, Mutex as StdMutex,
+            Arc, Mutex as StdMutex,
         },
         task::{Context, Poll},
         time::SystemTime,
@@ -63,7 +63,7 @@ use {
         metadata::AsciiMetadataValue,
         service::{interceptor, LayerExt},
         transport::{
-            server::{Connected, Server, TcpConnectInfo, TlsConnectInfo},
+            server::{Connected, Server},
             CertificateDer,
         },
         Request, Response, Result as TonicResult, Status, Streaming,
@@ -304,7 +304,7 @@ impl BlockMetaStorage {
     }
 }
 
-pub type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
+type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
 
 /// Messages broadcast on the deshred channel. Deshred is a pre-execution
 /// stream and has no commitment level: each message is emitted exactly
@@ -316,13 +316,82 @@ pub enum ReplayedResponse {
     Lagged(Slot),
 }
 
-pub type ReplayStoredSlotsRequest = (CommitmentLevel, Slot, oneshot::Sender<ReplayedResponse>);
+type ReplayStoredSlotsRequest = (CommitmentLevel, Slot, oneshot::Sender<ReplayedResponse>);
 
-type SubscriptionTracker = Arc<StdMutex<HashMap<String, usize>>>;
+///
+/// Tracks the number of active subscriptions per subscriber ID. When a new subscription is created, it increments the count for that subscriber ID. When the subscription is dropped, it decrements the count. If the count exceeds the configured limit,
+/// it returns an error when trying to create a new subscription.
+#[derive(Clone)]
+struct SubscriptionTracker {
+    counters: Arc<StdMutex<HashMap<String, usize>>>,
+    subscription_limit: NonZeroUsize,
+}
 
-static CONCURRENT_SUBSCRIPTIONS_PER_REMOTE_PEER_SK_ADDR: LazyLock<
-    StdMutex<HashMap<SocketAddr, usize>>,
-> = LazyLock::new(|| StdMutex::new(HashMap::new()));
+impl SubscriptionTracker {
+    fn new(subscription_limit: NonZeroUsize) -> Self {
+        Self {
+            counters: Arc::new(StdMutex::new(HashMap::new())),
+            subscription_limit,
+        }
+    }
+}
+///
+/// A permit that is owned by a subscriber. When the permit is dropped,
+/// it decrements the subscription count for the subscriber in the SubscriptionTracker.
+struct SubscriptionOwnedPermit {
+    inner: Option<SubscriptionTracker>,
+    key: String,
+}
+
+impl Drop for SubscriptionOwnedPermit {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            let mut tracker = inner
+                .counters
+                .lock()
+                .expect("subscription_tracker mutex poisoned");
+            if let Some(count) = tracker.get_mut(&self.key) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    metrics::remove_grpc_concurrent_subscribe_per_subscriber_id(&self.key);
+                    tracker.remove(&self.key);
+                } else {
+                    metrics::set_grpc_concurrent_subscribe_per_subscriber_id(
+                        &self.key,
+                        *count as u64,
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl SubscriptionTracker {
+    ///
+    /// Attempts to insert a new subscription for the given subscriber ID.
+    /// If the subscription limit is exceeded, it returns an error.
+    ///
+    /// Otherwise, it increments the count and returns a [`SubscriptionOwnedPermit`] that will decrement the count when dropped.
+    ///
+    pub fn try_insert(&self, subscriber_id: String) -> Result<SubscriptionOwnedPermit, ()> {
+        let mut tracker = self
+            .counters
+            .lock()
+            .map_err(|_| ())
+            .expect("subscription_tracker mutex poisoned");
+        let count = tracker.entry(subscriber_id.clone()).or_insert(0);
+        if *count >= self.subscription_limit.get() {
+            return Err(());
+        }
+        *count = count.saturating_add(1);
+        metrics::set_grpc_concurrent_subscribe_per_subscriber_id(&subscriber_id, *count as u64);
+        let permit = SubscriptionOwnedPermit {
+            inner: Some(self.clone()),
+            key: subscriber_id,
+        };
+        Ok(permit)
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 enum ClientSnapshotReplayError {
@@ -337,11 +406,10 @@ struct ClientSession {
     subscriber_id: String,
     endpoint: String,
     filter: Filter,
-    debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
     cancellation_token: CancellationToken,
     disconnect_reason: &'static str,
-    maybe_remote_peer_sk_addr: Option<SocketAddr>,
-    subscription_tracker: SubscriptionTracker,
+    /// Must own it so that when the session is dropped, the subscription count is decremented.
+    _subscription_permit: Option<SubscriptionOwnedPermit>,
 }
 
 impl ClientSession {
@@ -349,102 +417,35 @@ impl ClientSession {
         id: usize,
         subscriber_id: Option<String>,
         endpoint: String,
-        maybe_remote_peer_sk_addr: Option<SocketAddr>,
-        debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
         cancellation_token: CancellationToken,
-        subscription_tracker: SubscriptionTracker,
+        subscription_permit: Option<SubscriptionOwnedPermit>,
     ) -> Self {
         let filter = Filter::default();
         let subscriber_id = subscriber_id.unwrap_or("UNKNOWN".to_owned());
-        if let Some(remote_peer_sk_addr) = maybe_remote_peer_sk_addr {
-            let mut subscriptions_per_remote_addr =
-                CONCURRENT_SUBSCRIPTIONS_PER_REMOTE_PEER_SK_ADDR
-                    .lock()
-                    .expect("CONCURRENT_SUBSCRIPTIONS_PER_REMOTE_PEER_SK_ADDR mutex poisoned");
-            let count = subscriptions_per_remote_addr
-                .entry(remote_peer_sk_addr)
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
-            metrics::set_grpc_concurrent_subscribe_per_tcp_connection(
-                remote_peer_sk_addr.to_string(),
-                *count as u64,
-            );
-        }
         metrics::update_subscriptions(&endpoint, None, Some(&filter));
-        DebugClientMessage::maybe_send(&debug_client_tx, || DebugClientMessage::UpdateFilter {
-            id,
-            filter: Box::new(filter.clone()),
-        });
         info!("client #{id} ({subscriber_id}): new");
         Self {
             id,
             subscriber_id,
             endpoint,
             filter,
-            debug_client_tx,
             cancellation_token,
             disconnect_reason: "unknown",
-            maybe_remote_peer_sk_addr,
-            subscription_tracker,
+            _subscription_permit: subscription_permit,
         }
     }
 
     fn set_filter(&mut self, new_filter: Filter) {
         metrics::update_subscriptions(&self.endpoint, Some(&self.filter), Some(&new_filter));
-        DebugClientMessage::maybe_send(&self.debug_client_tx, || {
-            DebugClientMessage::UpdateFilter {
-                id: self.id,
-                filter: Box::new(new_filter.clone()),
-            }
-        });
         self.filter = new_filter;
     }
 }
 
 impl Drop for ClientSession {
     fn drop(&mut self) {
-        {
-            let mut tracker = self
-                .subscription_tracker
-                .lock()
-                .expect("subscription_tracker mutex poisoned");
-            if let Some(count) = tracker.get_mut(&self.subscriber_id) {
-                *count = count.saturating_sub(1);
-                if *count == 0 {
-                    tracker.remove(&self.subscriber_id);
-                }
-            }
-        }
-        if let Some(remote_peer_sk_addr) = self.maybe_remote_peer_sk_addr {
-            let mut subscriptions_per_remote_addr =
-                CONCURRENT_SUBSCRIPTIONS_PER_REMOTE_PEER_SK_ADDR
-                    .lock()
-                    .expect("CONCURRENT_SUBSCRIPTIONS_PER_REMOTE_PEER_SK_ADDR mutex poisoned");
-            if let Some(count) = subscriptions_per_remote_addr.get_mut(&remote_peer_sk_addr) {
-                if *count > 1 {
-                    *count -= 1;
-                    metrics::set_grpc_concurrent_subscribe_per_tcp_connection(
-                        remote_peer_sk_addr.to_string(),
-                        *count as u64,
-                    );
-                } else {
-                    subscriptions_per_remote_addr.remove(&remote_peer_sk_addr);
-                    metrics::set_grpc_concurrent_subscribe_per_tcp_connection(
-                        remote_peer_sk_addr.to_string(),
-                        0,
-                    );
-                    metrics::remove_grpc_concurrent_subscribe_per_tcp_connection(
-                        remote_peer_sk_addr.to_string(),
-                    );
-                }
-            }
-        }
-        set_subscriber_queue_size(&self.subscriber_id, 0);
+        observe_subscriber_queue_size(&self.subscriber_id, 0, "normal");
         metrics::incr_client_disconnect(&self.subscriber_id, self.disconnect_reason);
         metrics::update_subscriptions(&self.endpoint, Some(&self.filter), None);
-        DebugClientMessage::maybe_send(&self.debug_client_tx, || DebugClientMessage::Removed {
-            id: self.id,
-        });
         info!(
             "client #{} ({}): removed ({})",
             self.id, self.subscriber_id, self.disconnect_reason
@@ -457,17 +458,17 @@ struct DeshredClientSession {
     id: usize,
     subscriber_id: String,
     filter: DeshredFilter,
-    debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
     cancellation_token: CancellationToken,
     disconnect_reason: &'static str,
+    _subscription_permit: Option<SubscriptionOwnedPermit>,
 }
 
 impl DeshredClientSession {
     fn new(
         id: usize,
         subscriber_id: Option<String>,
-        debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
         cancellation_token: CancellationToken,
+        subscription_permit: Option<SubscriptionOwnedPermit>,
     ) -> Self {
         let subscriber_id = subscriber_id.unwrap_or("UNKNOWN".to_owned());
         info!("deshred client #{id} ({subscriber_id}): new");
@@ -475,20 +476,17 @@ impl DeshredClientSession {
             id,
             subscriber_id,
             filter: DeshredFilter::default(),
-            debug_client_tx,
             cancellation_token,
             disconnect_reason: "unknown",
+            _subscription_permit: subscription_permit,
         }
     }
 }
 
 impl Drop for DeshredClientSession {
     fn drop(&mut self) {
-        set_subscriber_queue_size(&self.subscriber_id, 0);
+        observe_subscriber_queue_size(&self.subscriber_id, 0, "deshred");
         metrics::incr_client_disconnect(&self.subscriber_id, self.disconnect_reason);
-        DebugClientMessage::maybe_send(&self.debug_client_tx, || DebugClientMessage::Removed {
-            id: self.id,
-        });
         info!(
             "deshred client #{} ({}): removed ({})",
             self.id, self.subscriber_id, self.disconnect_reason
@@ -554,12 +552,12 @@ impl interceptor::Interceptor for XTokenInterceptor {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GrpcService {
     config_snapshot_client_channel_capacity: usize,
     config_channel_capacity: usize,
     config_filter_limits: Arc<FilterLimits>,
-    subscription_limit: usize,
+    subscription_limit: NonZeroUsize,
     subscription_limit_enforce: bool,
     subscription_tracker: SubscriptionTracker,
     blocks_meta: Option<Arc<BlockMetaStorage>>,
@@ -569,7 +567,6 @@ pub struct GrpcService {
     deshred_broadcast_tx: broadcast::Sender<DeshredBroadcastedMessage>,
     replay_stored_slots_tx: Option<mpsc::Sender<ReplayStoredSlotsRequest>>,
     replay_first_available_slot: Option<Arc<AtomicU64>>,
-    debug_clients_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
     cancellation_token: CancellationToken,
     task_tracker: TaskTracker,
     filter_name_size_limit: usize,
@@ -624,7 +621,6 @@ impl GrpcService {
     #[allow(clippy::type_complexity)]
     pub async fn create(
         config: ConfigGrpc,
-        debug_clients_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
         is_reload: bool,
         service_cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
@@ -832,7 +828,7 @@ impl GrpcService {
             config_filter_limits: Arc::new(config.filter_limits),
             subscription_limit: config.subscription_limit,
             subscription_limit_enforce: config.subscription_limit_enforce,
-            subscription_tracker: Arc::new(StdMutex::new(HashMap::new())),
+            subscription_tracker: SubscriptionTracker::new(config.subscription_limit),
             blocks_meta: blocks_meta.map(Arc::new),
             subscribe_id: Arc::new(AtomicUsize::new(0)),
             snapshot_rx: Arc::new(Mutex::new(snapshot_rx)),
@@ -840,7 +836,6 @@ impl GrpcService {
             deshred_broadcast_tx: deshred_broadcast_tx.clone(),
             replay_stored_slots_tx,
             replay_first_available_slot: replay_first_available_slot.clone(),
-            debug_clients_tx,
             cancellation_token: service_cancellation_token.clone(),
             task_tracker: task_tracker.clone(),
             filter_name_size_limit: config.filter_name_size_limit,
@@ -1317,7 +1312,7 @@ impl GrpcService {
         }
 
         'outer: loop {
-            set_subscriber_queue_size(&session.subscriber_id, stream_tx.queue_size());
+            observe_subscriber_queue_size(&session.subscriber_id, stream_tx.queue_size(), "normal");
 
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
@@ -1454,17 +1449,6 @@ impl GrpcService {
                                         break 'outer;
                                     }
                                 }
-                            }
-                        }
-                    }
-
-                    if commitment == CommitmentLevel::Processed && session.debug_client_tx.is_some() {
-                        for message in messages.iter() {
-                            if let Message::Slot(slot_message) = &message {
-                                DebugClientMessage::maybe_send(&session.debug_client_tx, || DebugClientMessage::UpdateSlot {
-                                    id: session.id,
-                                    slot: slot_message.slot
-                                });
                             }
                         }
                     }
@@ -1694,28 +1678,23 @@ impl GrpcService {
 
     #[allow(clippy::too_many_arguments)]
     async fn deshred_client_loop(
-        id: usize,
-        subscriber_id: Option<String>,
+        mut session: DeshredClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdateDeshred>>,
         mut client_rx: mpsc::UnboundedReceiver<Option<DeshredFilter>>,
         mut messages_rx: broadcast::Receiver<DeshredBroadcastedMessage>,
-        debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
         cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
     ) {
-        let mut session = DeshredClientSession::new(
-            id,
-            subscriber_id,
-            debug_client_tx,
-            cancellation_token.clone(),
-        );
-
         'outer: loop {
-            set_subscriber_queue_size(&session.subscriber_id, stream_tx.queue_size());
+            observe_subscriber_queue_size(
+                &session.subscriber_id,
+                stream_tx.queue_size(),
+                "deshred",
+            );
 
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
-                    info!("deshred client #{id}: cancelled");
+                    info!("deshred client #{}/{}: cancelled", session.subscriber_id, session.id);
                     let _ = stream_tx.try_send(Err(Status::unavailable("server is shutting down try again later")));
                     session.disconnect_reason = "server_shutdown";
                     break 'outer;
@@ -1738,7 +1717,7 @@ impl GrpcService {
                     match message {
                         Some(Some(filter_new)) => {
                             session.filter = filter_new;
-                            info!("deshred client #{id}: filter updated");
+                            info!("deshred client #{}/{}: filter updated", session.subscriber_id, session.id);
                         }
                         Some(None) => {
                             session.disconnect_reason = "client_disconnect";
@@ -1758,7 +1737,7 @@ impl GrpcService {
                             break 'outer;
                         },
                         Err(broadcast::error::RecvError::Lagged(_)) => {
-                            info!("deshred client #{id}: lagged to receive deshred messages");
+                            info!("deshred client #{}/{}: lagged to receive deshred messages", session.subscriber_id, session.id);
                             session.disconnect_reason = "client_broadcast_lag";
                             task_tracker.spawn(async move {
                                 let _ = stream_tx.send(Err(Status::internal("lagged to receive deshred messages"))).await;
@@ -1775,7 +1754,7 @@ impl GrpcService {
                                 metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
                             }
                             Err(mpsc::error::TrySendError::Full(_)) => {
-                                error!("deshred client #{id}: lagged to send an update");
+                                error!("deshred client #{}/{}: lagged to send an update", session.subscriber_id, session.id);
                                 session.disconnect_reason = "client_channel_full";
                                 task_tracker.spawn(async move {
                                     let _ = stream_tx.send(Err(Status::internal("lagged to send an update"))).await;
@@ -1783,7 +1762,7 @@ impl GrpcService {
                                 break 'outer;
                             }
                             Err(mpsc::error::TrySendError::Closed(_)) => {
-                                error!("deshred client #{id}: stream closed");
+                                error!("deshred client #{}/{}: stream closed", session.subscriber_id, session.id);
                                 session.disconnect_reason = "client_closed";
                                 break 'outer;
                             }
@@ -1793,6 +1772,10 @@ impl GrpcService {
             }
         }
         // session Drop handles: queue_size(0), disconnect metric, debug removal, cancel, log
+    }
+
+    fn next_subscribe_seq_id(&self) -> usize {
+        self.subscribe_id.fetch_add(1, Ordering::Relaxed)
     }
 }
 
@@ -1820,21 +1803,10 @@ impl Geyser for GrpcService {
                     .or_else(|| request.remote_addr().map(|addr| addr.ip().to_string()))
             });
 
-        // Per-subscriber subscription limit: check and increment under a
-        // single lock hold so no two calls can race past the limit.
-        // Cleanup (decrement) is handled by `ClientSession::drop()`.
-        // When subscriber_id is None (no x-subscription-id header and no
-        // remote address) we skip the limit check entirely rather than
-        // grouping all unidentified clients into a shared bucket.
-        if let Some(id) = subscriber_id.as_deref() {
-            if self.subscription_limit > 0 {
-                let mut tracker = self
-                    .subscription_tracker
-                    .lock()
-                    .expect("subscription_tracker mutex poisoned");
-                let count = tracker.entry(id.to_owned()).or_insert(0);
-
-                if *count >= self.subscription_limit {
+        let subscription_permit = if let Some(id) = subscriber_id.as_deref() {
+            match self.subscription_tracker.try_insert(id.to_owned()) {
+                Ok(permit) => Some(permit),
+                Err(_) => {
                     subscription_limit_exceeded_inc(id);
                     if self.subscription_limit_enforce {
                         return Err(Status::resource_exhausted(
@@ -1842,26 +1814,17 @@ impl Geyser for GrpcService {
                         ));
                     }
                     info!(
-                        "subscriber {id:?} over limit ({count}/{}), not enforcing",
+                        "subscriber {id:?} over limit, not enforcing (limit: {})",
                         self.subscription_limit
                     );
+                    None
                 }
-                *count += 1;
             }
-        }
+        } else {
+            None
+        };
 
-        let maybe_remote_peer_sk_addr = request
-            .extensions()
-            .get::<TcpConnectInfo>()
-            .or_else(|| {
-                request
-                    .extensions()
-                    .get::<TlsConnectInfo<TcpConnectInfo>>()
-                    .map(|tls_info| tls_info.get_ref())
-            })
-            .and_then(|info| info.remote_addr());
-
-        let id = self.subscribe_id.fetch_add(1, Ordering::Relaxed);
+        let id = self.next_subscribe_seq_id();
         let client_cancellation_token = self.cancellation_token.child_token();
         if client_cancellation_token.is_cancelled() {
             return Err(Status::unavailable("server is shutting down"));
@@ -1954,7 +1917,7 @@ impl Geyser for GrpcService {
                                         }
                                         continue;
                                     }
-                                    let complexity_score = filter.get_complexity_profile();
+                                    let complexity_score = filter.get_filter_stats();
                                     metrics::observe_filter_complexity(&subscriber_id, &complexity_score);
                                     match incoming_client_tx.send(Some((request.from_slot, filter))) {
                                         Ok(()) => Ok(()),
@@ -1991,10 +1954,8 @@ impl Geyser for GrpcService {
             id,
             subscriber_id.clone(),
             endpoint.clone(),
-            maybe_remote_peer_sk_addr,
-            self.debug_clients_tx.clone(),
             client_cancellation_token,
-            Arc::clone(&self.subscription_tracker),
+            subscription_permit,
         );
         self.task_tracker.spawn(Self::client_loop(
             client_session,
@@ -2014,7 +1975,42 @@ impl Geyser for GrpcService {
         mut request: Request<Streaming<SubscribeDeshredRequest>>,
     ) -> TonicResult<Response<Self::SubscribeDeshredStream>> {
         incr_grpc_method_call_count("subscribe_deshred");
-        let id = self.subscribe_id.fetch_add(1, Ordering::Relaxed);
+
+        let subscriber_id = request
+            .extensions()
+            .get::<SubscriptionInfo>()
+            .cloned()
+            .map(|info| info.subscription_id)
+            .or_else(|| {
+                request
+                    .metadata()
+                    .get("x-subscription-id")
+                    .and_then(|h| h.to_str().ok().map(|s| s.to_string()))
+                    .or_else(|| request.remote_addr().map(|addr| addr.ip().to_string()))
+            });
+
+        let subscription_permit = if let Some(id) = subscriber_id.as_deref() {
+            match self.subscription_tracker.try_insert(id.to_owned()) {
+                Ok(permit) => Some(permit),
+                Err(_) => {
+                    subscription_limit_exceeded_inc(id);
+                    if self.subscription_limit_enforce {
+                        return Err(Status::resource_exhausted(
+                            "max subscription limit exceeded",
+                        ));
+                    }
+                    info!(
+                        "subscriber {id:?} over limit, not enforcing (limit: {})",
+                        self.subscription_limit
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let id = self.next_subscribe_seq_id();
 
         let client_cancellation_token = self.cancellation_token.child_token();
         if client_cancellation_token.is_cancelled() {
@@ -2115,13 +2111,17 @@ impl Geyser for GrpcService {
             }
         });
 
-        self.task_tracker.spawn(Self::deshred_client_loop(
+        let session = DeshredClientSession::new(
             id,
-            subscriber_id,
+            subscriber_id.clone(),
+            client_cancellation_token.clone(),
+            subscription_permit,
+        );
+        self.task_tracker.spawn(Self::deshred_client_loop(
+            session,
             stream_tx,
             client_rx,
             self.deshred_broadcast_tx.subscribe(),
-            self.debug_clients_tx.clone(),
             client_cancellation_token,
             self.task_tracker.clone(),
         ));
@@ -2293,7 +2293,6 @@ mod tests {
     async fn test_cancellation_on_client_disconnect_after_half_close() {
         let ct = CancellationToken::new();
         let tt = TaskTracker::new();
-        let st: SubscriptionTracker = Arc::new(StdMutex::new(HashMap::new()));
         let (broadcast_tx, _) = broadcast::channel::<BroadcastedMessage>(16);
         let (client_tx, client_rx) = mpsc::unbounded_channel();
         let (stream_tx, stream_rx) = load_aware_channel(16);
@@ -2308,15 +2307,7 @@ mod tests {
             incoming_ct,
         ));
 
-        let session = ClientSession::new(
-            0,
-            Some("test".into()),
-            "test".into(),
-            None,
-            None,
-            ct.clone(),
-            Arc::clone(&st),
-        );
+        let session = ClientSession::new(0, Some("test".into()), "test".into(), ct.clone(), None);
 
         let handle = tokio::spawn(GrpcService::client_loop(
             session,
@@ -2359,46 +2350,43 @@ mod tests {
 
     #[tokio::test]
     async fn test_subscription_tracker_decrements_on_session_drop() {
-        let tracker: SubscriptionTracker = Arc::new(StdMutex::new(HashMap::new()));
+        let tracker = SubscriptionTracker::new(NonZeroUsize::new(10).unwrap());
 
-        // simulate what subscribe() does: increment under lock
-        {
-            let mut map = tracker.lock().unwrap();
-            *map.entry("sub-1".to_owned()).or_insert(0) += 1;
-            *map.entry("sub-1".to_owned()).or_insert(0) += 1;
-        }
-        assert_eq!(*tracker.lock().unwrap().get("sub-1").unwrap(), 2);
+        // simulate what subscribe() does: acquire two permits
+        let _permit_a = tracker.try_insert("sub-1".to_owned()).unwrap();
+        let _permit_b = tracker.try_insert("sub-1".to_owned()).unwrap();
+        assert_eq!(*tracker.counters.lock().unwrap().get("sub-1").unwrap(), 2);
 
         // create a session (mirrors what client_loop does)
         {
+            let permit = tracker.try_insert("sub-1".to_owned()).unwrap();
             let _session = ClientSession::new(
                 0,
                 Some("sub-1".into()),
                 "".into(),
-                None,
-                None,
                 CancellationToken::new(),
-                Arc::clone(&tracker),
+                Some(permit),
             );
-            // session alive: count unchanged
-            assert_eq!(*tracker.lock().unwrap().get("sub-1").unwrap(), 2);
+            // session alive: count includes the session permit
+            assert_eq!(*tracker.counters.lock().unwrap().get("sub-1").unwrap(), 3);
         }
-        // session dropped: count decremented
-        assert_eq!(*tracker.lock().unwrap().get("sub-1").unwrap(), 1);
+        // session dropped: count decremented by one
+        assert_eq!(*tracker.counters.lock().unwrap().get("sub-1").unwrap(), 2);
 
         // second drop removes the entry entirely
         {
+            drop(_permit_a);
+            drop(_permit_b);
+            let permit = tracker.try_insert("sub-1".to_owned()).unwrap();
             let _session = ClientSession::new(
                 1,
                 Some("sub-1".into()),
                 "".into(),
-                None,
-                None,
                 CancellationToken::new(),
-                Arc::clone(&tracker),
+                Some(permit),
             );
         }
-        assert!(tracker.lock().unwrap().get("sub-1").is_none());
+        assert!(tracker.counters.lock().unwrap().get("sub-1").is_none());
     }
 
     mod geyser_loop_routing {
@@ -2575,23 +2563,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_subscription_tracker_skips_unidentified_subscribers() {
-        let tracker: SubscriptionTracker = Arc::new(StdMutex::new(HashMap::new()));
-
         // subscriber_id=None resolves to "UNKNOWN" inside ClientSession,
         // but subscribe() skips the limit check entirely for None.
         // The tracker should remain empty since no increment happened.
         {
-            let _session = ClientSession::new(
-                0,
-                None,
-                "".into(),
-                None,
-                None,
-                CancellationToken::new(),
-                Arc::clone(&tracker),
-            );
+            let _session = ClientSession::new(0, None, "".into(), CancellationToken::new(), None);
         }
-        // drop fires but "UNKNOWN" was never in the tracker, so nothing changes
-        assert!(tracker.lock().unwrap().is_empty());
     }
 }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -304,19 +304,19 @@ impl BlockMetaStorage {
     }
 }
 
-type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
+pub type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
 
 /// Messages broadcast on the deshred channel. Deshred is a pre-execution
 /// stream and has no commitment level: each message is emitted exactly
 /// once, when first received from the geyser plugin.
 type DeshredBroadcastedMessage = Message;
 
-enum ReplayedResponse {
+pub enum ReplayedResponse {
     Messages(Vec<Message>),
     Lagged(Slot),
 }
 
-type ReplayStoredSlotsRequest = (CommitmentLevel, Slot, oneshot::Sender<ReplayedResponse>);
+pub type ReplayStoredSlotsRequest = (CommitmentLevel, Slot, oneshot::Sender<ReplayedResponse>);
 
 type SubscriptionTracker = Arc<StdMutex<HashMap<String, usize>>>;
 
@@ -1275,46 +1275,29 @@ impl GrpcService {
 
     #[allow(clippy::too_many_arguments)]
     async fn client_loop(
-        id: usize,
-        subscriber_id: Option<String>,
-        endpoint: String,
+        mut session: ClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdate>>,
         mut client_rx: mpsc::UnboundedReceiver<Option<(Option<u64>, Filter)>>,
         mut snapshot_rx: Option<crossbeam_channel::Receiver<Box<Message>>>,
         mut messages_rx: broadcast::Receiver<BroadcastedMessage>,
         replay_stored_slots_tx: Option<mpsc::Sender<ReplayStoredSlotsRequest>>,
-        debug_client_tx: Option<mpsc::UnboundedSender<DebugClientMessage>>,
-        maybe_remote_peer_sk_addr: Option<SocketAddr>,
-        cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
-        subscription_tracker: SubscriptionTracker,
     ) {
-        let mut session = ClientSession::new(
-            id,
-            subscriber_id,
-            endpoint,
-            maybe_remote_peer_sk_addr,
-            debug_client_tx,
-            cancellation_token,
-            subscription_tracker,
-        );
         let cancellation_token = session.cancellation_token.clone();
 
         if let Some(snapshot_rx) = snapshot_rx.take() {
-            info!("client #{id}: snapshot requested");
+            info!("client #{}: snapshot requested", session.subscriber_id);
             let result = Self::client_loop_snapshot(
-                id,
-                &session.endpoint,
+                &mut session,
                 stream_tx.clone(),
                 &mut client_rx,
                 snapshot_rx,
-                &mut session.filter,
                 cancellation_token.clone(),
             )
             .await;
             match result {
                 Ok(()) => {
-                    info!("client #{id}: snapshot stream ended");
+                    info!("client #{}: snapshot stream ended", session.subscriber_id);
                 }
                 Err(ClientSnapshotReplayError::Cancelled) => {
                     let _ = stream_tx.try_send(Err(Status::internal(
@@ -1324,13 +1307,13 @@ impl GrpcService {
                     return;
                 }
                 Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed) => {
-                    info!("client #{id}: grpc connection closed");
+                    info!("client #{}: grpc connection closed", session.subscriber_id);
                     session.disconnect_reason = "client_closed";
                     return;
                 }
             }
         } else {
-            info!("client #{id}: no snapshot requested");
+            info!("client #{}: no snapshot requested", session.subscriber_id);
         }
 
         'outer: loop {
@@ -1338,7 +1321,7 @@ impl GrpcService {
 
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
-                    info!("client #{id}: cancelled");
+                    info!("client #{}: cancelled", session.subscriber_id);
                     let _ = stream_tx.try_send(Err(Status::unavailable("server is shutting down try again later")));
                     session.disconnect_reason = "server_shutdown";
                     break 'outer;
@@ -1361,11 +1344,11 @@ impl GrpcService {
                     match message {
                         Some(Some((from_slot, filter_new))) => {
                             session.set_filter(filter_new);
-                            info!("client #{id}: filter updated");
+                            info!("client #{}: filter updated", session.subscriber_id);
 
                             if let Some(from_slot) = from_slot {
                                 let Some(replay_stored_slots_tx) = &replay_stored_slots_tx else {
-                                    info!("client #{id}: from_slot is not supported");
+                                    info!("client #{}: from_slot is not supported", session.subscriber_id);
                                     task_tracker.spawn(async move {
                                         let _ = stream_tx.send(Err(Status::internal("from_slot is not supported"))).await;
                                     });
@@ -1376,7 +1359,7 @@ impl GrpcService {
                                 let (tx, rx) = oneshot::channel();
                                 let commitment = session.filter.get_commitment_level();
                                 if let Err(_error) = replay_stored_slots_tx.send((commitment, from_slot, tx)).await {
-                                    error!("client #{id}: failed to send from_slot request");
+                                    error!("client #{}: failed to send from_slot request", session.subscriber_id);
                                     task_tracker.spawn(async move {
                                         let _ = stream_tx.send(Err(Status::internal("failed to send from_slot request"))).await;
                                     });
@@ -1387,7 +1370,7 @@ impl GrpcService {
                                 let messages = match rx.await {
                                     Ok(ReplayedResponse::Messages(messages)) => messages,
                                     Ok(ReplayedResponse::Lagged(slot)) => {
-                                        info!("client #{id}: broadcast from {from_slot} is not available");
+                                        info!("client #{}: broadcast from {from_slot} is not available", session.subscriber_id);
                                         task_tracker.spawn(async move {
                                             let message = format!(
                                                 "broadcast from {from_slot} is not available, last available: {slot}"
@@ -1398,7 +1381,7 @@ impl GrpcService {
                                         break 'outer;
                                     },
                                     Err(_error) => {
-                                        error!("client #{id}: failed to get replay response");
+                                        error!("client #{}: failed to get replay response", session.subscriber_id);
                                         task_tracker.spawn(async move {
                                             let _ = stream_tx.send(Err(Status::internal("failed to get replay response"))).await;
                                         });
@@ -1414,7 +1397,7 @@ impl GrpcService {
                                                 metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
                                             }
                                             Err(mpsc::error::SendError(_)) => {
-                                                error!("client #{id}: stream closed");
+                                                error!("client #{}: stream closed", session.subscriber_id);
                                                 session.disconnect_reason = "client_closed";
                                                 break 'outer;
                                             }
@@ -1441,7 +1424,7 @@ impl GrpcService {
                             break 'outer;
                         },
                         Err(broadcast::error::RecvError::Lagged(_)) => {
-                            info!("client #{id}: lagged to receive geyser messages");
+                            info!("client #{}: lagged to receive geyser messages", session.subscriber_id);
                             task_tracker.spawn(async move {
                                 let _ = stream_tx.send(Err(Status::internal("lagged to receive geyser messages"))).await;
                             });
@@ -1458,7 +1441,7 @@ impl GrpcService {
                                         metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
                                     }
                                     Err(mpsc::error::TrySendError::Full(_)) => {
-                                        error!("client #{id}: lagged to send an update");
+                                        error!("client #{}: lagged to send an update", session.subscriber_id);
                                         task_tracker.spawn(async move {
                                             let _ = stream_tx.send(Err(Status::internal("lagged to send an update"))).await;
                                         });
@@ -1466,7 +1449,7 @@ impl GrpcService {
                                         break 'outer;
                                     }
                                     Err(mpsc::error::TrySendError::Closed(_)) => {
-                                        error!("client #{id}: stream closed");
+                                        error!("client #{}: stream closed", session.subscriber_id);
                                         session.disconnect_reason = "client_closed";
                                         break 'outer;
                                     }
@@ -1478,7 +1461,10 @@ impl GrpcService {
                     if commitment == CommitmentLevel::Processed && session.debug_client_tx.is_some() {
                         for message in messages.iter() {
                             if let Message::Slot(slot_message) = &message {
-                                DebugClientMessage::maybe_send(&session.debug_client_tx, || DebugClientMessage::UpdateSlot { id, slot: slot_message.slot });
+                                DebugClientMessage::maybe_send(&session.debug_client_tx, || DebugClientMessage::UpdateSlot {
+                                    id: session.id,
+                                    slot: slot_message.slot
+                                });
                             }
                         }
                     }
@@ -1488,21 +1474,22 @@ impl GrpcService {
     }
 
     async fn client_loop_snapshot(
-        id: usize,
-        endpoint: &str,
+        session: &mut ClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdate>>,
         client_rx: &mut mpsc::UnboundedReceiver<Option<(Option<u64>, Filter)>>,
         snapshot_rx: crossbeam_channel::Receiver<Box<Message>>,
-        filter: &mut Filter,
         cancellation_token: CancellationToken,
     ) -> Result<(), ClientSnapshotReplayError> {
-        info!("client #{id}: going to receive snapshot data");
+        info!(
+            "client #{}: going to receive snapshot data",
+            session.subscriber_id
+        );
 
         // we start with default filter, for snapshot we need wait actual filter first
         loop {
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
-                    info!("client #{id}: cancelled");
+                    info!("client #{}: cancelled", session.subscriber_id);
                     return Err(ClientSnapshotReplayError::Cancelled);
                 }
                 maybe = client_rx.recv() => {
@@ -1510,15 +1497,15 @@ impl GrpcService {
                         Some(Some((_from_slot, filter_new))) => {
                             if let Some(msg) = filter_new.get_pong_msg() {
                                 if stream_tx.send(Ok(msg)).await.is_err() {
-                                    error!("client #{id}: stream closed");
+                                    error!("client #{}: stream closed", session.subscriber_id);
                                     return Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed);
                                 }
                                 continue;
                             }
 
-                            metrics::update_subscriptions(endpoint, Some(filter), Some(&filter_new));
-                            *filter = filter_new;
-                            info!("client #{id}: filter updated");
+                            metrics::update_subscriptions(&session.endpoint, Some(&session.filter), Some(&filter_new));
+                            session.filter = filter_new;
+                            info!("client #{}: filter updated", session.subscriber_id);
                             break;
                         }
                         Some(None) => {
@@ -1535,7 +1522,7 @@ impl GrpcService {
 
         loop {
             if cancellation_token.is_cancelled() {
-                info!("client #{id}: cancelled");
+                info!("client #{}: cancelled", session.subscriber_id);
                 return Err(ClientSnapshotReplayError::Cancelled);
             }
             let message = match snapshot_rx.try_recv() {
@@ -1548,14 +1535,14 @@ impl GrpcService {
                     continue;
                 }
                 Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                    info!("client #{id}: end of startup");
+                    info!("client #{}: end of startup", session.subscriber_id);
                     break;
                 }
             };
 
-            for message in filter.get_updates(&message, None) {
+            for message in session.filter.get_updates(&message, None) {
                 if stream_tx.send(Ok(message)).await.is_err() {
-                    error!("client #{id}: stream closed");
+                    error!("client #{}: stream closed", session.subscriber_id);
                     return Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed);
                 }
             }
@@ -1943,11 +1930,14 @@ impl Geyser for GrpcService {
             self.filter_names_size_limit,
             self.filter_names_cleanup_interval,
         );
+
+        let subscriber_id2 = subscriber_id.clone();
         self.task_tracker.spawn(async move {
+            let subscriber_id = subscriber_id2.unwrap_or("unknown".to_string());
             loop {
                 tokio::select! {
                     _ = incoming_cancellation_token.cancelled() => {
-                        info!("client #{id}: filter receiver cancelled");
+                        info!("client #{subscriber_id:?}/{id}: filter receiver cancelled");
                         break;
                     }
                     message = request.get_mut().message() => match message {
@@ -1958,12 +1948,14 @@ impl Geyser for GrpcService {
                                 Ok(filter) => {
                                     if let Some(msg) = filter.get_pong_msg() {
                                         if incoming_stream_tx.send(Ok(msg)).await.is_err() {
-                                            error!("client #{id}: stream closed");
+                                            error!("client #{subscriber_id:?}/{id}: stream closed");
                                             let _ = incoming_client_tx.send(None);
                                             break;
                                         }
                                         continue;
                                     }
+                                    let complexity_score = filter.get_complexity_profile();
+                                    metrics::observe_filter_complexity(&subscriber_id, &complexity_score);
                                     match incoming_client_tx.send(Some((request.from_slot, filter))) {
                                         Ok(()) => Ok(()),
                                         Err(error) => Err(error.to_string()),
@@ -1982,7 +1974,7 @@ impl Geyser for GrpcService {
                         Ok(None) => {
                              // Client half-closed its send stream. Stop reading, but keep
                              // incoming_client_tx alive so client_loop continues running.
-                            info!("client #{id}: client closed send stream, waiting for cancellation");
+                            info!("client #{subscriber_id:?}/{id}: client closed send stream, waiting for cancellation");
                             incoming_cancellation_token.cancelled().await;
                             break;
                         }
@@ -1995,20 +1987,23 @@ impl Geyser for GrpcService {
             }
         });
 
-        self.task_tracker.spawn(Self::client_loop(
+        let client_session = ClientSession::new(
             id,
-            subscriber_id,
-            endpoint,
+            subscriber_id.clone(),
+            endpoint.clone(),
+            maybe_remote_peer_sk_addr,
+            self.debug_clients_tx.clone(),
+            client_cancellation_token,
+            Arc::clone(&self.subscription_tracker),
+        );
+        self.task_tracker.spawn(Self::client_loop(
+            client_session,
             stream_tx,
             client_rx,
             snapshot_rx,
             self.broadcast_tx.subscribe(),
             self.replay_stored_slots_tx.clone(),
-            self.debug_clients_tx.clone(),
-            maybe_remote_peer_sk_addr,
-            client_cancellation_token,
             self.task_tracker.clone(),
-            Arc::clone(&self.subscription_tracker),
         ));
 
         Ok(Response::new(stream_rx))
@@ -2313,20 +2308,24 @@ mod tests {
             incoming_ct,
         ));
 
-        let handle = tokio::spawn(GrpcService::client_loop(
+        let session = ClientSession::new(
             0,
             Some("test".into()),
             "test".into(),
+            None,
+            None,
+            ct.clone(),
+            Arc::clone(&st),
+        );
+
+        let handle = tokio::spawn(GrpcService::client_loop(
+            session,
             stream_tx,
             client_rx,
             None,
             broadcast_tx.subscribe(),
             None,
-            None,
-            None,
-            ct.clone(),
             tt.clone(),
-            Arc::clone(&st),
         ));
 
         // yield so incoming_handler sends the filter and client_loop

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         config::ConfigPrometheus,
-        plugin::{filter::Filter, message::SlotStatus},
+        plugin::{
+            filter::{Filter, FilterComplexityProfile},
+            message::SlotStatus,
+        },
         version::VERSION as VERSION_INFO,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::SlotStatus as GeyserSlosStatus,
@@ -17,8 +20,8 @@ use {
     },
     log::{debug, error, info},
     prometheus::{
-        Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
-        TextEncoder,
+        Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+        Opts, Registry, TextEncoder,
     },
     solana_clock::Slot,
     std::{
@@ -210,6 +213,102 @@ lazy_static::lazy_static! {
         ),
         &["subscriber_id", "method"]
     ).unwrap();
+
+    static ref FILTER_COMPLEXITY_ACCOUNTS_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_accounts_size",
+            "Distribution of account_include size per account filter"
+        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_OWNERS_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_owners_size",
+            "Distribution of owner_include size per account filter"
+        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_accounts_include_size",
+            "Distribution of account_include size per transaction filter"
+        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_accounts_exclude_size",
+            "Distribution of account_exclude size per transaction filter"
+        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_accounts_required_size",
+            "Distribution of account_required size per transaction filter"
+        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_token_mode_enabled",
+            "Whether token-account expansion is enabled (0/1) per transaction filter"
+        ).buckets(vec![0.0, 1.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_status_accounts_include_size",
+            "Distribution of account_include size per transaction-status filter"
+        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_status_accounts_exclude_size",
+            "Distribution of account_exclude size per transaction-status filter"
+        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_status_accounts_required_size",
+            "Distribution of account_required size per transaction-status filter"
+        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_tx_status_token_mode_enabled",
+            "Whether token-account expansion is enabled (0/1) per transaction-status filter"
+        ).buckets(vec![0.0, 1.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_blocks_include_size",
+            "Distribution of include complexity per block filter"
+        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0]),
+        &["subscriber_id"]
+    ).unwrap();
+
+    static ref FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_filter_complexity_blocks_exclude_size",
+            "Distribution of exclude complexity per block filter"
+        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0]),
+        &["subscriber_id"]
+    ).unwrap();
 }
 
 #[derive(Debug)]
@@ -376,6 +475,19 @@ impl PrometheusService {
             register!(AUTHORIZED_COUNT);
             register!(METHOD_RATELIMITED_COUNT);
 
+            register!(FILTER_COMPLEXITY_ACCOUNTS_SIZE);
+            register!(FILTER_COMPLEXITY_OWNERS_SIZE);
+            register!(FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE);
+            register!(FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE);
+            register!(FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE);
+            register!(FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED);
+            register!(FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE);
+            register!(FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE);
+            register!(FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE);
+            register!(FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED);
+            register!(FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE);
+            register!(FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE);
+
             VERSION
                 .with_label_values(&[
                     VERSION_INFO.buildts,
@@ -494,6 +606,64 @@ fn not_found_handler() -> http::Result<Response<BoxBody<Bytes, Infallible>>> {
     Response::builder()
         .status(StatusCode::NOT_FOUND)
         .body(BodyEmpty::new().boxed())
+}
+
+pub fn observe_filter_complexity(subscriber_id: &str, observation: &FilterComplexityProfile) {
+    for score in &observation.accounts {
+        FILTER_COMPLEXITY_ACCOUNTS_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_size as f64);
+        FILTER_COMPLEXITY_OWNERS_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.owners_size as f64);
+    }
+
+    for score in &observation.transactions {
+        FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_include_size as f64);
+        FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_exclude_size as f64);
+        FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_required_size as f64);
+        FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED
+            .with_label_values(&[subscriber_id])
+            .observe(if score.token_accounts_enabled {
+                1.0
+            } else {
+                0.0
+            });
+    }
+
+    for score in &observation.transaction_status {
+        FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_include_size as f64);
+        FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_exclude_size as f64);
+        FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.accounts_required_size as f64);
+        FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED
+            .with_label_values(&[subscriber_id])
+            .observe(if score.token_accounts_enabled {
+                1.0
+            } else {
+                0.0
+            });
+    }
+
+    for score in &observation.blocks {
+        FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.include_size as f64);
+        FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE
+            .with_label_values(&[subscriber_id])
+            .observe(score.exclude_size as f64);
+    }
 }
 
 pub fn incr_ip_conncur_rate_limit_exceeded(remote_peer_ip: Option<String>) {
@@ -720,6 +890,18 @@ pub fn reset_metrics() {
     UNAUTHORIZED_COUNT.reset();
     AUTHORIZED_COUNT.reset();
     METHOD_RATELIMITED_COUNT.reset();
+    FILTER_COMPLEXITY_ACCOUNTS_SIZE.reset();
+    FILTER_COMPLEXITY_OWNERS_SIZE.reset();
+    FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE.reset();
+    FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE.reset();
+    FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE.reset();
+    FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED.reset();
+    FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE.reset();
+    FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE.reset();
+    FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE.reset();
+    FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED.reset();
+    FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE.reset();
+    FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE.reset();
     // Note: VERSION and GEYSER_ACCOUNT_UPDATE_RECEIVED are intentionally not reset
     // - VERSION contains build info set once on startup
     // - GEYSER_ACCOUNT_UPDATE_RECEIVED is a Histogram which doesn't support reset()

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         config::ConfigPrometheus,
         plugin::{
-            filter::{Filter, FilterComplexityProfile},
+            filter::{Filter, FilterStats},
             message::SlotStatus,
         },
         version::VERSION as VERSION_INFO,
@@ -23,17 +23,8 @@ use {
         Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
         Opts, Registry, TextEncoder,
     },
-    solana_clock::Slot,
-    std::{
-        collections::{hash_map::Entry as HashMapEntry, HashMap},
-        convert::Infallible,
-        sync::{Arc, Once},
-    },
-    tokio::{
-        net::TcpListener,
-        sync::{mpsc, oneshot},
-        task::JoinHandle,
-    },
+    std::{convert::Infallible, sync::Once},
+    tokio::net::TcpListener,
     tokio_util::{sync::CancellationToken, task::TaskTracker},
 };
 
@@ -41,50 +32,46 @@ lazy_static::lazy_static! {
     pub static ref REGISTRY: Registry = Registry::new();
 
     static ref VERSION: IntCounterVec = IntCounterVec::new(
-        Opts::new("version", "Plugin version info"),
+        Opts::new("yellowstone_grpc_version", "Plugin version info"),
         &["buildts", "git", "package", "proto", "rustc", "solana", "version"]
     ).unwrap();
 
     static ref SLOT_STATUS: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("slot_status", "Lastest received slot from Geyser"),
+        Opts::new("yellowstone_grpc_slot_status", "Lastest received slot from Geyser"),
         &["status"]
     ).unwrap();
 
     static ref SLOT_STATUS_PLUGIN: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("slot_status_plugin", "Latest processed slot in the plugin to client queues"),
+        Opts::new("yellowstone_grpc_slot_status_plugin", "Latest processed slot in the plugin to client queues"),
         &["status"]
     ).unwrap();
 
     static ref INVALID_FULL_BLOCKS: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("invalid_full_blocks_total", "Total number of fails on constructin full blocks"),
+        Opts::new("yellowstone_grpc_invalid_full_blocks_total", "Total number of fails on constructin full blocks"),
         &["reason"]
     ).unwrap();
 
     static ref MESSAGE_QUEUE_SIZE: IntGauge = IntGauge::new(
-        "message_queue_size", "Size of geyser message queue"
+        "yellowstone_grpc_message_queue_size", "Size of geyser message queue"
     ).unwrap();
 
     static ref DESHRED_QUEUE_SIZE: IntGauge = IntGauge::new(
-        "deshred_queue_size", "Size of deshred message queue"
-    ).unwrap();
-
-    static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
-        "connections_total", "Total number of connections to gRPC service"
+        "yellowstone_grpc_deshred_queue_size", "Size of deshred message queue"
     ).unwrap();
 
     static ref SUBSCRIPTIONS_TOTAL: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("subscriptions_total", "Total number of subscriptions to gRPC service"),
+        Opts::new("yellowstone_grpc_subscriptions_total", "Total number of subscriptions to gRPC service"),
         &["endpoint", "subscription"]
     ).unwrap();
 
     static ref MISSED_STATUS_MESSAGE: IntCounterVec = IntCounterVec::new(
-        Opts::new("missed_status_message_total", "Number of missed messages by commitment"),
+        Opts::new("yellowstone_grpc_missed_status_message_total", "Number of missed messages by commitment"),
         &["status"]
     ).unwrap();
 
     static ref GRPC_MESSAGE_SENT: IntCounterVec = IntCounterVec::new(
         Opts::new(
-            "grpc_message_sent_count",
+            "yellowstone_grpc_message_sent_count",
             "Number of message sent over grpc to downstream client",
         ),
         &["subscriber_id"]
@@ -92,23 +79,24 @@ lazy_static::lazy_static! {
 
     static ref GRPC_SUBSCRIBER_SEND_BANDWIDTH_LOAD: IntGaugeVec = IntGaugeVec::new(
         Opts::new(
-            "grpc_subscriber_send_bandwidth_load",
+            "yellowstone_grpc_subscriber_send_bandwidth_load",
             "Current Send load we send to subscriber channel (in bytes per second)"
         ),
         &["subscriber_id"]
     ).unwrap();
 
-    static ref GRPC_SUBSCRIBER_QUEUE_SIZE: IntGaugeVec = IntGaugeVec::new(
-        Opts::new(
-            "grpc_subscriber_queue_size",
+    static ref GRPC_SUBSCRIBER_QUEUE_SIZE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "yellowstone_grpc_subscriber_queue_size",
             "Current size of subscriber channel queue"
-        ),
-        &["subscriber_id"]
+        )
+        .buckets(vec![1.0, 10.0, 100.0, 1000.0, 10000.0, 20000.0, 50000.0, 100_000.0, 175_000.0, 250_000.0, 500_000.0, 1_000_000.0]),
+        &["subscriber_id", "kind"]
     ).unwrap();
 
     static ref GRPC_CLIENT_DISCONNECTS: IntCounterVec = IntCounterVec::new(
         Opts::new(
-            "grpc_client_disconnects_total",
+            "yellowstone_grpc_client_disconnects_total",
             "Total client disconnections by reason"
         ),
         &["subscriber_id", "reason"]
@@ -116,7 +104,7 @@ lazy_static::lazy_static! {
 
     static ref GEYSER_ACCOUNT_UPDATE_RECEIVED: Histogram = Histogram::with_opts(
         HistogramOpts::new(
-            "geyser_account_update_data_size_kib",
+            "yellowstone_grpc_geyser_account_update_data_size_kib",
             "Histogram of all account update data (kib) received from Geyser plugin"
         )
         .buckets(vec![5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 10000.0])
@@ -124,7 +112,7 @@ lazy_static::lazy_static! {
 
     pub static ref GEYSER_BATCH_SIZE: Histogram = Histogram::with_opts(
         HistogramOpts::new(
-            "yellowstone_geyser_batch_size",
+            "yellowstone_grpc_geyser_batch_size",
             "Size of processed message batches"
         )
         .buckets(vec![1.0, 4.0, 8.0, 16.0, 24.0, 31.0])
@@ -140,16 +128,16 @@ lazy_static::lazy_static! {
         &["type"]
     ).unwrap();
 
-    static ref GRPC_CONCURRENT_SUBSCRIBE_PER_TCP_CONNECTION: IntGaugeVec = IntGaugeVec::new(
-            Opts::new(
-                "grpc_concurrent_subscribe_per_tcp_connection",
-                "Current concurrent subscriptions per remote TCP peer socket address"
-            ),
-            &["remote_peer_sk_addr"]
+    static ref GRPC_CONCURRENT_SUBSCRIBE_PER_SUBSCRIBER_ID: IntGaugeVec = IntGaugeVec::new(
+        Opts::new(
+            "yellowstone_grpc_concurrent_subscribe_per_subscriber_id",
+            "Current concurrent subscriptions per subscriber ID"
+        ),
+        &["subscriber_id"]
     ).unwrap();
 
     static ref TOTAL_TRAFFIC_SENT: IntCounter = IntCounter::new(
-        "total_traffic_sent_bytes",
+        "yellowstone_grpc_total_traffic_sent_bytes",
         "Total traffic sent to subscriber by type (account_update, block_meta, etc)"
     ).unwrap();
 
@@ -173,24 +161,24 @@ lazy_static::lazy_static! {
 
     static ref GEYSER_EVENT_DROPPED: IntCounterVec = IntCounterVec::new(
         Opts::new(
-            "geyser_event_dropped_total",
+            "yellowstone_grpc_geyser_event_dropped_total",
             "Total number of events dropped in the plugin due to drop_list"
         ),
         &["event"]
     ).unwrap();
 
     static ref GEYSER_BLOCK_MISMATCH_TRANSACTION: IntCounter = IntCounter::new(
-        "geyser_block_mismatch_transaction", "Number of block mismatch transactions encountered in the plugin"
+        "yellowstone_grpc_geyser_block_mismatch_transaction", "Number of block mismatch transactions encountered in the plugin"
     ).unwrap();
 
     static ref GEYSER_UNTRACK_SLOT_EVENT_DROPPED: IntCounter = IntCounter::new(
-        "geyser_untrack_slot_event_dropped_total", "Number of geyser event drop due to untrack slot"
+        "yellowstone_grpc_geyser_untrack_slot_event_dropped_total", "Number of geyser event drop due to untrack slot"
     ).unwrap();
 
 
     static ref IP_CONNCUR_RATE_LIMIT_EXCEEDED: IntCounterVec = IntCounterVec::new(
         Opts::new(
-            "yellowstone_grpc_ip_conncur_rate_limit_exceeded_total",
+            "yellowstone_grpc_ip_concurrent_rate_limit_exceeded_total",
             "Number of incoming connections that exceeded the per-IP connection limit at the transport layer"
         ),
         &["remote_peer_ip"]
@@ -214,218 +202,33 @@ lazy_static::lazy_static! {
         &["subscriber_id", "method"]
     ).unwrap();
 
-    static ref FILTER_COMPLEXITY_ACCOUNTS_SIZE: HistogramVec = HistogramVec::new(
+    static ref FILTER_STATS: HistogramVec = HistogramVec::new(
         HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_accounts_size",
-            "Distribution of account_include size per account filter"
-        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
-        &["subscriber_id"]
+            "yellowstone_grpc_filter_stats",
+            "Distribution of filter stats dimensions"
+        ).buckets(vec![
+            0.0,
+            1.0,
+            10.0,
+            50.0,
+            100.0,
+            1000.0,
+            2000.0,
+            5000.0,
+            10000.0,
+            20000.0,
+            50000.0,
+            100000.0,
+            175000.0,
+            250000.0,
+            375000.0,
+            500000.0,
+            800000.0,
+            1_000_000.0,
+            2_500_000.0,
+        ]),
+        &["subscriber_id", "type", "prop"]
     ).unwrap();
-
-    static ref FILTER_COMPLEXITY_OWNERS_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_owners_size",
-            "Distribution of owner_include size per account filter"
-        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_accounts_include_size",
-            "Distribution of account_include size per transaction filter"
-        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_accounts_exclude_size",
-            "Distribution of account_exclude size per transaction filter"
-        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_accounts_required_size",
-            "Distribution of account_required size per transaction filter"
-        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_token_mode_enabled",
-            "Whether token-account expansion is enabled (0/1) per transaction filter"
-        ).buckets(vec![0.0, 1.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_status_accounts_include_size",
-            "Distribution of account_include size per transaction-status filter"
-        ).buckets(vec![0.0, 1.0, 10.0, 100.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 2500000.0, 5000000.0, 1000000.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_status_accounts_exclude_size",
-            "Distribution of account_exclude size per transaction-status filter"
-        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_status_accounts_required_size",
-            "Distribution of account_required size per transaction-status filter"
-        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_tx_status_token_mode_enabled",
-            "Whether token-account expansion is enabled (0/1) per transaction-status filter"
-        ).buckets(vec![0.0, 1.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_blocks_include_size",
-            "Distribution of include complexity per block filter"
-        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0]),
-        &["subscriber_id"]
-    ).unwrap();
-
-    static ref FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new(
-            "yellowstone_grpc_filter_complexity_blocks_exclude_size",
-            "Distribution of exclude complexity per block filter"
-        ).buckets(vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0]),
-        &["subscriber_id"]
-    ).unwrap();
-}
-
-#[derive(Debug)]
-pub enum DebugClientMessage {
-    UpdateFilter { id: usize, filter: Box<Filter> },
-    UpdateSlot { id: usize, slot: Slot },
-    Removed { id: usize },
-}
-
-impl DebugClientMessage {
-    pub fn maybe_send(tx: &Option<mpsc::UnboundedSender<Self>>, get_msg: impl FnOnce() -> Self) {
-        if let Some(tx) = tx {
-            let _ = tx.send(get_msg());
-        }
-    }
-}
-
-#[derive(Debug)]
-struct DebugClientStatus {
-    filter: Box<Filter>,
-    processed_slot: Slot,
-}
-
-#[derive(Debug)]
-struct DebugClientStatuses {
-    requests_tx: mpsc::UnboundedSender<oneshot::Sender<String>>,
-    jh: JoinHandle<()>,
-}
-
-impl Drop for DebugClientStatuses {
-    fn drop(&mut self) {
-        self.jh.abort();
-    }
-}
-
-impl DebugClientStatuses {
-    fn new(
-        clients_rx: mpsc::UnboundedReceiver<DebugClientMessage>,
-        cancellation_token: CancellationToken,
-        task_tracker: TaskTracker,
-    ) -> Arc<Self> {
-        let (requests_tx, requests_rx) = mpsc::unbounded_channel();
-        let jh = task_tracker.spawn(Self::run(clients_rx, requests_rx, cancellation_token));
-        Arc::new(Self { requests_tx, jh })
-    }
-
-    async fn run(
-        mut clients_rx: mpsc::UnboundedReceiver<DebugClientMessage>,
-        mut requests_rx: mpsc::UnboundedReceiver<oneshot::Sender<String>>,
-        cancellation_token: CancellationToken,
-    ) {
-        let mut clients = HashMap::<usize, DebugClientStatus>::new();
-        loop {
-            tokio::select! {
-                () = cancellation_token.cancelled() => {
-                    info!("DebugClientStatuses received cancellation");
-                    break
-                },
-                maybe = clients_rx.recv() => {
-                    let Some(message) = maybe else {
-                        break;
-                    };
-                    match message {
-                        DebugClientMessage::UpdateFilter { id, filter } => {
-                            match clients.entry(id) {
-                                HashMapEntry::Occupied(mut entry) => {
-                                    entry.get_mut().filter = filter;
-                                }
-                                HashMapEntry::Vacant(entry) => {
-                                    entry.insert(DebugClientStatus {
-                                        filter,
-                                        processed_slot: 0,
-                                    });
-                                }
-                            }
-                        }
-                        DebugClientMessage::UpdateSlot { id, slot } => {
-                            if let Some(status) = clients.get_mut(&id) {
-                                status.processed_slot = slot;
-                            }
-                        }
-                        DebugClientMessage::Removed { id } => {
-                            clients.remove(&id);
-                        }
-                    }
-                },
-                Some(tx) = requests_rx.recv() => {
-                    let mut statuses: Vec<(usize, String)> = clients.iter().map(|(id, status)| {
-                        (*id, format!("client#{id:06}, {}, {:?}", status.processed_slot, status.filter))
-                    }).collect();
-                    statuses.sort();
-
-                    let mut status = statuses.into_iter().fold(String::new(), |mut acc: String, (_id, status)| {
-                        if !acc.is_empty() {
-                            acc += "\n";
-                        }
-                        acc + &status
-                    });
-                    if !status.is_empty() {
-                        status += "\n";
-                    }
-
-                    let _ = tx.send(status);
-                },
-            }
-        }
-        info!("DebugClientStatuses exiting");
-    }
-
-    async fn get_statuses(&self) -> anyhow::Result<String> {
-        let (tx, rx) = oneshot::channel();
-        self.requests_tx
-            .send(tx)
-            .map_err(|_error| anyhow::anyhow!("failed to send request"))?;
-        rx.await
-            .map_err(|_error| anyhow::anyhow!("failed to wait response"))
-    }
 }
 
 pub struct PrometheusService;
@@ -433,7 +236,6 @@ pub struct PrometheusService;
 impl PrometheusService {
     pub async fn spawn(
         config: Option<ConfigPrometheus>,
-        debug_clients_rx: Option<mpsc::UnboundedReceiver<DebugClientMessage>>,
         cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
     ) -> std::io::Result<()> {
@@ -451,7 +253,6 @@ impl PrometheusService {
             register!(SLOT_STATUS_PLUGIN);
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
-            register!(CONNECTIONS_TOTAL);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);
             register!(GRPC_MESSAGE_SENT);
@@ -462,7 +263,7 @@ impl PrometheusService {
             register!(GRPC_CLIENT_DISCONNECTS);
             register!(PRE_ENCODED_CACHE_HIT);
             register!(PRE_ENCODED_CACHE_MISS);
-            register!(GRPC_CONCURRENT_SUBSCRIBE_PER_TCP_CONNECTION);
+            register!(GRPC_CONCURRENT_SUBSCRIBE_PER_SUBSCRIBER_ID);
             register!(TOTAL_TRAFFIC_SENT);
             register!(GRPC_METHOD_CALL_COUNT);
             register!(GRPC_SUBSCRIPTION_LIMIT_EXCEEDED);
@@ -475,18 +276,7 @@ impl PrometheusService {
             register!(AUTHORIZED_COUNT);
             register!(METHOD_RATELIMITED_COUNT);
 
-            register!(FILTER_COMPLEXITY_ACCOUNTS_SIZE);
-            register!(FILTER_COMPLEXITY_OWNERS_SIZE);
-            register!(FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE);
-            register!(FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE);
-            register!(FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE);
-            register!(FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED);
-            register!(FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE);
-            register!(FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE);
-            register!(FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE);
-            register!(FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED);
-            register!(FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE);
-            register!(FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE);
+            register!(FILTER_STATS);
 
             VERSION
                 .with_label_values(&[
@@ -501,18 +291,7 @@ impl PrometheusService {
                 .inc();
         });
 
-        let mut debug_clients_statuses = None;
         if let Some(ConfigPrometheus { address }) = config {
-            if let Some(debug_clients_rx) = debug_clients_rx {
-                info!("starting DebugClientStatuses");
-                debug_clients_statuses = Some(DebugClientStatuses::new(
-                    debug_clients_rx,
-                    cancellation_token.child_token(),
-                    task_tracker.clone(),
-                ));
-            }
-            let debug_clients_statuses2 = debug_clients_statuses.clone();
-
             let listener = TcpListener::bind(&address).await?;
             info!("start prometheus server: {address}");
             let task_tracker_clone = task_tracker.clone();
@@ -534,7 +313,6 @@ impl PrometheusService {
                             }
                         }
                     };
-                    let debug_clients_statuses = debug_clients_statuses2.clone();
                     task_tracker_clone.spawn(async move {
                         let peer_addr = stream.peer_addr().ok();
                         debug!(
@@ -544,35 +322,10 @@ impl PrometheusService {
                         if let Err(error) = ServerBuilder::new(TokioExecutor::new())
                             .serve_connection(
                                 TokioIo::new(stream),
-                                service_fn(move |req: Request<BodyIncoming>| {
-                                    let debug_clients_statuses = debug_clients_statuses.clone();
-                                    async move {
-                                        match req.uri().path() {
-                                            "/metrics" => metrics_handler(),
-                                            "/debug_clients" => {
-                                                if let Some(debug_clients_statuses) =
-                                                    &debug_clients_statuses
-                                                {
-                                                    let (status, body) =
-                                                        match debug_clients_statuses
-                                                            .get_statuses()
-                                                            .await
-                                                        {
-                                                            Ok(body) => (StatusCode::OK, body),
-                                                            Err(error) => (
-                                                                StatusCode::INTERNAL_SERVER_ERROR,
-                                                                error.to_string(),
-                                                            ),
-                                                        };
-                                                    Response::builder().status(status).body(
-                                                        BodyFull::new(Bytes::from(body)).boxed(),
-                                                    )
-                                                } else {
-                                                    not_found_handler()
-                                                }
-                                            }
-                                            _ => not_found_handler(),
-                                        }
+                                service_fn(move |req: Request<BodyIncoming>| async move {
+                                    match req.uri().path() {
+                                        "/metrics" => metrics_handler(),
+                                        _ => not_found_handler(),
                                     }
                                 }),
                             )
@@ -608,28 +361,34 @@ fn not_found_handler() -> http::Result<Response<BoxBody<Bytes, Infallible>>> {
         .body(BodyEmpty::new().boxed())
 }
 
-pub fn observe_filter_complexity(subscriber_id: &str, observation: &FilterComplexityProfile) {
+pub fn observe_filter_complexity(subscriber_id: &str, observation: &FilterStats) {
+    FILTER_STATS
+        .with_label_values(&[subscriber_id, "accounts", "len"])
+        .observe(observation.accounts.len() as f64);
     for score in &observation.accounts {
-        FILTER_COMPLEXITY_ACCOUNTS_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_size as f64);
-        FILTER_COMPLEXITY_OWNERS_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.owners_size as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "accounts", "accounts_len"])
+            .observe(score.accounts_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "accounts", "owners_len"])
+            .observe(score.owners_len as f64);
     }
 
+    FILTER_STATS
+        .with_label_values(&[subscriber_id, "transactions", "len"])
+        .observe(observation.transactions.len() as f64);
     for score in &observation.transactions {
-        FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_include_size as f64);
-        FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_exclude_size as f64);
-        FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_required_size as f64);
-        FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED
-            .with_label_values(&[subscriber_id])
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transactions", "accounts_include_len"])
+            .observe(score.accounts_include_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transactions", "accounts_exclude_len"])
+            .observe(score.accounts_exclude_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transactions", "accounts_required_len"])
+            .observe(score.accounts_required_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transactions", "token_accounts_enabled"])
             .observe(if score.token_accounts_enabled {
                 1.0
             } else {
@@ -637,18 +396,25 @@ pub fn observe_filter_complexity(subscriber_id: &str, observation: &FilterComple
             });
     }
 
+    FILTER_STATS
+        .with_label_values(&[subscriber_id, "transaction_status", "len"])
+        .observe(observation.transaction_status.len() as f64);
     for score in &observation.transaction_status {
-        FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_include_size as f64);
-        FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_exclude_size as f64);
-        FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.accounts_required_size as f64);
-        FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED
-            .with_label_values(&[subscriber_id])
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transaction_status", "accounts_include_len"])
+            .observe(score.accounts_include_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transaction_status", "accounts_exclude_len"])
+            .observe(score.accounts_exclude_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "transaction_status", "accounts_required_len"])
+            .observe(score.accounts_required_len as f64);
+        FILTER_STATS
+            .with_label_values(&[
+                subscriber_id,
+                "transaction_status",
+                "token_accounts_enabled",
+            ])
             .observe(if score.token_accounts_enabled {
                 1.0
             } else {
@@ -656,13 +422,16 @@ pub fn observe_filter_complexity(subscriber_id: &str, observation: &FilterComple
             });
     }
 
+    FILTER_STATS
+        .with_label_values(&[subscriber_id, "blocks", "len"])
+        .observe(observation.blocks.len() as f64);
     for score in &observation.blocks {
-        FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.include_size as f64);
-        FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE
-            .with_label_values(&[subscriber_id])
-            .observe(score.exclude_size as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "blocks", "include_len"])
+            .observe(score.include_len as f64);
+        FILTER_STATS
+            .with_label_values(&[subscriber_id, "blocks", "exclude_len"])
+            .observe(score.exclude_len as f64);
     }
 }
 
@@ -744,14 +513,6 @@ pub fn deshred_queue_size_dec() {
     DESHRED_QUEUE_SIZE.dec()
 }
 
-pub fn connections_total_inc() {
-    CONNECTIONS_TOTAL.inc()
-}
-
-pub fn connections_total_dec() {
-    CONNECTIONS_TOTAL.dec()
-}
-
 pub fn subscription_limit_exceeded_inc<S: AsRef<str>>(subscriber_id: S) {
     GRPC_SUBSCRIPTION_LIMIT_EXCEEDED
         .with_label_values(&[subscriber_id.as_ref()])
@@ -790,10 +551,14 @@ pub fn set_subscriber_send_bandwidth_load<S: AsRef<str>>(subscriber_id: S, load:
         .set(load);
 }
 
-pub fn set_subscriber_queue_size<S: AsRef<str>>(subscriber_id: S, size: u64) {
+pub fn observe_subscriber_queue_size<S: AsRef<str>>(
+    subscriber_id: S,
+    size: u64,
+    kind: &'static str,
+) {
     GRPC_SUBSCRIBER_QUEUE_SIZE
-        .with_label_values(&[subscriber_id.as_ref()])
-        .set(size as i64);
+        .with_label_values(&[subscriber_id.as_ref(), kind])
+        .observe(size as f64);
 }
 
 pub fn incr_client_disconnect<S: AsRef<str>>(subscriber_id: S, reason: &str) {
@@ -839,25 +604,21 @@ pub fn add_total_traffic_sent(bytes: u64) {
     TOTAL_TRAFFIC_SENT.inc_by(bytes);
 }
 
-pub fn set_grpc_concurrent_subscribe_per_tcp_connection<S: AsRef<str>>(
-    remote_peer_sk_addr: S,
-    size: u64,
-) {
-    GRPC_CONCURRENT_SUBSCRIBE_PER_TCP_CONNECTION
-        .with_label_values(&[remote_peer_sk_addr.as_ref()])
+pub fn set_grpc_concurrent_subscribe_per_subscriber_id<S: AsRef<str>>(subscriber_id: S, size: u64) {
+    GRPC_CONCURRENT_SUBSCRIBE_PER_SUBSCRIBER_ID
+        .with_label_values(&[subscriber_id.as_ref()])
         .set(size as i64);
 }
 
-pub fn remove_grpc_concurrent_subscribe_per_tcp_connection<S: AsRef<str>>(remote_peer_sk_addr: S) {
-    GRPC_CONCURRENT_SUBSCRIBE_PER_TCP_CONNECTION
-        .remove_label_values(&[remote_peer_sk_addr.as_ref()])
+pub fn remove_grpc_concurrent_subscribe_per_subscriber_id<S: AsRef<str>>(subscriber_id: S) {
+    GRPC_CONCURRENT_SUBSCRIBE_PER_SUBSCRIBER_ID
+        .remove_label_values(&[subscriber_id.as_ref()])
         .expect("remove_label_values");
 }
 
 /// Reset all metrics on plugin unload to prevent metric accumulation across plugin lifecycle
 pub fn reset_metrics() {
     // Reset gauge metrics to 0
-    CONNECTIONS_TOTAL.set(0);
     MESSAGE_QUEUE_SIZE.set(0);
 
     // Reset gauge vectors (clears all label combinations)
@@ -872,7 +633,7 @@ pub fn reset_metrics() {
     MISSED_STATUS_MESSAGE.reset();
     GRPC_MESSAGE_SENT.reset();
     GRPC_CLIENT_DISCONNECTS.reset();
-    GRPC_CONCURRENT_SUBSCRIBE_PER_TCP_CONNECTION.reset();
+    GRPC_CONCURRENT_SUBSCRIBE_PER_SUBSCRIBER_ID.reset();
     TOTAL_TRAFFIC_SENT.reset();
     GRPC_SERVICE_OUTBOUND_BYTES.reset();
     GRPC_SUBSCRIPTION_LIMIT_EXCEEDED.reset();
@@ -890,18 +651,7 @@ pub fn reset_metrics() {
     UNAUTHORIZED_COUNT.reset();
     AUTHORIZED_COUNT.reset();
     METHOD_RATELIMITED_COUNT.reset();
-    FILTER_COMPLEXITY_ACCOUNTS_SIZE.reset();
-    FILTER_COMPLEXITY_OWNERS_SIZE.reset();
-    FILTER_COMPLEXITY_TX_ACCOUNTS_INCLUDE_SIZE.reset();
-    FILTER_COMPLEXITY_TX_ACCOUNTS_EXCLUDE_SIZE.reset();
-    FILTER_COMPLEXITY_TX_ACCOUNTS_REQUIRED_SIZE.reset();
-    FILTER_COMPLEXITY_TX_TOKEN_MODE_ENABLED.reset();
-    FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_INCLUDE_SIZE.reset();
-    FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_EXCLUDE_SIZE.reset();
-    FILTER_COMPLEXITY_TX_STATUS_ACCOUNTS_REQUIRED_SIZE.reset();
-    FILTER_COMPLEXITY_TX_STATUS_TOKEN_MODE_ENABLED.reset();
-    FILTER_COMPLEXITY_BLOCKS_INCLUDE_SIZE.reset();
-    FILTER_COMPLEXITY_BLOCKS_EXCLUDE_SIZE.reset();
+    FILTER_STATS.reset();
     // Note: VERSION and GEYSER_ACCOUNT_UPDATE_RECEIVED are intentionally not reset
     // - VERSION contains build info set once on startup
     // - GEYSER_ACCOUNT_UPDATE_RECEIVED is a Histogram which doesn't support reset()

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -128,11 +128,9 @@ impl GeyserPlugin for Plugin {
                 let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
             });
 
-            let (debug_client_tx, debug_client_rx) = mpsc::unbounded_channel();
             // Create prometheus service First so if it fails the plugin doesn't spawn geyser tasks unnecessarily.
             PrometheusService::spawn(
                 config.prometheus,
-                config.debug_clients_http.then_some(debug_client_rx),
                 prometheus_cancellation_token,
                 prometheus_task_tracker,
             )
@@ -141,7 +139,6 @@ impl GeyserPlugin for Plugin {
 
             let (snapshot_channel, grpc_channel, deshred_channel) = GrpcService::create(
                 config.grpc,
-                config.debug_clients_http.then_some(debug_client_tx),
                 is_reload,
                 grpc_cancellation_token,
                 grpc_task_tracker,

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -142,54 +142,53 @@ impl Default for Filter {
     }
 }
 
-/// Complexity snapshot for one account filter definition.
+/// Statistic snapshot for one account filter definition.
 ///
 /// Counts represent how many account/owner keys were configured in that
 /// filter, not how many runtime matches occurred.
 #[derive(Debug, Clone)]
-pub struct AccountFilterComplexityScore {
+pub struct AccountFilterStats {
     /// Number of configured account pubkeys in this filter.
-    pub accounts_size: usize,
+    pub accounts_len: usize,
     /// Number of configured owner pubkeys in this filter.
-    pub owners_size: usize,
+    pub owners_len: usize,
 }
 
-/// Complexity snapshot for one transaction (or transaction status) filter.
+/// Statistic snapshot for one transaction (or transaction status) filter.
 #[derive(Debug, Clone)]
-pub struct TxnFilterComplexityScore {
+pub struct TxnFilterStats {
     /// Number of pubkeys in `account_include`.
-    pub accounts_include_size: usize,
+    pub accounts_include_len: usize,
     /// Number of pubkeys in `account_exclude`.
-    pub accounts_exclude_size: usize,
+    pub accounts_exclude_len: usize,
     /// Number of pubkeys in `account_required`.
-    pub accounts_required_size: usize,
+    pub accounts_required_len: usize,
     /// Whether token-account expansion is enabled for this filter.
     pub token_accounts_enabled: bool,
 }
 
-/// Complexity snapshot for one block filter.
+/// Statistic snapshot for one block filter.
 #[derive(Debug, Clone)]
-pub struct BlocksFilterComplexityScore {
+pub struct BlocksFilterStats {
     /// Number of inclusion conditions enabled on this filter.
-    pub include_size: usize,
+    pub include_len: usize,
     /// Number of explicit exclusion toggles on this filter.
-    pub exclude_size: usize,
+    pub exclude_len: usize,
 }
 
-/// Aggregate complexity view across all filter groups.
+/// Aggregate statistics view across all filter groups.
 ///
-/// This is intended for diagnostics/telemetry and should not drive business
-/// logic decisions.
+/// This is intended for diagnostics/telemetry and should not drive business logic decisions.
 #[derive(Clone, Debug)]
-pub struct FilterComplexityProfile {
+pub struct FilterStats {
     /// Per-account-filter complexity entries.
-    pub accounts: Vec<AccountFilterComplexityScore>,
+    pub accounts: Vec<AccountFilterStats>,
     /// Per-transaction-filter complexity entries.
-    pub transactions: Vec<TxnFilterComplexityScore>,
+    pub transactions: Vec<TxnFilterStats>,
     /// Per-transaction-status-filter complexity entries.
-    pub transaction_status: Vec<TxnFilterComplexityScore>,
+    pub transaction_status: Vec<TxnFilterStats>,
     /// Per-block-filter complexity entries.
-    pub blocks: Vec<BlocksFilterComplexityScore>,
+    pub blocks: Vec<BlocksFilterStats>,
 }
 
 impl Filter {
@@ -225,12 +224,12 @@ impl Filter {
         })
     }
 
-    /// Build a static complexity snapshot of the currently parsed filter.
+    /// Build a static statistics snapshot of the currently parsed filter.
     ///
     /// The returned values are derived from configured filter criteria only.
     /// They do not depend on live traffic and are safe to call for logging,
     /// metrics, and debugging.
-    pub fn get_complexity_profile(&self) -> FilterComplexityProfile {
+    pub fn get_filter_stats(&self) -> FilterStats {
         // `accounts.account` is indexed by pubkey -> set(filter_name).
         // For complexity we need the inverse shape (filter_name -> count(pubkeys)),
         // so we accumulate how many pubkeys point to each filter.
@@ -262,12 +261,12 @@ impl Filter {
             .accounts
             .aggregates
             .iter()
-            .map(|aggregate| AccountFilterComplexityScore {
-                accounts_size: account_pubkey_hits
+            .map(|aggregate| AccountFilterStats {
+                accounts_len: account_pubkey_hits
                     .get(&aggregate.filter_name)
                     .copied()
                     .unwrap_or(0),
-                owners_size: owner_pubkey_hits
+                owners_len: owner_pubkey_hits
                     .get(&aggregate.filter_name)
                     .copied()
                     .unwrap_or(0),
@@ -280,10 +279,10 @@ impl Filter {
             .transactions
             .filters
             .iter()
-            .map(|(_name, inner)| TxnFilterComplexityScore {
-                accounts_include_size: inner.account_include.len(),
-                accounts_exclude_size: inner.account_exclude.len(),
-                accounts_required_size: inner.account_required.len(),
+            .map(|(_name, inner)| TxnFilterStats {
+                accounts_include_len: inner.account_include.len(),
+                accounts_exclude_len: inner.account_exclude.len(),
+                accounts_required_len: inner.account_required.len(),
                 token_accounts_enabled: inner.token_accounts.is_some(),
             })
             .collect();
@@ -293,10 +292,10 @@ impl Filter {
             .transactions_status
             .filters
             .iter()
-            .map(|(_name, inner)| TxnFilterComplexityScore {
-                accounts_include_size: inner.account_include.len(),
-                accounts_exclude_size: inner.account_exclude.len(),
-                accounts_required_size: inner.account_required.len(),
+            .map(|(_name, inner)| TxnFilterStats {
+                accounts_include_len: inner.account_include.len(),
+                accounts_exclude_len: inner.account_exclude.len(),
+                accounts_required_len: inner.account_required.len(),
                 token_accounts_enabled: inner.token_accounts.is_some(),
             })
             .collect();
@@ -308,20 +307,20 @@ impl Filter {
             .blocks
             .filters
             .values()
-            .map(|inner| BlocksFilterComplexityScore {
-                include_size: inner.account_include.len()
+            .map(|inner| BlocksFilterStats {
+                include_len: inner.account_include.len()
                     + usize::from(inner.account_cuckoo.is_some())
                     + usize::from(matches!(inner.include_transactions, None | Some(true)))
                     + usize::from(inner.include_accounts == Some(true))
                     + usize::from(inner.include_entries == Some(true)),
-                exclude_size: usize::from(inner.include_transactions == Some(false))
+                exclude_len: usize::from(inner.include_transactions == Some(false))
                     + usize::from(inner.include_accounts == Some(false))
                     + usize::from(inner.include_entries == Some(false)),
             })
             .collect();
 
         // Return a full snapshot grouped by filter category.
-        FilterComplexityProfile {
+        FilterStats {
             accounts,
             transactions,
             transaction_status,

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -142,6 +142,56 @@ impl Default for Filter {
     }
 }
 
+/// Complexity snapshot for one account filter definition.
+///
+/// Counts represent how many account/owner keys were configured in that
+/// filter, not how many runtime matches occurred.
+#[derive(Debug, Clone)]
+pub struct AccountFilterComplexityScore {
+    /// Number of configured account pubkeys in this filter.
+    pub accounts_size: usize,
+    /// Number of configured owner pubkeys in this filter.
+    pub owners_size: usize,
+}
+
+/// Complexity snapshot for one transaction (or transaction status) filter.
+#[derive(Debug, Clone)]
+pub struct TxnFilterComplexityScore {
+    /// Number of pubkeys in `account_include`.
+    pub accounts_include_size: usize,
+    /// Number of pubkeys in `account_exclude`.
+    pub accounts_exclude_size: usize,
+    /// Number of pubkeys in `account_required`.
+    pub accounts_required_size: usize,
+    /// Whether token-account expansion is enabled for this filter.
+    pub token_accounts_enabled: bool,
+}
+
+/// Complexity snapshot for one block filter.
+#[derive(Debug, Clone)]
+pub struct BlocksFilterComplexityScore {
+    /// Number of inclusion conditions enabled on this filter.
+    pub include_size: usize,
+    /// Number of explicit exclusion toggles on this filter.
+    pub exclude_size: usize,
+}
+
+/// Aggregate complexity view across all filter groups.
+///
+/// This is intended for diagnostics/telemetry and should not drive business
+/// logic decisions.
+#[derive(Clone, Debug)]
+pub struct FilterComplexityProfile {
+    /// Per-account-filter complexity entries.
+    pub accounts: Vec<AccountFilterComplexityScore>,
+    /// Per-transaction-filter complexity entries.
+    pub transactions: Vec<TxnFilterComplexityScore>,
+    /// Per-transaction-status-filter complexity entries.
+    pub transaction_status: Vec<TxnFilterComplexityScore>,
+    /// Per-block-filter complexity entries.
+    pub blocks: Vec<BlocksFilterComplexityScore>,
+}
+
 impl Filter {
     pub fn new(
         config: &SubscribeRequest,
@@ -173,6 +223,110 @@ impl Filter {
             )?,
             ping: config.ping.as_ref().map(|msg| msg.id),
         })
+    }
+
+    /// Build a static complexity snapshot of the currently parsed filter.
+    ///
+    /// The returned values are derived from configured filter criteria only.
+    /// They do not depend on live traffic and are safe to call for logging,
+    /// metrics, and debugging.
+    pub fn get_complexity_profile(&self) -> FilterComplexityProfile {
+        // `accounts.account` is indexed by pubkey -> set(filter_name).
+        // For complexity we need the inverse shape (filter_name -> count(pubkeys)),
+        // so we accumulate how many pubkeys point to each filter.
+        let mut account_pubkey_hits = HashMap::new();
+        for filter_names in self.accounts.account.values() {
+            for filter_name in filter_names {
+                *account_pubkey_hits
+                    .entry(filter_name.clone())
+                    .or_insert(0usize) += 1;
+            }
+        }
+
+        // Same inversion for owner constraints: owner pubkey -> set(filter_name)
+        // becomes per-filter owner count.
+        let mut owner_pubkey_hits = HashMap::new();
+        for filter_names in self.accounts.owner.values() {
+            for filter_name in filter_names {
+                *owner_pubkey_hits
+                    .entry(filter_name.clone())
+                    .or_insert(0usize) += 1;
+            }
+        }
+
+        // We iterate `aggregates` as the canonical list of account filters.
+        // Reason: an account filter can exist without account/owner pubkeys
+        // (for example only state checks or nonempty_txn_signature), and those
+        // filters would be missing if we iterated only account/owner maps.
+        let accounts = self
+            .accounts
+            .aggregates
+            .iter()
+            .map(|aggregate| AccountFilterComplexityScore {
+                accounts_size: account_pubkey_hits
+                    .get(&aggregate.filter_name)
+                    .copied()
+                    .unwrap_or(0),
+                owners_size: owner_pubkey_hits
+                    .get(&aggregate.filter_name)
+                    .copied()
+                    .unwrap_or(0),
+            })
+            .collect();
+
+        // Transaction filter complexity is direct: one observation per parsed
+        // filter with sizes of include/exclude/required lists plus token mode.
+        let transactions = self
+            .transactions
+            .filters
+            .iter()
+            .map(|(_name, inner)| TxnFilterComplexityScore {
+                accounts_include_size: inner.account_include.len(),
+                accounts_exclude_size: inner.account_exclude.len(),
+                accounts_required_size: inner.account_required.len(),
+                token_accounts_enabled: inner.token_accounts.is_some(),
+            })
+            .collect();
+
+        // Same logic for transaction-status filters.
+        let transaction_status = self
+            .transactions_status
+            .filters
+            .iter()
+            .map(|(_name, inner)| TxnFilterComplexityScore {
+                accounts_include_size: inner.account_include.len(),
+                accounts_exclude_size: inner.account_exclude.len(),
+                accounts_required_size: inner.account_required.len(),
+                token_accounts_enabled: inner.token_accounts.is_some(),
+            })
+            .collect();
+
+        // Block filters have both selector lists and include/exclude toggles.
+        // We summarize these as simple counts so logs/metrics can compare
+        // relative complexity without serializing full filter internals.
+        let blocks = self
+            .blocks
+            .filters
+            .values()
+            .map(|inner| BlocksFilterComplexityScore {
+                include_size: inner.account_include.len()
+                    + usize::from(inner.account_cuckoo.is_some())
+                    + usize::from(matches!(inner.include_transactions, None | Some(true)))
+                    + usize::from(inner.include_accounts == Some(true))
+                    + usize::from(inner.include_entries == Some(true)),
+                exclude_size: usize::from(inner.include_transactions == Some(false))
+                    + usize::from(inner.include_accounts == Some(false))
+                    + usize::from(inner.include_entries == Some(false)),
+            })
+            .collect();
+
+        // Return a full snapshot grouped by filter category.
+        FilterComplexityProfile {
+            accounts,
+            transactions,
+            transaction_status,
+            blocks,
+        }
     }
 
     fn decode_commitment(commitment: Option<i32>) -> FilterResult<CommitmentLevel> {

--- a/yellowstone-grpc-geyser/src/plugin/filter/mod.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/mod.rs
@@ -6,6 +6,5 @@ pub mod message;
 pub mod name;
 
 pub use filter::{
-    DeshredFilter, Filter, FilterAccountsDataSlice, FilterComplexityProfile, FilterError,
-    FilterResult,
+    DeshredFilter, Filter, FilterAccountsDataSlice, FilterError, FilterResult, FilterStats,
 };

--- a/yellowstone-grpc-geyser/src/plugin/filter/mod.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/mod.rs
@@ -5,4 +5,7 @@ pub mod limits;
 pub mod message;
 pub mod name;
 
-pub use filter::{DeshredFilter, Filter, FilterAccountsDataSlice, FilterError, FilterResult};
+pub use filter::{
+    DeshredFilter, Filter, FilterAccountsDataSlice, FilterComplexityProfile, FilterError,
+    FilterResult,
+};


### PR DESCRIPTION
### Features

- Added new set of `yellowstone_grpc_filter_stats` metrics to monitor the size and complexity of a filters.

### Fixes

- Added proper subscription tracking for deshred subscription: no ratelimiting was imposed.
- Fixed a subtil bug where updating the subscription tracker counter maps could leak a decrement if the future/thread panic before `ClientSession` is created. Now subscription tracking acquision and release is done via proper RAII struct that implements `Drop`.

### Breaking

- Prefixed all prometheus metrics with `yellowstone_grpc` to set a convention that is what we found in OTel metrics framework.
- Removed `/debug_clients` endpoint from the auxiliary sidecar server.
- Change the client loop logs to include subscription for better monitoring/troubleshooting.
- Changed `yellowstone_grpc_subscriber_queue_size` from `IntGaugeVec` to `HistogramVec` since many subscription may exists for the same subscriber at the same time.