### PR TITLE
STR-600: refactor TS client to accomodate reconnect changes in rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -14,8 +14,4 @@ ignore = [
     # bincode 1.3.3
     # Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0141
     "RUSTSEC-2025-0141",
-
-    # time 0.3.45 — fix (>=0.3.47) requires Rust 1.88.0, we are on 1.86.0
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0009
-    "RUSTSEC-2026-0009",
 ]

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -82,7 +82,20 @@ npm start -- --endpoint https://api.rpcpool.com \
   --autoreconnect-initial-interval-ms 100 \
   --autoreconnect-multiplier 2 \
   --autoreconnect-max-retries 10 \
+  --autoreconnect-replay-policy from-checkpoint \
+  --autoreconnect-checkpoint-buffer "2" \
   --autoreconnect-slot-retention 250 \
+  subscribe \
+  --slots
+```
+
+Use fresh reconnect to reconnect from the current stream point without checkpoint replay:
+
+```shell
+npm start -- --endpoint https://api.rpcpool.com \
+  --x-token "<token>" \
+  --autoreconnect \
+  --autoreconnect-replay-policy fresh \
   subscribe \
   --slots
 ```
@@ -95,11 +108,15 @@ const client = new Client(
   "<token>",
   { grpcMaxDecodingMessageSize: 64 * 1024 * 1024 },
   {
-    enabled: true,
     backoff: {
       initialIntervalMs: 100,
       multiplier: 2,
       maxRetries: 10,
+    },
+    replayPolicy: {
+      fromCheckpoint: {
+        checkpointBuffer: "2",
+      },
     },
     slotRetention: 250,
   },

--- a/examples/typescript/src/client.ts
+++ b/examples/typescript/src/client.ts
@@ -10,7 +10,10 @@ import Client, {
   txEncode,
   txErrDecode,
 } from "@triton-one/yellowstone-grpc";
-import type { ReconnectOptions } from "@triton-one/yellowstone-grpc";
+import type {
+  ReconnectOptions,
+  ReconnectReplayPolicy,
+} from "@triton-one/yellowstone-grpc";
 
 async function main() {
   const args = await parseCommandLineArgs();
@@ -93,13 +96,22 @@ function buildReconnectOptions(args): ReconnectOptions | undefined {
     return undefined;
   }
 
+  const replayPolicy: ReconnectReplayPolicy =
+    args.autoreconnectReplayPolicy === "fresh"
+      ? { fresh: true }
+      : {
+          fromCheckpoint: {
+            checkpointBuffer: String(args.autoreconnectCheckpointBuffer),
+          },
+        };
+
   return {
-    enabled: true,
     backoff: {
       initialIntervalMs: args.autoreconnectInitialIntervalMs,
       multiplier: args.autoreconnectMultiplier,
       maxRetries: args.autoreconnectMaxRetries,
     },
+    replayPolicy,
     slotRetention: args.autoreconnectSlotRetention,
   };
 }
@@ -506,6 +518,17 @@ async function parseCommandLineArgs() {
         default: 3,
         describe: "auto-reconnect retry count per reconnect attempt",
         type: "number",
+      },
+      "autoreconnect-replay-policy": {
+        choices: ["from-checkpoint", "fresh"],
+        default: "from-checkpoint",
+        describe: "auto-reconnect replay policy",
+        type: "string",
+      },
+      "autoreconnect-checkpoint-buffer": {
+        default: "2",
+        describe: "slots behind the latest block meta to replay from",
+        type: "string",
       },
       "autoreconnect-slot-retention": {
         default: 250,

--- a/yellowstone-grpc-client-nodejs/README.md
+++ b/yellowstone-grpc-client-nodejs/README.md
@@ -38,6 +38,11 @@ const client = new Client(endpoint, xToken, channelOptions, {
     multiplier: 2,
     maxRetries: 10,
   },
+  replayPolicy: {
+    fromCheckpoint: {
+      checkpointBuffer: "2",
+    },
+  },
   slotRetention: 250,
 });
 
@@ -45,8 +50,11 @@ await client.connect();
 const stream = await client.subscribe(request);
 ```
 
-Omit the fourth argument, or pass `{ enabled: false }`, to keep the previous
-no-reconnect behavior. Deshred subscriptions are unchanged.
+Omit the fourth argument to keep the previous no-reconnect behavior. When
+`replayPolicy` is omitted from a reconnect config, the Rust client default is
+used: `fromCheckpoint` with a checkpoint buffer of `2`. Use
+`replayPolicy: { fresh: true }` to reconnect from the current stream point
+without checkpoint replay. Deshred subscriptions are unchanged.
 
 ### Compressed account filters
 

--- a/yellowstone-grpc-client-nodejs/napi/index.d.ts
+++ b/yellowstone-grpc-client-nodejs/napi/index.d.ts
@@ -141,13 +141,18 @@ export interface JsReconnectBackoff {
 }
 
 export interface JsReconnectConfig {
-  /**
-   * Omitted or true enables reconnect when this object is provided.
-   * False keeps legacy no-reconnect behavior.
-   */
-  enabled?: boolean
   backoff?: JsReconnectBackoff
+  replayPolicy?: JsReconnectReplayPolicy
   slotRetention?: number
+}
+
+export interface JsReconnectFromCheckpoint {
+  checkpointBuffer: string
+}
+
+export interface JsReconnectReplayPolicy {
+  fromCheckpoint?: JsReconnectFromCheckpoint
+  fresh?: boolean
 }
 
 export declare const enum WasmUiTransactionEncoding {

--- a/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
@@ -57,11 +57,22 @@ pub struct JsReconnectBackoff {
 
 #[napi(object)]
 #[derive(Deserialize, Debug, Clone)]
+pub struct JsReconnectFromCheckpoint {
+  pub checkpoint_buffer: String,
+}
+
+#[napi(object)]
+#[derive(Deserialize, Debug, Clone)]
+pub struct JsReconnectReplayPolicy {
+  pub from_checkpoint: Option<JsReconnectFromCheckpoint>,
+  pub fresh: Option<bool>,
+}
+
+#[napi(object)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct JsReconnectConfig {
-  /// Omitted or true enables reconnect when this object is provided.
-  /// False keeps legacy no-reconnect behavior.
-  pub enabled: Option<bool>,
   pub backoff: Option<JsReconnectBackoff>,
+  pub replay_policy: Option<JsReconnectReplayPolicy>,
   pub slot_retention: Option<u32>,
 }
 

--- a/yellowstone-grpc-client-nodejs/napi/src/utils.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/utils.rs
@@ -1,7 +1,11 @@
-use crate::bindings::{JsChannelOptions, JsCompressionAlgorithm, JsReconnectConfig};
+use crate::bindings::{
+  JsChannelOptions, JsCompressionAlgorithm, JsReconnectConfig, JsReconnectReplayPolicy,
+};
 use napi::bindgen_prelude::{Result, Status};
 use std::time::Duration;
-use yellowstone_grpc_client::{Backoff, ClientTlsConfig, GeyserGrpcBuilder, ReconnectConfig};
+use yellowstone_grpc_client::{
+  reconnect::ReplayPolicy, Backoff, ClientTlsConfig, GeyserGrpcBuilder, ReconnectConfig,
+};
 use yellowstone_grpc_proto::tonic::codec::CompressionEncoding;
 
 fn to_napi_cause(status: Status, source: &dyn std::error::Error) -> napi::Error {
@@ -25,6 +29,41 @@ fn invalid_arg(reason: impl Into<String>) -> napi::Error {
   error
 }
 
+fn parse_u64_string(value: &str, field_name: &str) -> Result<u64> {
+  value.parse::<u64>().map_err(|error| {
+    invalid_arg_with_cause(
+      format!("invalid {field_name}: expected a u64 string"),
+      &error,
+    )
+  })
+}
+
+fn replay_policy_from_js(replay_policy: Option<JsReconnectReplayPolicy>) -> Result<ReplayPolicy> {
+  let Some(replay_policy) = replay_policy else {
+    return Ok(ReplayPolicy::default());
+  };
+
+  match (replay_policy.from_checkpoint, replay_policy.fresh) {
+    (Some(from_checkpoint), None) => {
+      let checkpoint_buffer = parse_u64_string(
+        &from_checkpoint.checkpoint_buffer,
+        "reconnect.replayPolicy.fromCheckpoint.checkpointBuffer",
+      )?;
+      Ok(ReplayPolicy::FromCheckpoint { checkpoint_buffer })
+    }
+    (None, Some(true)) => Ok(ReplayPolicy::Fresh),
+    (None, Some(false)) => Err(invalid_arg(
+      "invalid reconnect.replayPolicy.fresh: expected true when set",
+    )),
+    (None, None) => Err(invalid_arg(
+      "invalid reconnect.replayPolicy: expected fromCheckpoint or fresh",
+    )),
+    (Some(_), Some(_)) => Err(invalid_arg(
+      "invalid reconnect.replayPolicy: expected exactly one of fromCheckpoint or fresh",
+    )),
+  }
+}
+
 fn reconnect_config_from_js(
   reconnect_config: Option<JsReconnectConfig>,
 ) -> Result<Option<ReconnectConfig>> {
@@ -32,11 +71,8 @@ fn reconnect_config_from_js(
     return Ok(None);
   };
 
-  if reconnect_config.enabled == Some(false) {
-    return Ok(None);
-  }
-
   let mut native_config = ReconnectConfig::default();
+  native_config.replay_policy = replay_policy_from_js(reconnect_config.replay_policy)?;
 
   if let Some(slot_retention) = reconnect_config.slot_retention {
     if slot_retention == 0 {
@@ -247,6 +283,11 @@ pub async fn get_client_builder(
 #[cfg(test)]
 mod tests {
   use super::get_client_builder;
+  use crate::bindings::{
+    JsReconnectBackoff, JsReconnectConfig, JsReconnectFromCheckpoint, JsReconnectReplayPolicy,
+  };
+  use std::time::Duration;
+  use yellowstone_grpc_client::{reconnect::ReplayPolicy, ReconnectConfig};
 
   #[tokio::test]
   async fn get_client_builder_invalid_endpoint_includes_cause() {
@@ -286,20 +327,31 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn get_client_builder_applies_reconnect_config() {
-    use crate::bindings::{JsReconnectBackoff, JsReconnectConfig};
-    use std::time::Duration;
+  async fn get_client_builder_omits_reconnect_config_by_default() {
+    let builder = get_client_builder("http://127.0.0.1:10000".to_string(), None, None, None)
+      .await
+      .expect("valid endpoint should build");
 
+    assert!(builder.reconnect_config.is_none());
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_applies_reconnect_config() {
     let builder = get_client_builder(
       "http://127.0.0.1:10000".to_string(),
       None,
       None,
       Some(JsReconnectConfig {
-        enabled: Some(true),
         backoff: Some(JsReconnectBackoff {
           initial_interval_ms: Some(125),
           multiplier: Some(1.5),
           max_retries: Some(8),
+        }),
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: Some(JsReconnectFromCheckpoint {
+            checkpoint_buffer: "12".to_string(),
+          }),
+          fresh: None,
         }),
         slot_retention: Some(300),
       }),
@@ -307,30 +359,129 @@ mod tests {
     .await
     .expect("valid reconnect config should build");
 
+    let reconnect_config = builder
+      .reconnect_config
+      .expect("reconnect config should be set");
+
     assert_eq!(
-      builder.reconnect_config.backoff.initial_interval,
+      reconnect_config.backoff.initial_interval,
       Duration::from_millis(125)
     );
-    assert_eq!(builder.reconnect_config.backoff.multiplier, 1.5);
-    assert_eq!(builder.reconnect_config.backoff.max_retries, 8);
-    assert_eq!(builder.reconnect_config.slot_retention, 300);
+    assert_eq!(reconnect_config.backoff.multiplier, 1.5);
+    assert_eq!(reconnect_config.backoff.max_retries, 8);
+    assert_eq!(reconnect_config.slot_retention, 300);
+    match reconnect_config.replay_policy {
+      ReplayPolicy::FromCheckpoint { checkpoint_buffer } => assert_eq!(checkpoint_buffer, 12),
+      ReplayPolicy::Fresh => panic!("expected checkpoint replay policy"),
+    }
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_uses_default_replay_policy() {
+    let builder = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: None,
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect("valid reconnect config should build");
+
+    let reconnect_config = builder
+      .reconnect_config
+      .expect("reconnect config should be set");
+
+    match (
+      reconnect_config.replay_policy,
+      ReconnectConfig::default().replay_policy,
+    ) {
+      (
+        ReplayPolicy::FromCheckpoint { checkpoint_buffer },
+        ReplayPolicy::FromCheckpoint {
+          checkpoint_buffer: expected,
+        },
+      ) => assert_eq!(checkpoint_buffer, expected),
+      _ => panic!("expected default checkpoint replay policy"),
+    }
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_applies_fresh_replay_policy() {
+    let builder = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: None,
+          fresh: Some(true),
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect("valid reconnect config should build");
+
+    let reconnect_config = builder
+      .reconnect_config
+      .expect("reconnect config should be set");
+
+    match reconnect_config.replay_policy {
+      ReplayPolicy::Fresh => {}
+      ReplayPolicy::FromCheckpoint { .. } => panic!("expected fresh replay policy"),
+    }
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_accepts_checkpoint_buffer_above_u32_max() {
+    let builder = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: Some(JsReconnectFromCheckpoint {
+            checkpoint_buffer: "4294967296".to_string(),
+          }),
+          fresh: None,
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect("u64 checkpoint buffer should build");
+
+    let reconnect_config = builder
+      .reconnect_config
+      .expect("reconnect config should be set");
+
+    match reconnect_config.replay_policy {
+      ReplayPolicy::FromCheckpoint { checkpoint_buffer } => {
+        assert_eq!(checkpoint_buffer, 4294967296)
+      }
+      ReplayPolicy::Fresh => panic!("expected checkpoint replay policy"),
+    }
   }
 
   #[tokio::test]
   async fn get_client_builder_rejects_invalid_reconnect_config() {
-    use crate::bindings::{JsReconnectBackoff, JsReconnectConfig};
-
     let error = get_client_builder(
       "http://127.0.0.1:10000".to_string(),
       None,
       None,
       Some(JsReconnectConfig {
-        enabled: Some(true),
         backoff: Some(JsReconnectBackoff {
           initial_interval_ms: None,
           multiplier: Some(0.5),
           max_retries: None,
         }),
+        replay_policy: None,
         slot_retention: None,
       }),
     )
@@ -343,5 +494,135 @@ mod tests {
         .contains("invalid reconnect.backoff.multiplier"),
       "unexpected error message: {error}"
     );
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_rejects_zero_slot_retention() {
+    let error = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: None,
+        slot_retention: Some(0),
+      }),
+    )
+    .await
+    .expect_err("zero slot retention should fail");
+
+    assert!(
+      error
+        .to_string()
+        .contains("invalid reconnect.slotRetention"),
+      "unexpected error message: {error}"
+    );
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_rejects_empty_replay_policy() {
+    let error = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: None,
+          fresh: None,
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect_err("empty replay policy should fail");
+
+    assert!(
+      error.to_string().contains("invalid reconnect.replayPolicy"),
+      "unexpected error message: {error}"
+    );
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_rejects_ambiguous_replay_policy() {
+    let error = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: Some(JsReconnectFromCheckpoint {
+            checkpoint_buffer: "2".to_string(),
+          }),
+          fresh: Some(true),
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect_err("ambiguous replay policy should fail");
+
+    assert!(
+      error
+        .to_string()
+        .contains("expected exactly one of fromCheckpoint or fresh"),
+      "unexpected error message: {error}"
+    );
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_rejects_false_fresh_replay_policy() {
+    let error = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: None,
+          fresh: Some(false),
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect_err("false fresh policy should fail");
+
+    assert!(
+      error
+        .to_string()
+        .contains("invalid reconnect.replayPolicy.fresh"),
+      "unexpected error message: {error}"
+    );
+  }
+
+  #[tokio::test]
+  async fn get_client_builder_rejects_invalid_checkpoint_buffer() {
+    let error = get_client_builder(
+      "http://127.0.0.1:10000".to_string(),
+      None,
+      None,
+      Some(JsReconnectConfig {
+        backoff: None,
+        replay_policy: Some(JsReconnectReplayPolicy {
+          from_checkpoint: Some(JsReconnectFromCheckpoint {
+            checkpoint_buffer: "not-a-number".to_string(),
+          }),
+          fresh: None,
+        }),
+        slot_retention: None,
+      }),
+    )
+    .await
+    .expect_err("invalid checkpoint buffer should fail");
+
+    assert!(
+      error
+        .to_string()
+        .contains("invalid reconnect.replayPolicy.fromCheckpoint.checkpointBuffer"),
+      "unexpected error message: {error}"
+    );
+    assert!(error.cause.is_some(), "expected native parse cause");
   }
 }

--- a/yellowstone-grpc-client-nodejs/src/index.ts
+++ b/yellowstone-grpc-client-nodejs/src/index.ts
@@ -92,8 +92,21 @@ import type {
 
 import { Duplex } from "stream";
 import * as napi from "./napi/index";
+import type {
+  JsReconnectBackoff as ReconnectBackoff,
+  JsReconnectConfig as ReconnectOptions,
+  JsReconnectFromCheckpoint as ReconnectFromCheckpoint,
+  JsReconnectReplayPolicy as ReconnectReplayPolicy,
+} from "./napi/index";
 
 export const AUTORECONNECT_FILTER_KEY: string = napi.AUTORECONNECT_FILTER_KEY;
+
+export type {
+  ReconnectBackoff,
+  ReconnectFromCheckpoint,
+  ReconnectOptions,
+  ReconnectReplayPolicy,
+};
 
 /**
  * Public channel options accepted by the SDK constructor.
@@ -101,16 +114,6 @@ export const AUTORECONNECT_FILTER_KEY: string = napi.AUTORECONNECT_FILTER_KEY;
  * duplicating option fields in this file.
  */
 export type ChannelOptions = NonNullable<Parameters<typeof napi.GrpcClient.new>[2]>;
-
-export interface ReconnectOptions {
-  enabled?: boolean;
-  backoff?: {
-    initialIntervalMs?: number;
-    multiplier?: number;
-    maxRetries?: number;
-  };
-  slotRetention?: number;
-}
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -1,5 +1,5 @@
 mod dedup;
-mod reconnect;
+pub mod reconnect;
 
 use {
     crate::{


### PR DESCRIPTION
- Exposed the Rust reconnect module so NAPI can use ReplayPolicy.
- Updated Node NAPI reconnect options to match the Rust client:
    - removed enabled
    - added replayPolicy
    - supports fromCheckpoint and fresh
    - parses checkpointBuffer as a u64 string since JS cannnot handle u64

- Re-exported generated NAPI reconnect types from the JS SDK without redefining them.
- Updated Node SDK docs and TypeScript examples for the new reconnect shape.
- Added example CLI flags for replay policy and checkpoint buffer.