### PR TITLE
docs(client): document reconnect config default values

### DIFF
--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -84,12 +84,22 @@ pub type GeyserGrpcClientResult<T> = Result<T, GeyserGrpcClientError>;
 
 #[derive(Clone, Debug)]
 /// Configuration for automatic subscribe reconnect behavior.
+///
+/// The [`Default`] configuration uses [`Backoff::default`] and a
+/// `slot_retention` of `250` slots. Use [`ReconnectConfig::no_reconnect`] to
+/// disable automatic reconnection entirely.
 pub struct ReconnectConfig {
+    /// Backoff policy applied between reconnect attempts. Defaults to
+    /// [`Backoff::default`] (`10ms` initial interval, `2.0` multiplier, `3`
+    /// retries).
     pub backoff: Backoff,
+    /// Number of most-recent slots retained to de-duplicate messages across a
+    /// reconnect. Default: `250`.
     pub slot_retention: usize,
 }
 
 impl Default for ReconnectConfig {
+    /// [`Backoff::default`] with a `slot_retention` of `250` slots.
     fn default() -> Self {
         Self {
             backoff: Backoff::default(),

--- a/yellowstone-grpc-client/src/reconnect.rs
+++ b/yellowstone-grpc-client/src/reconnect.rs
@@ -33,10 +33,25 @@ pub const AUTORECONNECT_FILTER_KEY: &str = "__autoreconnect";
 type ConnectFuture<S> =
     Pin<Box<dyn Future<Output = Result<DedupStream<S>, GeyserGrpcClientError>> + Send + 'static>>;
 
+/// Exponential backoff policy for automatic subscribe reconnects.
+///
+/// After each failed attempt the wait interval is multiplied by [`multiplier`],
+/// starting from [`initial_interval`], for up to [`max_retries`] attempts.
+///
+/// The [`Default`] policy is a `10ms` initial interval, a `2.0` multiplier, and
+/// `3` retries (waits of roughly `10ms`, `20ms`, then `40ms` before giving up).
+///
+/// [`initial_interval`]: Backoff::initial_interval
+/// [`multiplier`]: Backoff::multiplier
+/// [`max_retries`]: Backoff::max_retries
 #[derive(Debug, Clone)]
 pub struct Backoff {
+    /// Wait interval before the first retry. Default: `10ms`.
     pub initial_interval: Duration,
+    /// Factor the wait interval is multiplied by after each attempt.
+    /// Default: `2.0`.
     pub multiplier: f64,
+    /// Maximum number of reconnect attempts before giving up. Default: `3`.
     pub max_retries: u32,
 }
 
@@ -160,6 +175,7 @@ impl Backoff {
 }
 
 impl Default for Backoff {
+    /// A `10ms` initial interval, a `2.0` multiplier, and `3` retries.
     fn default() -> Self {
         Self::new(
             Self::default_initial_interval(),


### PR DESCRIPTION
The auto-reconnect support added in 13.1.0 exposes `ReconnectConfig` and `Backoff`, but their default values were only discoverable by reading the crate source (see #812).

This adds rustdoc to `ReconnectConfig` and `Backoff` and their fields, documenting the defaults:

- `backoff.initial_interval`: `10ms`
- `backoff.multiplier`: `2.0`
- `backoff.max_retries`: `3`
- `slot_retention`: `250` slots

Docs-only; no behavior change. Verified with `cargo doc` (no broken intra-doc links) and `cargo fmt --check`.

Closes #812