### PR TITLE
Plugin data feed abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 - Changed client-loop logs to include subscriber context for improved monitoring and troubleshooting.
 - Changed `yellowstone_grpc_geyser_subscriber_queue_size` from `IntGaugeVec` to `HistogramVec` to better represent multiple concurrent subscriptions per subscriber.
 
+### Misc
+- Introduced a stream which feeds data into the geyser and block reconstruction loops
+- Optimizes the geyser_loop processed message feed by moving block reconstruction, block meta and slot messages to a 1hop channel send instead of running through geyser_loop
+
 ## 2026-07-03
 
 - yellowstone-grpc-geyser 14.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5245,26 +5245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6432,7 +6412,6 @@ dependencies = [
  "solana-transaction-status",
  "spl-token-2022-interface",
  "thiserror 2.0.18",
- "tikv-jemallocator",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -21,7 +21,6 @@ default = []
 bench = ["dep:solana-storage-proto"]
 
 [dependencies]
-tikv-jemallocator = { version = "0.6.1", features = ["disable_initial_exec_tls"] }
 foldhash = { workspace = true }
 arc-swap = { workspace = true }
 anyhow = { workspace = true }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -31,7 +31,7 @@ use {
     },
     anyhow::Context as _,
     bytesize::ByteSize,
-    futures::{Stream, StreamExt},
+    futures::Stream,
     log::{error, info},
     prost_types::Timestamp,
     rustls::{
@@ -64,15 +64,11 @@ use {
     tokio_util::{sync::CancellationToken, task::TaskTracker},
     tonic::{
         metadata::AsciiMetadataValue,
-        ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks},
         service::{interceptor, LayerExt},
-        stream::{BatchInto, GeyserStream, PollReceiver},
         transport::{
             server::{Connected, Server},
             CertificateDer,
         },
-        util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
-        version::GrpcVersionInfo,
         Request, Response, Result as TonicResult, Status, Streaming,
     },
     tonic_health::{pb::health_server::HealthServer, server::health_reporter},
@@ -314,7 +310,11 @@ impl BlockMetaStorage {
     }
 }
 
-type BlockReconstructionMessage = Arc<Vec<Message>>;
+#[derive(Clone)]
+pub enum BlockReconstructionMessage {
+    Single(Message),
+    Batch(Arc<Vec<Message>>),
+}
 
 impl BatchInto<BlockReconstructionMessage> for BlockReconstructionMessage {
     fn batch_into(self, batch: &mut Vec<BlockReconstructionMessage>, count: &mut usize) {
@@ -323,7 +323,7 @@ impl BatchInto<BlockReconstructionMessage> for BlockReconstructionMessage {
     }
 }
 
-type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
+pub type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
 
 /// Messages broadcast on the deshred channel. Deshred is a pre-execution
 /// stream and has no commitment level: each message is emitted exactly
@@ -728,6 +728,14 @@ fn load_server_config_from_tls_config(
     }
 }
 
+pub struct GrpcServiceResult {
+    pub snapshot_tx: Option<crossbeam_channel::Sender<Box<Message>>>,
+    pub deshred_broadcast_tx: broadcast::Sender<DeshredBroadcastedMessage>,
+    pub block_reconstruction_tx: mpsc::UnboundedSender<BlockReconstructionMessage>,
+    pub broadcast_tx: broadcast::Sender<BroadcastedMessage>,
+    pub blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
+}
+
 impl GrpcService {
     #[allow(clippy::type_complexity)]
     pub async fn create<St>(
@@ -737,10 +745,7 @@ impl GrpcService {
         task_tracker: TaskTracker,
         file_watcher: Arc<FileWatcher>,
         messages_rx: St,
-    ) -> anyhow::Result<(
-        Option<crossbeam_channel::Sender<Box<Message>>>,
-        broadcast::Sender<DeshredBroadcastedMessage>,
-    )>
+    ) -> anyhow::Result<GrpcServiceResult>
     where
         St: BatchStream<Item = Message> + Unpin + Send + 'static,
     {
@@ -982,10 +987,10 @@ impl GrpcService {
 
         {
             let broadcast_tx = broadcast_tx.clone();
+
             task_tracker.spawn(async move {
                 Self::block_reconstruction_loop(
                     BatchStreamUnboundedReceiver::new(block_reconstruction_rx),
-                    blocks_meta_tx,
                     broadcast_tx,
                     replay_stored_slots_rx,
                     replay_first_available_slot,
@@ -995,9 +1000,14 @@ impl GrpcService {
             });
         }
 
-        task_tracker.spawn(async move {
-            Self::geyser_loop(messages_rx, broadcast_tx, block_reconstruction_tx).await;
-        });
+        {
+            let block_reconstruction_tx = block_reconstruction_tx.clone();
+            let broadcast_tx = broadcast_tx.clone();
+
+            task_tracker.spawn(async move {
+                Self::geyser_loop(messages_rx, broadcast_tx, block_reconstruction_tx).await;
+            });
+        }
 
         // Health check service
         let (health_reporter, health_service) = health_reporter();
@@ -1070,7 +1080,13 @@ impl GrpcService {
             });
         }
 
-        Ok((snapshot_tx, deshred_broadcast_tx))
+        Ok(GrpcServiceResult {
+            snapshot_tx,
+            deshred_broadcast_tx,
+            block_reconstruction_tx,
+            broadcast_tx,
+            blocks_meta_tx,
+        })
     }
 
     /// Core message routing loop that reconstructs Solana blocks from raw Geyser plugin events
@@ -1143,7 +1159,7 @@ impl GrpcService {
     async fn geyser_loop<St>(
         mut messages_rx: St,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
-        block_reconstruction_tx: mpsc::UnboundedSender<Arc<Vec<Message>>>,
+        block_reconstruction_tx: mpsc::UnboundedSender<BlockReconstructionMessage>,
     ) where
         St: BatchStream<Item = Message> + Unpin + Send + 'static,
     {
@@ -1159,12 +1175,19 @@ impl GrpcService {
                 continue;
             }
 
+            metrics::message_queue_size_dec_by(message_batch.len() as i64);
             encode_messages(&message_batch);
             GEYSER_BATCH_SIZE.observe(message_batch.len() as f64);
 
             let message_batch_arc = Arc::new(message_batch);
             let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&message_batch_arc)));
-            let _ = block_reconstruction_tx.send(message_batch_arc);
+
+            if block_reconstruction_tx
+                .send(BlockReconstructionMessage::Batch(message_batch_arc))
+                .is_ok()
+            {
+                metrics::block_reconstruction_queue_size_inc();
+            }
 
             message_batch = Vec::with_capacity(32);
         }
@@ -1172,13 +1195,12 @@ impl GrpcService {
 
     async fn block_reconstruction_loop<St>(
         mut messages_rx: St,
-        blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
         replay_stored_slots_rx: Option<mpsc::Receiver<ReplayStoredSlotsRequest>>,
         replay_first_available_slot: Option<Arc<AtomicU64>>,
         replay_stored_slots: u64,
     ) where
-        St: BatchStream<Item = Arc<Vec<Message>>> + Unpin + Send + 'static,
+        St: BatchStream<Item = BlockReconstructionMessage> + Unpin + Send + 'static,
     {
         let (_tx, rx) = mpsc::channel(1);
         let mut replay_stored_slots_rx = replay_stored_slots_rx.unwrap_or(rx);
@@ -1196,64 +1218,71 @@ impl GrpcService {
         loop {
             tokio::select! {
                 maybe = messages_rx.next_batch(&mut buffered_messages) => {
-                    if maybe.is_none() {
+                    let Some(buffered_size) = maybe else {
                         info!("Block reconstruction loop: messages channel closed");
                         break;
-                    }
+                    };
+
+                    metrics::block_reconstruction_queue_size_dec_by(buffered_size as i64);
 
                     for messages in buffered_messages.drain(..) {
-                        for message in messages.iter() {
-                            if let Message::Slot(slot_message) = message {
-                                metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
-                            }
+                        match messages {
+                            BlockReconstructionMessage::Batch(messages) => {
+                                for message in messages.iter() {
+                                    if let Message::Slot(slot_message) = message {
+                                        metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
+                                    }
 
-                            if let Some(blocks_meta_tx) = &blocks_meta_tx {
-                                if matches!(&message, Message::Slot(_) | Message::BlockMeta(_)) {
-                                    let _ = blocks_meta_tx.send(message.clone());
+                                    block_machine.add(message.clone());
                                 }
                             }
-
-                            block_machine.add(message.clone());
-
-                            while let Some((slot_update, frozen_block)) = block_machine.pop_ready_block() {
-                                let commitment_level = match slot_update.commitment {
-                                    solana_commitment_config::CommitmentLevel::Processed => CommitmentLevel::Processed,
-                                    solana_commitment_config::CommitmentLevel::Confirmed => CommitmentLevel::Confirmed,
-                                    solana_commitment_config::CommitmentLevel::Finalized => CommitmentLevel::Finalized,
-                                };
-                                // Processed must be sent differently, since processed geyser event were individually sent,
-                                // we only need to send Message::Block for block subscriber downstream.
-                                // While, confirmed,finalized must be sent in the two flavors: as a stream of individual events and block.
-                                if commitment_level != CommitmentLevel::Processed {
-                                    let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
+                            BlockReconstructionMessage::Single(message) => {
+                                if let Message::Slot(slot_message) = &message {
+                                    metrics::update_slot_plugin_status(slot_message.status, slot_message.slot);
                                 }
 
-                                let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
-                                let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
-                                let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
-
-                                let slot_message = Message::Slot(MessageSlot {
-                                    slot: slot_update.slot,
-                                    parent: slot_update.parent_slot,
-                                    status: match slot_update.commitment {
-                                        solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
-                                        solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
-                                        solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
-                                    },
-                                    dead_error: None,
-                                    created_at: Timestamp::from(SystemTime::now())
-                                });
-                                let slot_message_singleton_vec = Arc::new(vec![slot_message.clone()]);
-                                for commitment_level in ALL_COMMITMENT_LEVELS {
-                                    let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
-                                }
-                            }
-
-                            let min_replayable_slot = block_machine.min_replayable_slot();
-                            if let (Some(min_slot), Some(replay_first_available_slot)) = (min_replayable_slot, replay_first_available_slot.as_ref()) {
-                                replay_first_available_slot.store(min_slot, Ordering::Relaxed);
+                                block_machine.add(message);
                             }
                         }
+                    }
+
+                    while let Some((slot_update, frozen_block)) = block_machine.pop_ready_block() {
+                        let commitment_level = match slot_update.commitment {
+                            solana_commitment_config::CommitmentLevel::Processed => CommitmentLevel::Processed,
+                            solana_commitment_config::CommitmentLevel::Confirmed => CommitmentLevel::Confirmed,
+                            solana_commitment_config::CommitmentLevel::Finalized => CommitmentLevel::Finalized,
+                        };
+                        // Processed must be sent differently, since processed geyser event were individually sent,
+                        // we only need to send Message::Block for block subscriber downstream.
+                        // While, confirmed,finalized must be sent in the two flavors: as a stream of individual events and block.
+                        if commitment_level != CommitmentLevel::Processed {
+                            let _ = broadcast_tx.send((commitment_level, frozen_block.messages()));
+                        }
+
+                        let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
+                        let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
+                        let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
+
+                        let slot_message = Message::Slot(MessageSlot {
+                            slot: slot_update.slot,
+                            parent: slot_update.parent_slot,
+                            status: match slot_update.commitment {
+                                solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
+                                solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
+                                solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
+                            },
+                            dead_error: None,
+                            created_at: Timestamp::from(SystemTime::now())
+                        });
+                        let slot_message_singleton_vec = Arc::new(vec![slot_message.clone()]);
+                        for commitment_level in ALL_COMMITMENT_LEVELS {
+                            let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
+                        }
+                    }
+
+                    let min_replayable_slot = block_machine.min_replayable_slot();
+                    if let (Some(min_slot), Some(replay_first_available_slot)) = (min_replayable_slot, replay_first_available_slot.as_ref()) {
+                        replay_first_available_slot.store(min_slot, Ordering::Relaxed);
                     }
                 },
                 Some((commitment, replay_slot, tx)) = replay_stored_slots_rx.recv() => {
@@ -2508,7 +2537,6 @@ mod tests {
             };
             let handle_reconstruction = tokio::spawn(GrpcService::block_reconstruction_loop(
                 BatchStreamUnboundedReceiver::new(block_reconstruction_rx),
-                None,
                 broadcast_tx,
                 None,
                 None,

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -25,7 +25,7 @@ use {
             proto::geyser_server::{Geyser, GeyserServer},
         },
         ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks},
-        stream::{BatchInto, GeyserStream, PollReceiver},
+        stream::{tokio::BatchStreamUnboundedReceiver, BatchStream, BatchStreamExt},
         util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
         version::GrpcVersionInfo,
     },
@@ -64,11 +64,15 @@ use {
     tokio_util::{sync::CancellationToken, task::TaskTracker},
     tonic::{
         metadata::AsciiMetadataValue,
+        ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks},
         service::{interceptor, LayerExt},
+        stream::{BatchInto, GeyserStream, PollReceiver},
         transport::{
             server::{Connected, Server},
             CertificateDer,
         },
+        util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
+        version::GrpcVersionInfo,
         Request, Response, Result as TonicResult, Status, Streaming,
     },
     tonic_health::{pb::health_server::HealthServer, server::health_reporter},
@@ -717,20 +721,19 @@ fn load_server_config_from_tls_config(
 
 impl GrpcService {
     #[allow(clippy::type_complexity)]
-    pub async fn create<R>(
+    pub async fn create<St>(
         config: ConfigGrpc,
         is_reload: bool,
         service_cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
         file_watcher: Arc<FileWatcher>,
-        messages_rx: R,
+        messages_rx: St,
     ) -> anyhow::Result<(
         Option<crossbeam_channel::Sender<Box<Message>>>,
         broadcast::Sender<DeshredBroadcastedMessage>,
     )>
     where
-        R: PollReceiver + Unpin + Send + 'static,
-        R::Item: BatchInto<Message>,
+        St: BatchStream<Item = Message> + Unpin + Send + 'static,
     {
         // Bind all configured addresses (TCP or Unix domain socket)
         let mut listeners = Vec::new();
@@ -972,7 +975,7 @@ impl GrpcService {
             let broadcast_tx = broadcast_tx.clone();
             task_tracker.spawn(async move {
                 Self::block_reconstruction_loop(
-                    block_reconstruction_rx,
+                    BatchStreamUnboundedReceiver::new(block_reconstruction_rx),
                     blocks_meta_tx,
                     broadcast_tx,
                     replay_stored_slots_rx,
@@ -1128,39 +1131,48 @@ impl GrpcService {
     /// - `replay_stored_slots_rx`: services replay requests from newly-connected subscribers.
     ///   `replay_first_available_slot` is updated after every batch to reflect the oldest slot
     ///   still available in the replay buffer, and is exposed via `subscribe_first_available_slot`.
-    async fn geyser_loop<R>(
-        messages_rx: R,
+    async fn geyser_loop<St>(
+        mut messages_rx: St,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
         block_reconstruction_tx: mpsc::UnboundedSender<Arc<Vec<Message>>>,
     ) where
-        R: PollReceiver + Unpin,
-        R::Item: BatchInto<Message>,
+        St: BatchStream<Item = Message> + Unpin + Send + 'static,
     {
-        let mut stream = GeyserStream::new(messages_rx, 32);
+        let mut batch = Vec::with_capacity(32);
         loop {
-            let message_batch_maybe = stream.next().await;
-            let Some(message_batch) = message_batch_maybe else {
+            batch.clear();
+            let batch_size_maybe = messages_rx.next_batch(&mut batch).await;
+            let Some(batch_size) = batch_size_maybe else {
                 info!("Geyser loop: messages channel closed");
                 break;
             };
 
-            encode_messages(&message_batch);
-            GEYSER_BATCH_SIZE.observe(message_batch.len() as f64);
+            if batch_size == 0 {
+                continue;
+            }
 
-            let message_batch_arc = Arc::new(message_batch);
+            encode_messages(&batch);
+            GEYSER_BATCH_SIZE.observe(batch.len() as f64);
+
+            let mut out = Vec::with_capacity(batch.capacity());
+            std::mem::swap(&mut out, &mut batch);
+
+            let message_batch_arc = Arc::new(out);
             let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&message_batch_arc)));
             let _ = block_reconstruction_tx.send(message_batch_arc);
         }
     }
 
-    async fn block_reconstruction_loop(
-        mut messages_rx: mpsc::UnboundedReceiver<Arc<Vec<Message>>>,
+    async fn block_reconstruction_loop<St>(
+        mut messages_rx: St,
         blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
         replay_stored_slots_rx: Option<mpsc::Receiver<ReplayStoredSlotsRequest>>,
         replay_first_available_slot: Option<Arc<AtomicU64>>,
         replay_stored_slots: u64,
-    ) {
+    ) where
+        St: BatchStream<Item = Arc<Vec<Message>>> + Unpin + Send + 'static,
+    {
         let (_tx, rx) = mpsc::channel(1);
         let mut replay_stored_slots_rx = replay_stored_slots_rx.unwrap_or(rx);
 
@@ -1176,19 +1188,10 @@ impl GrpcService {
 
         loop {
             tokio::select! {
-                maybe = messages_rx.recv() => {
-                    let Some(messages) = maybe else {
-                        info!("Geyser loop: messages channel closed");
+                maybe = messages_rx.next_batch(&mut buffered_messages) => {
+                    if maybe.is_none() {
+                        info!("Block reconstruction loop: messages channel closed");
                         break;
-                    };
-
-                    buffered_messages.push(messages);
-
-                    while let Ok(messages) = messages_rx.try_recv() {
-                        buffered_messages.push(messages);
-                        if buffered_messages.len() >= BUFFERED_MESSAGES_CAPACITY {
-                            break;
-                        }
                     }
 
                     for messages in buffered_messages.drain(..) {
@@ -2452,12 +2455,15 @@ mod tests {
     mod geyser_loop_routing {
         use {
             super::super::*,
-            crate::plugin::{
-                convert_to,
-                message::{
-                    MessageDeshredTransaction, MessageDeshredTransactionInfo, MessageSlot,
-                    SlotStatus,
+            crate::{
+                plugin::{
+                    convert_to,
+                    message::{
+                        MessageDeshredTransaction, MessageDeshredTransactionInfo, MessageSlot,
+                        SlotStatus,
+                    },
                 },
+                stream::tokio::{BatchStreamReceiver, BatchStreamUnboundedReceiver},
             },
             foldhash::{HashSet as FoldHashSet, HashSetExt as _},
             prost_types::Timestamp,
@@ -2484,6 +2490,7 @@ mod tests {
             let (block_reconstruction_tx, block_reconstruction_rx) = mpsc::unbounded_channel();
             let (broadcast_tx, broadcast_rx) = broadcast::channel(1024);
             let (deshred_tx, deshred_rx) = broadcast::channel(1024);
+            let messages_rx = BatchStreamUnboundedReceiver::new(messages_rx);
             let handle = {
                 let broadcast_tx = broadcast_tx.clone();
                 tokio::spawn(GrpcService::geyser_loop(
@@ -2493,7 +2500,7 @@ mod tests {
                 ))
             };
             let handle_reconstruction = tokio::spawn(GrpcService::block_reconstruction_loop(
-                block_reconstruction_rx,
+                BatchStreamUnboundedReceiver::new(block_reconstruction_rx),
                 None,
                 broadcast_tx,
                 None,

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -25,12 +25,13 @@ use {
             proto::geyser_server::{Geyser, GeyserServer},
         },
         ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks},
+        stream::{BatchInto, GeyserStream, PollReceiver},
         util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
         version::GrpcVersionInfo,
     },
     anyhow::Context as _,
     bytesize::ByteSize,
-    futures::Stream,
+    futures::{Stream, StreamExt},
     log::{error, info},
     prost_types::Timestamp,
     rustls::{
@@ -716,17 +717,21 @@ fn load_server_config_from_tls_config(
 
 impl GrpcService {
     #[allow(clippy::type_complexity)]
-    pub async fn create(
+    pub async fn create<R>(
         config: ConfigGrpc,
         is_reload: bool,
         service_cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
         file_watcher: Arc<FileWatcher>,
+        messages_rx: R,
     ) -> anyhow::Result<(
         Option<crossbeam_channel::Sender<Box<Message>>>,
-        mpsc::UnboundedSender<Message>,
         broadcast::Sender<DeshredBroadcastedMessage>,
-    )> {
+    )>
+    where
+        R: PollReceiver + Unpin + Send + 'static,
+        R::Item: BatchInto<Message>,
+    {
         // Bind all configured addresses (TCP or Unix domain socket)
         let mut listeners = Vec::new();
 
@@ -953,8 +958,6 @@ impl GrpcService {
             service = service.send_compressed(encoding);
         }
 
-        // Run geyser message loop
-        let (messages_tx, messages_rx) = mpsc::unbounded_channel();
         let (block_reconstruction_tx, block_reconstruction_rx) = mpsc::unbounded_channel();
 
         // Warn if replay buffer is too small for auto-reconnect
@@ -1055,7 +1058,7 @@ impl GrpcService {
             });
         }
 
-        Ok((snapshot_tx, messages_tx, deshred_broadcast_tx))
+        Ok((snapshot_tx, deshred_broadcast_tx))
     }
 
     /// Core message routing loop that reconstructs Solana blocks from raw Geyser plugin events
@@ -1125,110 +1128,28 @@ impl GrpcService {
     /// - `replay_stored_slots_rx`: services replay requests from newly-connected subscribers.
     ///   `replay_first_available_slot` is updated after every batch to reflect the oldest slot
     ///   still available in the replay buffer, and is exposed via `subscribe_first_available_slot`.
-    async fn geyser_loop(
-        mut messages_rx: mpsc::UnboundedReceiver<Message>,
+    async fn geyser_loop<R>(
+        messages_rx: R,
         broadcast_tx: broadcast::Sender<BroadcastedMessage>,
         block_reconstruction_tx: mpsc::UnboundedSender<Arc<Vec<Message>>>,
-    ) {
-        const PROCESSED_MESSAGES_MAX: usize = 31;
-        const STATE_MESSAGES_MAX: usize = 4; /* In a reasonable loop, we don't expect to receive more than FirstShredReceived, Completed, CreatedBank, or Finalized messages per iteration */
-
-        let mut processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-        let mut confirmed_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
-        let mut finalized_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
-        let mut block_reconstruction_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
-
-        let is_block_reconstruction_message = |message: &Message| match message {
-            Message::BlockMeta(_) => true,
-            Message::Slot(slot_message) => matches!(
-                slot_message.status,
-                SlotStatus::Processed | SlotStatus::Confirmed | SlotStatus::Finalized
-            ),
-            _ => false,
-        };
-
+    ) where
+        R: PollReceiver + Unpin,
+        R::Item: BatchInto<Message>,
+    {
+        let mut stream = GeyserStream::new(messages_rx, 32);
         loop {
-            tokio::select! {
-                maybe = messages_rx.recv() => {
-                    let Some(message) = maybe else {
-                        info!("Geyser loop: messages channel closed");
-                        break;
-                    };
+            let message_batch_maybe = stream.next().await;
+            let Some(message_batch) = message_batch_maybe else {
+                info!("Geyser loop: messages channel closed");
+                break;
+            };
 
-                    metrics::message_queue_size_dec();
+            encode_messages(&message_batch);
+            GEYSER_BATCH_SIZE.observe(message_batch.len() as f64);
 
-                    if is_block_reconstruction_message(&message) {
-                        block_reconstruction_messages.push(message);
-                    }
-                    else {
-                        processed_messages.push(message);
-                    }
-
-                    while let Ok(message) = messages_rx.try_recv() {
-                        metrics::message_queue_size_dec();
-
-                        if is_block_reconstruction_message(&message) {
-                            block_reconstruction_messages.push(message);
-                        }
-                        else {
-                            processed_messages.push(message);
-                            if processed_messages.len() >= PROCESSED_MESSAGES_MAX {
-                                break;
-                            }
-                        }
-                    }
-
-                    for message in processed_messages.iter() {
-                        match message {
-                            Message::Slot(slot_message) => {
-                                // Only match on slot lifecycle update not commitment update, as
-                                // we must go through the block machine to make sure users sees block content before any commitment update.
-                                if matches!(slot_message.status,
-                                    SlotStatus::FirstShredReceived |
-                                    SlotStatus::Completed |
-                                    SlotStatus::CreatedBank |
-                                    SlotStatus::Dead
-                                ) {
-                                    confirmed_messages.push(Message::Slot(slot_message.clone()));
-                                    finalized_messages.push(Message::Slot(slot_message.clone()));
-                                }
-                            }
-                            Message::Block(_) => {
-                               unreachable!("Block message should not be sent by plugin directly, it is constructed in geyser loop after receiving all necessary messages for the slot and then broadcasted to subscribers");
-                            }
-                            _ => {
-                                /* We don't need to process anything here.  */
-                            }
-                        }
-                    }
-
-                    encode_messages(&processed_messages);
-                    GEYSER_BATCH_SIZE.observe(processed_messages.len() as f64);
-
-                    let processed_messages_arc = Arc::new(processed_messages);
-                    let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&processed_messages_arc)));
-                    processed_messages = Vec::with_capacity(PROCESSED_MESSAGES_MAX);
-
-                    if !confirmed_messages.is_empty() {
-                        let _ = broadcast_tx.send((CommitmentLevel::Confirmed, Arc::new(confirmed_messages)));
-                        confirmed_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
-                    }
-
-                    if !finalized_messages.is_empty() {
-                        let _ = broadcast_tx.send((CommitmentLevel::Finalized, Arc::new(finalized_messages)));
-                        finalized_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
-                    }
-
-                    let _ = block_reconstruction_tx.send(processed_messages_arc);
-
-                    // Make sure that blockmeta is always after all kind of other events so the block-machine sees every block
-                    // updates.
-                    if !block_reconstruction_messages.is_empty() {
-                        let _ = block_reconstruction_tx.send(Arc::new(block_reconstruction_messages));
-                        block_reconstruction_messages = Vec::with_capacity(STATE_MESSAGES_MAX);
-                    }
-                }
-            }
+            let message_batch_arc = Arc::new(message_batch);
+            let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&message_batch_arc)));
+            let _ = block_reconstruction_tx.send(message_batch_arc);
         }
     }
 

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -25,7 +25,7 @@ use {
             proto::geyser_server::{Geyser, GeyserServer},
         },
         ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks},
-        stream::{tokio::BatchStreamUnboundedReceiver, BatchStream, BatchStreamExt},
+        stream::{tokio::BatchStreamUnboundedReceiver, BatchInto, BatchStream, BatchStreamExt},
         util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
         version::GrpcVersionInfo,
     },
@@ -311,6 +311,15 @@ impl BlockMetaStorage {
             .unwrap_or(false);
 
         Ok(Response::new(IsBlockhashValidResponse { valid, slot }))
+    }
+}
+
+type BlockReconstructionMessage = Arc<Vec<Message>>;
+
+impl BatchInto<BlockReconstructionMessage> for BlockReconstructionMessage {
+    fn batch_into(self, batch: &mut Vec<BlockReconstructionMessage>, count: &mut usize) {
+        batch.push(self);
+        *count += 1;
     }
 }
 
@@ -1138,28 +1147,26 @@ impl GrpcService {
     ) where
         St: BatchStream<Item = Message> + Unpin + Send + 'static,
     {
-        let mut batch = Vec::with_capacity(32);
+        let mut message_batch = Vec::with_capacity(32);
         loop {
-            batch.clear();
-            let batch_size_maybe = messages_rx.next_batch(&mut batch).await;
-            let Some(batch_size) = batch_size_maybe else {
+            let batch_size_maybe = messages_rx.next_batch(&mut message_batch).await;
+            let Some(_) = batch_size_maybe else {
                 info!("Geyser loop: messages channel closed");
                 break;
             };
 
-            if batch_size == 0 {
+            if message_batch.len() == 0 {
                 continue;
             }
 
-            encode_messages(&batch);
-            GEYSER_BATCH_SIZE.observe(batch.len() as f64);
+            encode_messages(&message_batch);
+            GEYSER_BATCH_SIZE.observe(message_batch.len() as f64);
 
-            let mut out = Vec::with_capacity(batch.capacity());
-            std::mem::swap(&mut out, &mut batch);
-
-            let message_batch_arc = Arc::new(out);
+            let message_batch_arc = Arc::new(message_batch);
             let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&message_batch_arc)));
             let _ = block_reconstruction_tx.send(message_batch_arc);
+
+            message_batch = Vec::with_capacity(32);
         }
     }
 
@@ -2463,7 +2470,7 @@ mod tests {
                         SlotStatus,
                     },
                 },
-                stream::tokio::{BatchStreamReceiver, BatchStreamUnboundedReceiver},
+                stream::tokio::BatchStreamUnboundedReceiver,
             },
             foldhash::{HashSet as FoldHashSet, HashSetExt as _},
             prost_types::Timestamp,

--- a/yellowstone-grpc-geyser/src/lib.rs
+++ b/yellowstone-grpc-geyser/src/lib.rs
@@ -11,6 +11,7 @@ pub mod plugin;
 pub(crate) mod ratelimit;
 pub(crate) mod util;
 pub mod version;
+pub mod stream;
 
 pub fn get_thread_name() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/yellowstone-grpc-geyser/src/lib.rs
+++ b/yellowstone-grpc-geyser/src/lib.rs
@@ -9,9 +9,9 @@ pub mod metered;
 pub mod metrics;
 pub mod plugin;
 pub(crate) mod ratelimit;
+pub mod stream;
 pub(crate) mod util;
 pub mod version;
-pub mod stream;
 
 pub fn get_thread_name() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/yellowstone-grpc-geyser/src/lib.rs
+++ b/yellowstone-grpc-geyser/src/lib.rs
@@ -3,15 +3,16 @@ pub(crate) mod billing;
 mod block_reconstruction;
 mod cache_ext;
 pub mod config;
-pub(crate) mod file_watcher;
+pub mod file_watcher;
 pub mod grpc;
 pub mod metered;
 pub mod metrics;
 pub mod plugin;
 pub(crate) mod ratelimit;
 pub mod stream;
-pub(crate) mod util;
+pub mod util;
 pub mod version;
+pub use agave_geyser_plugin_interface as plugin_interface;
 
 pub fn get_thread_name() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -20,8 +21,3 @@ pub fn get_thread_name() -> String {
     let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
     format!("solGeyserGrpc{id:02}")
 }
-
-use tikv_jemallocator::Jemalloc;
-
-#[global_allocator]
-static ALLOC: Jemalloc = Jemalloc;

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -59,6 +59,10 @@ lazy_static::lazy_static! {
         "yellowstone_grpc_geyser_deshred_queue_size", "Size of deshred message queue"
     ).unwrap();
 
+    static ref BLOCK_RECONSTRUCTION_QUEUE_SIZE: IntGauge = IntGauge::new(
+        "yellowstone_grpc_geyser_block_reconstruction_queue_size", "Size of block reconstruction message queue"
+    ).unwrap();
+
     static ref SUBSCRIPTIONS_TOTAL: IntGaugeVec = IntGaugeVec::new(
         Opts::new("yellowstone_grpc_geyser_subscriptions_total", "Total number of subscriptions to gRPC service"),
         &["endpoint", "subscription"]
@@ -253,6 +257,7 @@ impl PrometheusService {
             register!(SLOT_STATUS_PLUGIN);
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
+            register!(BLOCK_RECONSTRUCTION_QUEUE_SIZE);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);
             register!(GRPC_MESSAGE_SENT);
@@ -505,12 +510,24 @@ pub fn deshred_queue_size_inc(amount: i64) {
     DESHRED_QUEUE_SIZE.add(amount);
 }
 
+pub fn block_reconstruction_queue_size_inc() {
+    BLOCK_RECONSTRUCTION_QUEUE_SIZE.inc()
+}
+
 pub fn message_queue_size_dec() {
-    MESSAGE_QUEUE_SIZE.dec()
+    MESSAGE_QUEUE_SIZE.dec();
+}
+
+pub fn message_queue_size_dec_by(amount: i64) {
+    MESSAGE_QUEUE_SIZE.sub(amount);
 }
 
 pub fn deshred_queue_size_dec() {
     DESHRED_QUEUE_SIZE.dec()
+}
+
+pub fn block_reconstruction_queue_size_dec_by(amount: i64) {
+    BLOCK_RECONSTRUCTION_QUEUE_SIZE.sub(amount);
 }
 
 pub fn subscription_limit_exceeded_inc<S: AsRef<str>>(subscriber_id: S) {
@@ -620,6 +637,8 @@ pub fn remove_grpc_concurrent_subscribe_per_subscriber_id<S: AsRef<str>>(subscri
 pub fn reset_metrics() {
     // Reset gauge metrics to 0
     MESSAGE_QUEUE_SIZE.set(0);
+    DESHRED_QUEUE_SIZE.set(0);
+    BLOCK_RECONSTRUCTION_QUEUE_SIZE.set(0);
 
     // Reset gauge vectors (clears all label combinations)
     SUBSCRIPTIONS_TOTAL.reset();

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -143,16 +143,18 @@ impl GeyserPlugin for Plugin {
             .await
             .map_err(|error| GeyserPluginError::Custom(Box::new(error)))?;
 
-            let (snapshot_channel, grpc_channel, deshred_channel) = GrpcService::create(
+            let (grpc_channel_tx, grpc_channel_receiver) = mpsc::unbounded_channel();
+            let (snapshot_channel, deshred_channel) = GrpcService::create(
                 config.grpc,
                 is_reload,
                 grpc_cancellation_token,
                 grpc_task_tracker,
                 geyser_svc_file_watcher,
+                grpc_channel_receiver,
             )
             .await
             .map_err(|error| GeyserPluginError::Custom(format!("{error:?}").into()))?;
-            Ok::<_, GeyserPluginError>((snapshot_channel, grpc_channel, deshred_channel))
+            Ok::<_, GeyserPluginError>((snapshot_channel, grpc_channel_tx, deshred_channel))
         });
 
         let (snapshot_channel, grpc_channel, deshred_channel) = match result {

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -2,13 +2,13 @@ use {
     crate::{
         config::Config,
         file_watcher::FileWatcher,
-        grpc::GrpcService,
+        grpc::{BlockReconstructionMessage, BroadcastedMessage, GrpcService},
         metrics::{self, incr_geyser_event_dropped, PrometheusService},
         plugin::{
             filter::limits::FilterLimits,
             message::{
-                Message, MessageAccount, MessageBlockMeta, MessageDeshredTransaction, MessageEntry,
-                MessageSlot, MessageTransaction,
+                CommitmentLevel, Message, MessageAccount, MessageBlockMeta,
+                MessageDeshredTransaction, MessageEntry, MessageSlot, MessageTransaction,
             },
         },
         stream::tokio::BatchStreamUnboundedReceiver,
@@ -41,23 +41,47 @@ pub struct PluginInner {
     snapshot_channel: Mutex<Option<crossbeam_channel::Sender<Box<Message>>>>,
     snapshot_channel_closed: AtomicBool,
     filter_limits: FilterLimits,
-    grpc_channel: mpsc::UnboundedSender<Message>,
-    deshred_channel: broadcast::Sender<Message>,
+    grpc_channel: mpsc::UnboundedSender<Message>, // geyser_loop
+    deshred_channel: broadcast::Sender<Message>,  // deshred_client_loop
+    block_reconstruction_channel: mpsc::UnboundedSender<BlockReconstructionMessage>, // block_reconstruction_loop
+    broadcast_channel: broadcast::Sender<BroadcastedMessage>,                        // client_loop
+    blocks_meta_tx: Option<mpsc::UnboundedSender<Message>>,
     plugin_cancellation_token: CancellationToken,
     plugin_task_tracker: TaskTracker,
     file_watcher: Arc<FileWatcher>,
 }
 
 impl PluginInner {
+    // Sends messages to the geyser_loop
     fn send_message(&self, message: Message) {
         if self.grpc_channel.send(message).is_ok() {
             metrics::message_queue_size_inc();
         }
     }
 
+    // Sends messages to the deshred subscribers if their filter allows it.
     fn send_deshred_message(&self, message: Message) {
         if let Ok(count) = self.deshred_channel.send(message) {
             metrics::deshred_queue_size_inc(count as i64);
+        }
+    }
+
+    // Sends messages to the block reconstruction loop
+    fn send_block_reconstruction_message(&self, message: BlockReconstructionMessage) {
+        if self.block_reconstruction_channel.send(message).is_ok() {
+            metrics::block_reconstruction_queue_size_inc();
+        }
+    }
+
+    // Sends messages to all subscribed clients if their filter matches the message.
+    fn send_broadcast_message(&self, message: BroadcastedMessage) {
+        let _ = self.broadcast_channel.send(message);
+    }
+
+    // Sends messages to block meta storage
+    fn send_blocks_meta_message(&self, message: Message) {
+        if let Some(blocks_meta_tx) = &self.blocks_meta_tx {
+            let _ = blocks_meta_tx.send(message);
         }
     }
 }
@@ -129,6 +153,7 @@ impl GeyserPlugin for Plugin {
         })?;
         let file_watcher = Arc::new(file_watcher);
         let geyser_svc_file_watcher = Arc::clone(&file_watcher);
+        let (grpc_channel_tx, grpc_channel_receiver) = mpsc::unbounded_channel();
         let result = runtime.block_on(async move {
             static CRYPTO_PROVIDER_INIT: Once = Once::new();
 
@@ -144,9 +169,8 @@ impl GeyserPlugin for Plugin {
             .await
             .map_err(|error| GeyserPluginError::Custom(Box::new(error)))?;
 
-            let (grpc_channel_tx, grpc_channel_receiver) = mpsc::unbounded_channel();
             let grpc_channel_rx = BatchStreamUnboundedReceiver::new(grpc_channel_receiver);
-            let (snapshot_channel, deshred_channel) = GrpcService::create(
+            let grpc_service_result = GrpcService::create(
                 config.grpc,
                 is_reload,
                 grpc_cancellation_token,
@@ -156,10 +180,10 @@ impl GeyserPlugin for Plugin {
             )
             .await
             .map_err(|error| GeyserPluginError::Custom(format!("{error:?}").into()))?;
-            Ok::<_, GeyserPluginError>((snapshot_channel, grpc_channel_tx, deshred_channel))
+            Ok::<_, GeyserPluginError>(grpc_service_result)
         });
 
-        let (snapshot_channel, grpc_channel, deshred_channel) = match result {
+        let grpc_service_result = match result {
             Ok(val) => val,
             Err(e) => {
                 log::error!("failed to start plugin services: {e}");
@@ -171,11 +195,14 @@ impl GeyserPlugin for Plugin {
 
         self.inner = Some(PluginInner {
             runtime,
-            snapshot_channel: Mutex::new(snapshot_channel),
+            snapshot_channel: Mutex::new(grpc_service_result.snapshot_tx),
             snapshot_channel_closed: AtomicBool::new(false),
             filter_limits,
-            grpc_channel,
-            deshred_channel,
+            grpc_channel: grpc_channel_tx,
+            deshred_channel: grpc_service_result.deshred_broadcast_tx,
+            block_reconstruction_channel: grpc_service_result.block_reconstruction_tx,
+            broadcast_channel: grpc_service_result.broadcast_tx,
+            blocks_meta_tx: grpc_service_result.blocks_meta_tx,
             plugin_cancellation_token,
             plugin_task_tracker,
             file_watcher,
@@ -269,8 +296,50 @@ impl GeyserPlugin for Plugin {
     ) -> PluginResult<()> {
         self.with_inner(|inner| {
             let message = Message::Slot(MessageSlot::from_geyser(slot, parent, status));
-            inner.send_message(message.clone());
-            inner.send_deshred_message(message);
+
+            if matches!(
+                status,
+                SlotStatus::Processed | SlotStatus::Confirmed | SlotStatus::Rooted
+            ) {
+                // Processed/Confirmed/Finalized slot status updates are handled by the block reconstruction loop and are never directly exposed by the processed message loop (geyser_loop.)
+                // If they were to be sent through geyser_loop, the block_reconstruction_loop would also send them, resulting in duplicate slot life-cycle messages.
+                // By sending them directly to block_reconstruction_loop, we avoid this issue while ensuring block reconstruction happens as normal.
+                inner.send_block_reconstruction_message(BlockReconstructionMessage::Single(
+                    message.clone(),
+                ));
+            } else {
+                // The only remaining states are FirstShredReceived/Completed/CreatedBank/Dead.
+                // These states are used by both block reconstruction and the geyser_loop (processed message loop).
+                // When sending to geyser_loop, the loop will batch all messages (whether it's slot updates, account updates, or transaction updates) and send them to the block_reconstruction_loop in a single batch.
+                // CreatedBank in particular is critical to the life-cycle of a block reconstruction, but it is not forwarded to the subscribed client from block_reconstruction_loop, so it must be sent to geyser_loop to ensure subscribers receive it.
+                inner.send_message(message.clone());
+
+                // Note: The following if statement remains here in case of any future additions to a slot's life-cycle state.
+                // It could be removed as it is right now, since we've already filtered out all other states above, but it is left here for clarity and future-proofing.
+                if matches!(
+                    status,
+                    SlotStatus::FirstShredReceived
+                        | SlotStatus::Completed
+                        | SlotStatus::CreatedBank
+                        | SlotStatus::Dead(_)
+                ) {
+                    // FirstShredReceived/Completed/CreatedBank/Dead slot status updates for Confirmed/Finalized commitment subscribers are not explicitly sent by the block reconstruction loop.
+                    // Therefore we explicitly need to forward these updates to the subscribers for all commitment levels, the geyser_loop will take care of forwarding them to the Processed commitment level.
+                    let messages = Arc::new(vec![message.clone()]);
+                    inner.send_broadcast_message((
+                        CommitmentLevel::Confirmed,
+                        Arc::clone(&messages),
+                    ));
+                    inner.send_broadcast_message((CommitmentLevel::Finalized, messages));
+                }
+            }
+
+            // Deshred subscribers need to receive all slot status updates.
+            inner.send_deshred_message(message.clone());
+
+            // Blocks meta subscribers need to receive all slot status updates.
+            inner.send_blocks_meta_message(message);
+
             metrics::update_slot_status(status, slot);
             Ok(())
         })
@@ -332,7 +401,10 @@ impl GeyserPlugin for Plugin {
             };
 
             let message = Message::BlockMeta(Arc::new(MessageBlockMeta::from_geyser(blockinfo)));
-            inner.send_message(message);
+            inner.send_block_reconstruction_message(BlockReconstructionMessage::Single(
+                message.clone(),
+            ));
+            inner.send_blocks_meta_message(message);
 
             Ok(())
         })

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -11,6 +11,7 @@ use {
                 MessageSlot, MessageTransaction,
             },
         },
+        stream::tokio::BatchStreamUnboundedReceiver,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         GeyserPlugin, GeyserPluginError, ReplicaAccountInfoVersions, ReplicaBlockInfoVersions,
@@ -144,13 +145,14 @@ impl GeyserPlugin for Plugin {
             .map_err(|error| GeyserPluginError::Custom(Box::new(error)))?;
 
             let (grpc_channel_tx, grpc_channel_receiver) = mpsc::unbounded_channel();
+            let grpc_channel_rx = BatchStreamUnboundedReceiver::new(grpc_channel_receiver);
             let (snapshot_channel, deshred_channel) = GrpcService::create(
                 config.grpc,
                 is_reload,
                 grpc_cancellation_token,
                 grpc_task_tracker,
                 geyser_svc_file_watcher,
-                grpc_channel_receiver,
+                grpc_channel_rx,
             )
             .await
             .map_err(|error| GeyserPluginError::Custom(format!("{error:?}").into()))?;

--- a/yellowstone-grpc-geyser/src/plugin/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/message.rs
@@ -1,5 +1,6 @@
 use {
     super::convert_to,
+    crate::stream::BatchInto,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         ReplicaAccountInfoV3, ReplicaBlockInfoV4, ReplicaDeshredTransactionInfo,
         ReplicaDeshredTransactionInfoV2, ReplicaDeshredTransactionInfoVersions, ReplicaEntryInfoV2,
@@ -687,6 +688,12 @@ pub enum Message {
     Entry(Arc<MessageEntry>),
     BlockMeta(Arc<MessageBlockMeta>),
     Block(Arc<MessageBlock>),
+}
+
+impl BatchInto<Message> for Message {
+    fn batch_into(self, batch: &mut Vec<Message>) {
+        batch.push(self);
+    }
 }
 
 impl Message {

--- a/yellowstone-grpc-geyser/src/plugin/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/message.rs
@@ -691,8 +691,9 @@ pub enum Message {
 }
 
 impl BatchInto<Message> for Message {
-    fn batch_into(self, batch: &mut Vec<Message>) {
+    fn batch_into(self, batch: &mut Vec<Message>, count: &mut usize) {
         batch.push(self);
+        *count += 1;
     }
 }
 

--- a/yellowstone-grpc-geyser/src/stream.rs
+++ b/yellowstone-grpc-geyser/src/stream.rs
@@ -1,0 +1,104 @@
+use futures::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::plugin::message::Message;
+
+pub enum TryRecv<T> {
+    Item(T),
+    Empty,
+    Closed,
+}
+
+pub trait PollReceiver {
+    type Item;
+
+    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
+    fn try_recv(&mut self) -> TryRecv<Self::Item>;
+}
+
+pub trait BatchInto {
+    fn batch_into(self, batch: &mut Vec<Message>);
+}
+
+pub struct GeyserStream<R> {
+    receiver: R,
+    batch_capacity: usize,
+}
+
+impl<R> GeyserStream<R> {
+    pub fn new(receiver: R, batch_capacity: usize) -> Self {
+        Self {
+            receiver,
+            batch_capacity,
+        }
+    }
+}
+
+impl<R> Stream for GeyserStream<R>
+where
+    R: PollReceiver + Unpin,
+    R::Item: BatchInto,
+{
+    type Item = Vec<Message>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let message = match Pin::new(&mut self.receiver).poll_recv(cx) {
+            Poll::Ready(Some(item)) => item,
+            Poll::Ready(None) => return Poll::Ready(None),
+            Poll::Pending => return Poll::Pending,
+        };
+
+        let mut batch_messages = Vec::with_capacity(self.batch_capacity);
+        message.batch_into(&mut batch_messages);
+
+        while batch_messages.len() < self.batch_capacity {
+            match self.receiver.try_recv() {
+                TryRecv::Item(item) => item.batch_into(&mut batch_messages),
+                TryRecv::Empty | TryRecv::Closed => break,
+            }
+        }
+
+        Poll::Ready(Some(batch_messages))
+    }
+}
+
+impl BatchInto for Message {
+    fn batch_into(self, batch: &mut Vec<Message>) {
+        batch.push(self);
+    }
+}
+
+impl<T> PollReceiver for tokio::sync::mpsc::UnboundedReceiver<T> {
+    type Item = T;
+
+    fn poll_recv(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        tokio::sync::mpsc::UnboundedReceiver::poll_recv(&mut self, cx)
+    }
+
+    fn try_recv(&mut self) -> TryRecv<Self::Item> {
+        use tokio::sync::mpsc::error::TryRecvError;
+        match tokio::sync::mpsc::UnboundedReceiver::try_recv(self) {
+            Ok(item) => TryRecv::Item(item),
+            Err(TryRecvError::Empty) => TryRecv::Empty,
+            Err(TryRecvError::Disconnected) => TryRecv::Closed,
+        }
+    }
+}
+
+impl<T> PollReceiver for tokio::sync::mpsc::Receiver<T> {
+    type Item = T;
+
+    fn poll_recv(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        tokio::sync::mpsc::Receiver::poll_recv(&mut self, cx)
+    }
+
+    fn try_recv(&mut self) -> TryRecv<Self::Item> {
+        use tokio::sync::mpsc::error::TryRecvError;
+        match tokio::sync::mpsc::Receiver::try_recv(self) {
+            Ok(item) => TryRecv::Item(item),
+            Err(TryRecvError::Empty) => TryRecv::Empty,
+            Err(TryRecvError::Disconnected) => TryRecv::Closed,
+        }
+    }
+}

--- a/yellowstone-grpc-geyser/src/stream.rs
+++ b/yellowstone-grpc-geyser/src/stream.rs
@@ -1,106 +1,11 @@
-use {
-    futures::Stream,
-    std::{
-        future::Future,
-        marker::PhantomData,
-        pin::Pin,
-        task::{Context, Poll},
-    },
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
 };
 
-pub enum TryRecv<T> {
-    Item(T),
-    Empty,
-    Closed,
-}
-
-pub trait PollReceiver {
-    type Item;
-
-    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
-    fn try_recv(&mut self) -> TryRecv<Self::Item>;
-}
-
 pub trait BatchInto<Out> {
-    fn batch_into(self, batch: &mut Vec<Out>);
-}
-
-pub struct GeyserStream<R, Out> {
-    receiver: R,
-    batch_capacity: usize,
-    _out: PhantomData<fn() -> Out>,
-}
-
-impl<R, Out> GeyserStream<R, Out> {
-    pub fn new(receiver: R, batch_capacity: usize) -> Self {
-        Self {
-            receiver,
-            batch_capacity,
-            _out: PhantomData,
-        }
-    }
-}
-
-impl<R, Out> Stream for GeyserStream<R, Out>
-where
-    R: PollReceiver + Unpin,
-    R::Item: BatchInto<Out>,
-{
-    type Item = Vec<Out>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let message = match Pin::new(&mut self.receiver).poll_recv(cx) {
-            Poll::Ready(Some(item)) => item,
-            Poll::Ready(None) => return Poll::Ready(None),
-            Poll::Pending => return Poll::Pending,
-        };
-
-        let mut batch_messages = Vec::with_capacity(self.batch_capacity);
-        message.batch_into(&mut batch_messages);
-
-        while batch_messages.len() < self.batch_capacity {
-            match self.receiver.try_recv() {
-                TryRecv::Item(item) => item.batch_into(&mut batch_messages),
-                TryRecv::Empty | TryRecv::Closed => break,
-            }
-        }
-
-        Poll::Ready(Some(batch_messages))
-    }
-}
-
-impl<T> PollReceiver for ::tokio::sync::mpsc::UnboundedReceiver<T> {
-    type Item = T;
-
-    fn poll_recv(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        ::tokio::sync::mpsc::UnboundedReceiver::poll_recv(&mut self, cx)
-    }
-
-    fn try_recv(&mut self) -> TryRecv<Self::Item> {
-        use ::tokio::sync::mpsc::error::TryRecvError;
-        match ::tokio::sync::mpsc::UnboundedReceiver::try_recv(self) {
-            Ok(item) => TryRecv::Item(item),
-            Err(TryRecvError::Empty) => TryRecv::Empty,
-            Err(TryRecvError::Disconnected) => TryRecv::Closed,
-        }
-    }
-}
-
-impl<T> PollReceiver for ::tokio::sync::mpsc::Receiver<T> {
-    type Item = T;
-
-    fn poll_recv(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        ::tokio::sync::mpsc::Receiver::poll_recv(&mut self, cx)
-    }
-
-    fn try_recv(&mut self) -> TryRecv<Self::Item> {
-        use ::tokio::sync::mpsc::error::TryRecvError;
-        match ::tokio::sync::mpsc::Receiver::try_recv(self) {
-            Ok(item) => TryRecv::Item(item),
-            Err(TryRecvError::Empty) => TryRecv::Empty,
-            Err(TryRecvError::Disconnected) => TryRecv::Closed,
-        }
-    }
+    fn batch_into(self, batch: &mut Vec<Out>, count: &mut usize);
 }
 
 pub trait BatchStream {
@@ -111,7 +16,6 @@ pub trait BatchStream {
         cx: &mut Context<'_>,
         batch: &mut Vec<Self::Item>,
     ) -> Poll<Option<usize>>;
-    fn try_recv(&mut self) -> TryRecv<Self::Item>;
 }
 
 pub struct NextBatch<'a, S, T> {
@@ -161,59 +65,69 @@ impl<S> BatchStreamExt for S where S: BatchStream + Unpin {}
 
 pub mod tokio {
     use {
-        crate::stream::{BatchStream, TryRecv},
+        crate::stream::{BatchInto, BatchStream},
         std::{
+            marker::PhantomData,
             pin::Pin,
             task::{Context, Poll},
         },
     };
 
-    pub struct BatchStreamReceiver<T> {
+    pub struct BatchStreamReceiver<T, Out> {
         inner: ::tokio::sync::mpsc::Receiver<T>,
+        _out: PhantomData<fn() -> Out>,
     }
 
-    impl<T> BatchStreamReceiver<T> {
-        pub fn new(inner: ::tokio::sync::mpsc::Receiver<T>) -> BatchStreamReceiver<T> {
-            BatchStreamReceiver { inner }
+    impl<T, Out> BatchStreamReceiver<T, Out> {
+        pub fn new(inner: ::tokio::sync::mpsc::Receiver<T>) -> BatchStreamReceiver<T, Out> {
+            BatchStreamReceiver {
+                inner,
+                _out: PhantomData,
+            }
         }
     }
 
-    pub struct BatchStreamUnboundedReceiver<T> {
+    pub struct BatchStreamUnboundedReceiver<T, Out> {
         inner: ::tokio::sync::mpsc::UnboundedReceiver<T>,
+        _out: PhantomData<fn() -> Out>,
     }
 
-    impl<T> BatchStreamUnboundedReceiver<T> {
+    impl<T, Out> BatchStreamUnboundedReceiver<T, Out> {
         pub fn new(
             inner: ::tokio::sync::mpsc::UnboundedReceiver<T>,
-        ) -> BatchStreamUnboundedReceiver<T> {
-            BatchStreamUnboundedReceiver { inner }
+        ) -> BatchStreamUnboundedReceiver<T, Out> {
+            BatchStreamUnboundedReceiver {
+                inner,
+                _out: PhantomData,
+            }
         }
     }
 
-    impl<T> BatchStream for BatchStreamReceiver<T> {
-        type Item = T;
+    impl<T, Out> BatchStream for BatchStreamReceiver<T, Out>
+    where
+        T: BatchInto<Out>,
+    {
+        type Item = Out;
 
         fn poll_recv_batch(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             batch: &mut Vec<Self::Item>,
         ) -> Poll<Option<usize>> {
-            if batch.len() == batch.capacity() {
+            if batch.len() >= batch.capacity() {
                 return Poll::Ready(Some(0));
             }
 
             let this = self.get_mut();
             let mut i = 0;
+
             match Pin::new(&mut this.inner).poll_recv(cx) {
                 Poll::Ready(Some(item)) => {
-                    i += 1;
-                    batch.push(item);
+                    item.batch_into(batch, &mut i);
 
-                    // try drain loop here
                     while let Ok(item) = this.inner.try_recv() {
-                        batch.push(item);
-                        i += 1;
-                        if batch.len() == batch.capacity() {
+                        item.batch_into(batch, &mut i);
+                        if batch.len() >= batch.capacity() {
                             break;
                         }
                     }
@@ -224,40 +138,33 @@ pub mod tokio {
                 Poll::Pending => Poll::Pending,
             }
         }
-
-        fn try_recv(&mut self) -> TryRecv<Self::Item> {
-            use ::tokio::sync::mpsc::error::TryRecvError;
-            match self.inner.try_recv() {
-                Ok(item) => TryRecv::Item(item),
-                Err(TryRecvError::Empty) => TryRecv::Empty,
-                Err(TryRecvError::Disconnected) => TryRecv::Closed,
-            }
-        }
     }
 
-    impl<T> BatchStream for BatchStreamUnboundedReceiver<T> {
-        type Item = T;
+    impl<T, Out> BatchStream for BatchStreamUnboundedReceiver<T, Out>
+    where
+        T: BatchInto<Out>,
+    {
+        type Item = Out;
 
         fn poll_recv_batch(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             batch: &mut Vec<Self::Item>,
         ) -> Poll<Option<usize>> {
-            if batch.len() == batch.capacity() {
+            if batch.len() >= batch.capacity() {
                 return Poll::Ready(Some(0));
             }
 
             let this = self.get_mut();
             let mut i = 0;
+
             match Pin::new(&mut this.inner).poll_recv(cx) {
                 Poll::Ready(Some(item)) => {
-                    i += 1;
-                    batch.push(item);
+                    item.batch_into(batch, &mut i);
 
                     while let Ok(item) = this.inner.try_recv() {
-                        batch.push(item);
-                        i += 1;
-                        if batch.len() == batch.capacity() {
+                        item.batch_into(batch, &mut i);
+                        if batch.len() >= batch.capacity() {
                             break;
                         }
                     }
@@ -266,15 +173,6 @@ pub mod tokio {
                 }
                 Poll::Ready(None) => Poll::Ready(None),
                 Poll::Pending => Poll::Pending,
-            }
-        }
-
-        fn try_recv(&mut self) -> TryRecv<Self::Item> {
-            use ::tokio::sync::mpsc::error::TryRecvError;
-            match self.inner.try_recv() {
-                Ok(item) => TryRecv::Item(item),
-                Err(TryRecvError::Empty) => TryRecv::Empty,
-                Err(TryRecvError::Disconnected) => TryRecv::Closed,
             }
         }
     }

--- a/yellowstone-grpc-geyser/src/stream.rs
+++ b/yellowstone-grpc-geyser/src/stream.rs
@@ -1,6 +1,7 @@
 use {
     futures::Stream,
     std::{
+        future::Future,
         marker::PhantomData,
         pin::Pin,
         task::{Context, Poll},
@@ -68,16 +69,16 @@ where
     }
 }
 
-impl<T> PollReceiver for tokio::sync::mpsc::UnboundedReceiver<T> {
+impl<T> PollReceiver for ::tokio::sync::mpsc::UnboundedReceiver<T> {
     type Item = T;
 
     fn poll_recv(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        tokio::sync::mpsc::UnboundedReceiver::poll_recv(&mut self, cx)
+        ::tokio::sync::mpsc::UnboundedReceiver::poll_recv(&mut self, cx)
     }
 
     fn try_recv(&mut self) -> TryRecv<Self::Item> {
-        use tokio::sync::mpsc::error::TryRecvError;
-        match tokio::sync::mpsc::UnboundedReceiver::try_recv(self) {
+        use ::tokio::sync::mpsc::error::TryRecvError;
+        match ::tokio::sync::mpsc::UnboundedReceiver::try_recv(self) {
             Ok(item) => TryRecv::Item(item),
             Err(TryRecvError::Empty) => TryRecv::Empty,
             Err(TryRecvError::Disconnected) => TryRecv::Closed,
@@ -85,19 +86,196 @@ impl<T> PollReceiver for tokio::sync::mpsc::UnboundedReceiver<T> {
     }
 }
 
-impl<T> PollReceiver for tokio::sync::mpsc::Receiver<T> {
+impl<T> PollReceiver for ::tokio::sync::mpsc::Receiver<T> {
     type Item = T;
 
     fn poll_recv(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        tokio::sync::mpsc::Receiver::poll_recv(&mut self, cx)
+        ::tokio::sync::mpsc::Receiver::poll_recv(&mut self, cx)
     }
 
     fn try_recv(&mut self) -> TryRecv<Self::Item> {
-        use tokio::sync::mpsc::error::TryRecvError;
-        match tokio::sync::mpsc::Receiver::try_recv(self) {
+        use ::tokio::sync::mpsc::error::TryRecvError;
+        match ::tokio::sync::mpsc::Receiver::try_recv(self) {
             Ok(item) => TryRecv::Item(item),
             Err(TryRecvError::Empty) => TryRecv::Empty,
             Err(TryRecvError::Disconnected) => TryRecv::Closed,
+        }
+    }
+}
+
+pub trait BatchStream {
+    type Item;
+
+    fn poll_recv_batch(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        batch: &mut Vec<Self::Item>,
+    ) -> Poll<Option<usize>>;
+    fn try_recv(&mut self) -> TryRecv<Self::Item>;
+}
+
+pub struct NextBatch<'a, S, T> {
+    stream: &'a mut S,
+    batch: &'a mut Vec<T>,
+}
+
+impl<S, T> Future for NextBatch<'_, S, T>
+where
+    S: BatchStream<Item = T> + Unpin,
+{
+    type Output = Option<usize>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().get_mut();
+        Pin::new(&mut *this.stream).poll_recv_batch(cx, this.batch)
+    }
+}
+
+pub trait BatchStreamExt: BatchStream + Unpin {
+    fn next_batch<'a>(
+        &'a mut self,
+        batch: &'a mut Vec<Self::Item>,
+    ) -> NextBatch<'a, Self, Self::Item>
+    where
+        Self: Sized,
+    {
+        NextBatch {
+            stream: self,
+            batch,
+        }
+    }
+
+    fn poll_next_batch(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        batch: &mut Vec<Self::Item>,
+    ) -> Poll<Option<usize>>
+    where
+        Self: Sized,
+    {
+        self.poll_recv_batch(cx, batch)
+    }
+}
+
+impl<S> BatchStreamExt for S where S: BatchStream + Unpin {}
+
+pub mod tokio {
+    use {
+        crate::stream::{BatchStream, TryRecv},
+        std::{
+            pin::Pin,
+            task::{Context, Poll},
+        },
+    };
+
+    pub struct BatchStreamReceiver<T> {
+        inner: ::tokio::sync::mpsc::Receiver<T>,
+    }
+
+    impl<T> BatchStreamReceiver<T> {
+        pub fn new(inner: ::tokio::sync::mpsc::Receiver<T>) -> BatchStreamReceiver<T> {
+            BatchStreamReceiver { inner }
+        }
+    }
+
+    pub struct BatchStreamUnboundedReceiver<T> {
+        inner: ::tokio::sync::mpsc::UnboundedReceiver<T>,
+    }
+
+    impl<T> BatchStreamUnboundedReceiver<T> {
+        pub fn new(
+            inner: ::tokio::sync::mpsc::UnboundedReceiver<T>,
+        ) -> BatchStreamUnboundedReceiver<T> {
+            BatchStreamUnboundedReceiver { inner }
+        }
+    }
+
+    impl<T> BatchStream for BatchStreamReceiver<T> {
+        type Item = T;
+
+        fn poll_recv_batch(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            batch: &mut Vec<Self::Item>,
+        ) -> Poll<Option<usize>> {
+            if batch.len() == batch.capacity() {
+                return Poll::Ready(Some(0));
+            }
+
+            let this = self.get_mut();
+            let mut i = 0;
+            match Pin::new(&mut this.inner).poll_recv(cx) {
+                Poll::Ready(Some(item)) => {
+                    i += 1;
+                    batch.push(item);
+
+                    // try drain loop here
+                    while let Ok(item) = this.inner.try_recv() {
+                        batch.push(item);
+                        i += 1;
+                        if batch.len() == batch.capacity() {
+                            break;
+                        }
+                    }
+
+                    Poll::Ready(Some(i))
+                }
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn try_recv(&mut self) -> TryRecv<Self::Item> {
+            use ::tokio::sync::mpsc::error::TryRecvError;
+            match self.inner.try_recv() {
+                Ok(item) => TryRecv::Item(item),
+                Err(TryRecvError::Empty) => TryRecv::Empty,
+                Err(TryRecvError::Disconnected) => TryRecv::Closed,
+            }
+        }
+    }
+
+    impl<T> BatchStream for BatchStreamUnboundedReceiver<T> {
+        type Item = T;
+
+        fn poll_recv_batch(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            batch: &mut Vec<Self::Item>,
+        ) -> Poll<Option<usize>> {
+            if batch.len() == batch.capacity() {
+                return Poll::Ready(Some(0));
+            }
+
+            let this = self.get_mut();
+            let mut i = 0;
+            match Pin::new(&mut this.inner).poll_recv(cx) {
+                Poll::Ready(Some(item)) => {
+                    i += 1;
+                    batch.push(item);
+
+                    while let Ok(item) = this.inner.try_recv() {
+                        batch.push(item);
+                        i += 1;
+                        if batch.len() == batch.capacity() {
+                            break;
+                        }
+                    }
+
+                    Poll::Ready(Some(i))
+                }
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn try_recv(&mut self) -> TryRecv<Self::Item> {
+            use ::tokio::sync::mpsc::error::TryRecvError;
+            match self.inner.try_recv() {
+                Ok(item) => TryRecv::Item(item),
+                Err(TryRecvError::Empty) => TryRecv::Empty,
+                Err(TryRecvError::Disconnected) => TryRecv::Closed,
+            }
         }
     }
 }

--- a/yellowstone-grpc-geyser/src/stream.rs
+++ b/yellowstone-grpc-geyser/src/stream.rs
@@ -1,7 +1,11 @@
-use futures::Stream;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use {
+    futures::Stream,
+    std::{
+        marker::PhantomData,
+        pin::Pin,
+        task::{Context, Poll},
+    },
+};
 
 pub enum TryRecv<T> {
     Item(T),

--- a/yellowstone-grpc-geyser/src/stream.rs
+++ b/yellowstone-grpc-geyser/src/stream.rs
@@ -1,8 +1,7 @@
 use futures::Stream;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-
-use crate::plugin::message::Message;
 
 pub enum TryRecv<T> {
     Item(T),
@@ -17,30 +16,32 @@ pub trait PollReceiver {
     fn try_recv(&mut self) -> TryRecv<Self::Item>;
 }
 
-pub trait BatchInto {
-    fn batch_into(self, batch: &mut Vec<Message>);
+pub trait BatchInto<Out> {
+    fn batch_into(self, batch: &mut Vec<Out>);
 }
 
-pub struct GeyserStream<R> {
+pub struct GeyserStream<R, Out> {
     receiver: R,
     batch_capacity: usize,
+    _out: PhantomData<fn() -> Out>,
 }
 
-impl<R> GeyserStream<R> {
+impl<R, Out> GeyserStream<R, Out> {
     pub fn new(receiver: R, batch_capacity: usize) -> Self {
         Self {
             receiver,
             batch_capacity,
+            _out: PhantomData,
         }
     }
 }
 
-impl<R> Stream for GeyserStream<R>
+impl<R, Out> Stream for GeyserStream<R, Out>
 where
     R: PollReceiver + Unpin,
-    R::Item: BatchInto,
+    R::Item: BatchInto<Out>,
 {
-    type Item = Vec<Message>;
+    type Item = Vec<Out>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let message = match Pin::new(&mut self.receiver).poll_recv(cx) {
@@ -60,12 +61,6 @@ where
         }
 
         Poll::Ready(Some(batch_messages))
-    }
-}
-
-impl BatchInto for Message {
-    fn batch_into(self, batch: &mut Vec<Message>) {
-        batch.push(self);
     }
 }
 


### PR DESCRIPTION
1. Introduces a stream which feeds data into the geyser and block reconstruction loops
2. Optimizes the geyser_loop processed message feed by moving block reconstruction, block meta and slot messages to a 1hop channel send instead of running through geyser_loop 