### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,15 @@ The minor version will be incremented upon a breaking change and the patch versi
 - Removed `/debug_clients` endpoint from the auxiliary sidecar server.
 - Changed client-loop logs to include subscriber context for improved monitoring and troubleshooting.
 - Changed `yellowstone_grpc_geyser_subscriber_queue_size` from `IntGaugeVec` to `HistogramVec` to better represent multiple concurrent subscriptions per subscriber.
+- Removed 'yellowstone_grpc_geyser_batch_size' metric due to geyser_loop overhead and unnecessary tracking
 
 ### Misc
 - Introduced a stream which feeds data into the geyser and block reconstruction loops
 - Optimizes the geyser_loop processed message feed by moving block reconstruction, block meta and slot messages to a 1hop channel send instead of running through geyser_loop
+- Optimizes geyser_loop by lazily encoding messages on a first visit basis instead of encoding them in geyser_loop
+- Optimizes block reconstruction message ingress and egress
+- Optimizes replay 
+- Wrap MessageSlot in an Arc to reduce overall size of 'Message' to 40 bytes down from 80, reducing amount of memory required during copy and allocate
 
 ## 2026-07-03
 

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -301,7 +301,7 @@ impl BlockMachineStorage {
             .retain(|(_, block)| block.block_meta.slot != slot);
     }
 
-    fn on_message_slot(&mut self, slot_update: MessageSlot) -> Result<(), UntrackedSlot> {
+    fn on_message_slot(&mut self, slot_update: &MessageSlot) -> Result<(), UntrackedSlot> {
         let slot_status = slot_update.status;
         const LIFE_CYCLE_STATUS: [SlotStatus; 4] = [
             SlotStatus::FirstShredReceived,
@@ -506,7 +506,7 @@ impl BlockMachineStorage {
     pub fn add(&mut self, message: Message) {
         match message {
             Message::Slot(message_slot) => {
-                if self.on_message_slot(message_slot).is_err() {
+                if self.on_message_slot(&message_slot).is_err() {
                     // Symmetric with handle_block_data which increments the same metric
                     // when is_slot_tracked returns false.
                     metrics::incr_geyser_untrack_slot_event_dropped();
@@ -625,13 +625,13 @@ mod tests {
     }
 
     fn make_slot_msg(slot: u64, parent: Option<u64>, status: SlotStatus) -> Message {
-        Message::Slot(MessageSlot {
+        Message::Slot(Arc::new(MessageSlot {
             slot,
             parent,
             status,
             dead_error: None,
             created_at: ts(),
-        })
+        }))
     }
 
     fn make_block_meta_msg(slot: u64, parent_slot: u64) -> Message {

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -137,12 +137,12 @@ impl ProcessingSlot {
             );
         }
 
-        let pre_computed_message_block = MessageBlock::new(
+        let pre_computed_message_block = Arc::new(MessageBlock::new(
             Arc::clone(&block_meta),
             self.transactions,
             account_info_vec,
             self.entries,
-        );
+        ));
 
         FrozenBlock {
             original_messages: Arc::new(dedup_messages),
@@ -155,12 +155,12 @@ impl ProcessingSlot {
 pub struct FrozenBlock {
     original_messages: Arc<Vec<Message>>,
     block_meta: Arc<MessageBlockMeta>,
-    pre_computed_message_block: MessageBlock,
+    pre_computed_message_block: Arc<MessageBlock>,
 }
 
 impl FrozenBlock {
-    pub fn get_message_block(&self) -> MessageBlock {
-        self.pre_computed_message_block.clone()
+    pub fn get_message_block(&self) -> Arc<MessageBlock> {
+        Arc::clone(&self.pre_computed_message_block)
     }
 
     pub fn messages(&self) -> Arc<Vec<Message>> {

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -11,7 +11,7 @@ use {
     solana_pubkey::Pubkey,
     std::{
         borrow::Borrow,
-        collections::{btree_map::Range, BTreeMap, HashMap, VecDeque},
+        collections::{btree_map::Range, BTreeMap, VecDeque},
         str::FromStr,
         sync::Arc,
     },
@@ -19,17 +19,31 @@ use {
         BlockReplayEvent, BlockStateMachineOutput, BlockSummary, BlocksStateMachine,
         SlotCommitmentStatusUpdate, SlotLifecycle, SlotLifecycleUpdate, UntrackedSlot,
     },
+    foldhash::{HashMap as FoldHashMap, HashMapExt},
 };
 
-#[derive(Default)]
 pub struct ProcessingSlot {
     original_messages: Vec<Message>,
-    account_write_version_map: HashMap<Pubkey, u64>,
+    account_write_version_map: FoldHashMap<Pubkey, u64>,
     blockmeta: Option<Arc<MessageBlockMeta>>,
     transactions: Vec<Arc<MessageTransactionInfo>>,
     accounts: Vec<Arc<MessageAccountInfo>>,
     entries: Vec<Arc<MessageEntry>>,
     is_sealed: bool,
+}
+
+impl Default for ProcessingSlot {
+    fn default() -> Self {
+        Self {
+            original_messages: Vec::with_capacity(4096),
+            account_write_version_map: FoldHashMap::with_capacity(4096),
+            blockmeta: None,
+            transactions: Vec::with_capacity(4096),
+            accounts: Vec::with_capacity(4096),
+            entries: Vec::with_capacity(64),
+            is_sealed: false,
+        }
+    }
 }
 
 enum TrySealError {
@@ -75,17 +89,17 @@ impl ProcessingSlot {
         if self.is_sealed {
             return Err(TrySealError::AlreadySealed);
         }
-        if self.blockmeta.is_none() {
+        let Some(blockmeta) = self.blockmeta.as_ref() else {
             return Err(TrySealError::NotSealable);
-        }
-        let expected_txn_count =
-            self.blockmeta.as_ref().unwrap().executed_transaction_count as usize;
+        };
 
-        let expected_entry_count = self.blockmeta.as_ref().unwrap().entries_count as usize;
+        let expected_txn_count =
+            blockmeta.executed_transaction_count as usize;
         if self.transactions.len() < expected_txn_count {
             return Err(TrySealError::NotSealable);
         }
 
+        let expected_entry_count = blockmeta.entries_count as usize;
         if self.entries.len() < expected_entry_count {
             return Err(TrySealError::NotSealable);
         }
@@ -178,10 +192,10 @@ pub struct SlotProgression {
 }
 
 pub struct BlockMachineStorage {
-    processing_slots: HashMap<u64, ProcessingSlot>,
-    pending_blockmeta: HashMap<u64, Arc<MessageBlockMeta>>,
+    processing_slots: FoldHashMap<u64, ProcessingSlot>,
+    pending_blockmeta: FoldHashMap<u64, Arc<MessageBlockMeta>>,
     replayed_slot: BTreeMap<u64, Arc<FrozenBlock>>,
-    slot_commitment_progression_map: HashMap<u64, SlotProgression>,
+    slot_commitment_progression_map: FoldHashMap<u64, SlotProgression>,
     replayed_capacity: usize,
     ready_queue: VecDeque<(SlotCommitmentStatusUpdate, Arc<FrozenBlock>)>,
     state: BlocksStateMachine,
@@ -254,11 +268,11 @@ pub const MINIMUM_FINALIZED_SLOT_TO_BUFFER: usize = 10;
 impl BlockMachineStorage {
     pub fn new(replayed_capacity: usize) -> Self {
         Self {
-            processing_slots: HashMap::new(),
+            processing_slots: FoldHashMap::new(),
             replayed_slot: BTreeMap::new(),
             replayed_capacity,
-            pending_blockmeta: HashMap::new(),
-            slot_commitment_progression_map: HashMap::new(),
+            pending_blockmeta: FoldHashMap::new(),
+            slot_commitment_progression_map: FoldHashMap::new(),
             ready_queue: VecDeque::new(),
             state: BlocksStateMachine::default(),
             min_slot: None,

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -6,6 +6,7 @@ use {
             MessageTransactionInfo, SlotStatus,
         },
     },
+    foldhash::{HashMap as FoldHashMap, HashMapExt},
     solana_commitment_config::CommitmentLevel,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
@@ -19,7 +20,6 @@ use {
         BlockReplayEvent, BlockStateMachineOutput, BlockSummary, BlocksStateMachine,
         SlotCommitmentStatusUpdate, SlotLifecycle, SlotLifecycleUpdate, UntrackedSlot,
     },
-    foldhash::{HashMap as FoldHashMap, HashMapExt},
 };
 
 pub struct ProcessingSlot {
@@ -93,8 +93,7 @@ impl ProcessingSlot {
             return Err(TrySealError::NotSealable);
         };
 
-        let expected_txn_count =
-            blockmeta.executed_transaction_count as usize;
+        let expected_txn_count = blockmeta.executed_transaction_count as usize;
         if self.transactions.len() < expected_txn_count {
             return Err(TrySealError::NotSealable);
         }

--- a/yellowstone-grpc-geyser/src/block_reconstruction.rs
+++ b/yellowstone-grpc-geyser/src/block_reconstruction.rs
@@ -192,7 +192,6 @@ pub struct SlotProgression {
 
 pub struct BlockMachineStorage {
     processing_slots: FoldHashMap<u64, ProcessingSlot>,
-    pending_blockmeta: FoldHashMap<u64, Arc<MessageBlockMeta>>,
     replayed_slot: BTreeMap<u64, Arc<FrozenBlock>>,
     slot_commitment_progression_map: FoldHashMap<u64, SlotProgression>,
     replayed_capacity: usize,
@@ -267,12 +266,11 @@ pub const MINIMUM_FINALIZED_SLOT_TO_BUFFER: usize = 10;
 impl BlockMachineStorage {
     pub fn new(replayed_capacity: usize) -> Self {
         Self {
-            processing_slots: FoldHashMap::new(),
+            processing_slots: FoldHashMap::with_capacity(replayed_capacity),
             replayed_slot: BTreeMap::new(),
             replayed_capacity,
-            pending_blockmeta: FoldHashMap::new(),
-            slot_commitment_progression_map: FoldHashMap::new(),
-            ready_queue: VecDeque::new(),
+            slot_commitment_progression_map: FoldHashMap::with_capacity(replayed_capacity),
+            ready_queue: VecDeque::with_capacity(replayed_capacity),
             state: BlocksStateMachine::default(),
             min_slot: None,
             num_buffered_finalized_slot: 0,
@@ -285,7 +283,6 @@ impl BlockMachineStorage {
 
     fn prune_slot(&mut self, slot: u64, refresh_min_slot: bool) {
         self.processing_slots.remove(&slot);
-        self.pending_blockmeta.remove(&slot);
         self.replayed_slot.remove(&slot);
         if let Some(progression) = self.slot_commitment_progression_map.remove(&slot) {
             if progression.max_commitment == CommitmentLevel::Finalized {

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1278,7 +1278,7 @@ impl GrpcService {
                             dead_error: None,
                             created_at: Timestamp::from(SystemTime::now())
                         });
-                        let slot_message_singleton_vec = Arc::new(vec![slot_message.clone()]);
+                        let slot_message_singleton_vec = Arc::new(vec![slot_message]);
                         for commitment_level in ALL_COMMITMENT_LEVELS {
                             let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
                         }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -329,8 +329,13 @@ pub type BroadcastedMessage = (CommitmentLevel, Arc<Vec<Message>>);
 /// once, when first received from the geyser plugin.
 type DeshredBroadcastedMessage = Message;
 
+pub enum ReplayResponseMessageType {
+    Single(Message),
+    Batch(Arc<Vec<Message>>),
+}
+
 pub enum ReplayedResponse {
-    Messages(Vec<Message>),
+    Messages(Vec<ReplayResponseMessageType>),
     Lagged(Slot),
 }
 
@@ -1298,34 +1303,40 @@ impl GrpcService {
                         CommitmentLevel::Finalized => solana_commitment_config::CommitmentLevel::Finalized,
                     };
 
-                    let mut replayed_messages = Vec::with_capacity(32_768);
+                    // Elaboration on 5 * replay_stored_slots: Each slot can have up to 5 messages (1 for messages, 1 for block meta, 3 for slot status). So we allocate enough space for the worst case scenario.
+                    let mut replayed_messages = Vec::with_capacity(replay_stored_slots as usize + (5 * replay_stored_slots as usize));
                     let replayed_slot_iter = block_machine.replay_from_slot(replay_slot, min_solana_commitment);
 
+                    // We need only an estimated timestamp for the replayed slot messages, so we can use the same timestamp for all of them.
+                    let created_at = Timestamp::from(SystemTime::now());
+
                     for replayed_slot in replayed_slot_iter {
-                        let slot_messages = replayed_slot
-                            .slot_status_messages
-                            .iter()
-                            .map(|s| {
-                                Message::Slot(MessageSlot {
-                                    slot: s.slot,
-                                    parent: s.parent_slot,
-                                    status: match s.commitment {
-                                        solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
-                                        solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
-                                        solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
-                                    },
-                                    dead_error: None,
-                                    created_at: Timestamp::from(SystemTime::now())
-                                })
-                            });
                         // 1st Put data (account/txn/entries)
-                        replayed_messages.extend(replayed_slot.frozen_block.messages().iter().cloned());
+                        replayed_messages.push(ReplayResponseMessageType::Batch(replayed_slot.frozen_block.messages()));
+
                         // 2nd Put block summary
-                        replayed_messages.push(Message::BlockMeta(replayed_slot.frozen_block.get_block_meta()));
+                        replayed_messages.push(ReplayResponseMessageType::Single(Message::BlockMeta(replayed_slot.frozen_block.get_block_meta())));
+
                         // 3rd Put slot status
-                        replayed_messages.extend(slot_messages);
+                        for slot_update in replayed_slot.slot_status_messages.iter() {
+                            let slot_message = Message::Slot(MessageSlot {
+                                slot: slot_update.slot,
+                                parent: slot_update.parent_slot,
+                                status: match slot_update.commitment {
+                                    solana_commitment_config::CommitmentLevel::Processed => SlotStatus::Processed,
+                                    solana_commitment_config::CommitmentLevel::Confirmed => SlotStatus::Confirmed,
+                                    solana_commitment_config::CommitmentLevel::Finalized => SlotStatus::Finalized,
+                                },
+                                dead_error: None,
+                                created_at,
+                            });
+                            replayed_messages.push(ReplayResponseMessageType::Single(slot_message));
+                        }
                     }
-                    let _ = tx.send(ReplayedResponse::Messages(replayed_messages));
+
+                    if !replayed_messages.is_empty() {
+                        let _ = tx.send(ReplayedResponse::Messages(replayed_messages));
+                    }
                 }
                 else => {
                     // No new messages and replay request channel closed, can only happen on shutdown
@@ -1430,8 +1441,8 @@ impl GrpcService {
                                     break 'outer;
                                 }
 
-                                let messages = match rx.await {
-                                    Ok(ReplayedResponse::Messages(messages)) => messages,
+                                let messages_batch = match rx.await {
+                                    Ok(ReplayedResponse::Messages(messages_batch)) => messages_batch,
                                     Ok(ReplayedResponse::Lagged(slot)) => {
                                         info!("client #{}: broadcast from {from_slot} is not available", session.subscriber_id);
                                         task_tracker.spawn(async move {
@@ -1453,16 +1464,37 @@ impl GrpcService {
                                     }
                                 };
 
-                                for message in messages.iter() {
-                                    for message in session.filter.get_updates(message, Some(commitment)) {
-                                        match stream_tx.send(Ok(message)).await {
-                                            Ok(()) => {
-                                                metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
+
+                                for message_batch in messages_batch.iter() {
+                                    match message_batch {
+                                        ReplayResponseMessageType::Single(message) => {
+                                            for filtered_message in session.filter.get_updates(message, Some(commitment)) {
+                                                match stream_tx.send(Ok(filtered_message)).await {
+                                                    Ok(()) => {
+                                                        metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
+                                                    }
+                                                    Err(mpsc::error::SendError(_)) => {
+                                                        error!("client #{}: stream closed", session.subscriber_id);
+                                                        session.disconnect_reason = "client_closed";
+                                                        break 'outer;
+                                                    }
+                                                }
                                             }
-                                            Err(mpsc::error::SendError(_)) => {
-                                                error!("client #{}: stream closed", session.subscriber_id);
-                                                session.disconnect_reason = "client_closed";
-                                                break 'outer;
+                                        }
+                                        ReplayResponseMessageType::Batch(message_batch) => {
+                                            for message in message_batch.iter() {
+                                                for filtered_message in session.filter.get_updates(message, Some(commitment)) {
+                                                    match stream_tx.send(Ok(filtered_message)).await {
+                                                        Ok(()) => {
+                                                            metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
+                                                        }
+                                                        Err(mpsc::error::SendError(_)) => {
+                                                            error!("client #{}: stream closed", session.subscriber_id);
+                                                            session.disconnect_reason = "client_closed";
+                                                            break 'outer;
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -349,9 +349,9 @@ pub struct ReplayResponseMessageIterator<'a> {
 }
 
 impl ReplayResponseMessageType {
-    fn iter(&self) -> ReplayResponseMessageIterator<'_> {
+    const fn iter(&self) -> ReplayResponseMessageIterator<'_> {
         ReplayResponseMessageIterator {
-            msg: &self,
+            msg: self,
             current_index: 0,
         }
     }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -64,11 +64,15 @@ use {
     tokio_util::{sync::CancellationToken, task::TaskTracker},
     tonic::{
         metadata::AsciiMetadataValue,
+        ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks}, 
         service::{interceptor, LayerExt},
+        stream::{BatchInto, GeyserStream, PollReceiver},
         transport::{
             server::{Connected, Server},
             CertificateDer,
         },
+        util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
+        version::GrpcVersionInfo,
         Request, Response, Result as TonicResult, Status, Streaming,
     },
     tonic_health::{pb::health_server::HealthServer, server::health_reporter},

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -334,6 +334,55 @@ pub enum ReplayResponseMessageType {
     Batch(Arc<Vec<Message>>),
 }
 
+impl<'a> IntoIterator for &'a ReplayResponseMessageType {
+    type Item = &'a Message;
+    type IntoIter = ReplayResponseMessageIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct ReplayResponseMessageIterator<'a> {
+    msg: &'a ReplayResponseMessageType,
+    current_index: usize,
+}
+
+impl ReplayResponseMessageType {
+    fn iter(&self) -> ReplayResponseMessageIterator<'_> {
+        ReplayResponseMessageIterator {
+            msg: &self,
+            current_index: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for ReplayResponseMessageIterator<'a> {
+    type Item = &'a Message;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.msg {
+            ReplayResponseMessageType::Single(msg) => {
+                if self.current_index == 0 {
+                    self.current_index += 1;
+                    Some(msg)
+                } else {
+                    None
+                }
+            }
+            ReplayResponseMessageType::Batch(batch) => {
+                if self.current_index < batch.len() {
+                    let msg = &batch[self.current_index];
+                    self.current_index += 1;
+                    Some(msg)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
 pub enum ReplayedResponse {
     Messages(Vec<ReplayResponseMessageType>),
     Lagged(Slot),
@@ -1465,38 +1514,20 @@ impl GrpcService {
                                     }
                                 };
 
+                                let replay_it = messages_batch
+                                    .iter()
+                                    .flatten()
+                                    .flat_map(|message| session.filter.get_updates(message, Some(commitment)));
 
-                                for message_batch in messages_batch.iter() {
-                                    match message_batch {
-                                        ReplayResponseMessageType::Single(message) => {
-                                            for filtered_message in session.filter.get_updates(message, Some(commitment)) {
-                                                match stream_tx.send(Ok(filtered_message)).await {
-                                                    Ok(()) => {
-                                                        metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
-                                                    }
-                                                    Err(mpsc::error::SendError(_)) => {
-                                                        error!("client #{}: stream closed", session.subscriber_id);
-                                                        session.disconnect_reason = "client_closed";
-                                                        break 'outer;
-                                                    }
-                                                }
-                                            }
+                                for filtered_message in replay_it {
+                                    match stream_tx.send(Ok(filtered_message)).await {
+                                        Ok(()) => {
+                                            metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
                                         }
-                                        ReplayResponseMessageType::Batch(message_batch) => {
-                                            for message in message_batch.iter() {
-                                                for filtered_message in session.filter.get_updates(message, Some(commitment)) {
-                                                    match stream_tx.send(Ok(filtered_message)).await {
-                                                        Ok(()) => {
-                                                            metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
-                                                        }
-                                                        Err(mpsc::error::SendError(_)) => {
-                                                            error!("client #{}: stream closed", session.subscriber_id);
-                                                            session.disconnect_reason = "client_closed";
-                                                            break 'outer;
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                        Err(mpsc::error::SendError(_)) => {
+                                            error!("client #{}: stream closed", session.subscriber_id);
+                                            session.disconnect_reason = "client_closed";
+                                            break 'outer;
                                         }
                                     }
                                 }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -31,7 +31,7 @@ use {
     },
     anyhow::Context as _,
     bytesize::ByteSize,
-    futures::{Stream, StreamExt},
+    futures::Stream,
     log::{error, info},
     prost_types::Timestamp,
     rustls::{
@@ -64,15 +64,11 @@ use {
     tokio_util::{sync::CancellationToken, task::TaskTracker},
     tonic::{
         metadata::AsciiMetadataValue,
-        ratelimit::{MethodRatelimiter, PrometheusRatelimitCallbacks}, 
         service::{interceptor, LayerExt},
-        stream::{BatchInto, GeyserStream, PollReceiver},
         transport::{
             server::{Connected, Server},
             CertificateDer,
         },
-        util::stream::{load_aware_channel, LoadAwareReceiver, LoadAwareSender},
-        version::GrpcVersionInfo,
         Request, Response, Result as TonicResult, Status, Streaming,
     },
     tonic_health::{pb::health_server::HealthServer, server::health_reporter},

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -11,11 +11,10 @@ use {
         metered::PrometheusMeteredManager,
         metrics::{
             self, incr_grpc_method_call_count, observe_subscriber_queue_size,
-            subscription_limit_exceeded_inc, GEYSER_BATCH_SIZE,
+            subscription_limit_exceeded_inc,
         },
         plugin::{
             filter::{
-                encoder::encode_messages,
                 limits::FilterLimits,
                 message::{FilteredUpdate, FilteredUpdateDeshred, FilteredUpdateOneof},
                 name::FilterNames,
@@ -1163,7 +1162,9 @@ impl GrpcService {
     ) where
         St: BatchStream<Item = Message> + Unpin + Send + 'static,
     {
-        let mut message_batch = Vec::with_capacity(32);
+        const MESSAGE_BATCH_SIZE: usize = 1024;
+
+        let mut message_batch = Vec::with_capacity(MESSAGE_BATCH_SIZE);
         loop {
             let batch_size_maybe = messages_rx.next_batch(&mut message_batch).await;
             let Some(_) = batch_size_maybe else {
@@ -1176,8 +1177,6 @@ impl GrpcService {
             }
 
             metrics::message_queue_size_dec_by(message_batch.len() as i64);
-            encode_messages(&message_batch);
-            GEYSER_BATCH_SIZE.observe(message_batch.len() as f64);
 
             let message_batch_arc = Arc::new(message_batch);
             let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::clone(&message_batch_arc)));
@@ -1189,7 +1188,7 @@ impl GrpcService {
                 metrics::block_reconstruction_queue_size_inc();
             }
 
-            message_batch = Vec::with_capacity(32);
+            message_batch = Vec::with_capacity(MESSAGE_BATCH_SIZE);
         }
     }
 
@@ -1260,7 +1259,7 @@ impl GrpcService {
                         }
 
                         let block_meta = Message::BlockMeta(frozen_block.get_block_meta());
-                        let msg_block = Message::Block(Arc::new(frozen_block.get_message_block()));
+                        let msg_block = Message::Block(frozen_block.get_message_block());
                         let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
 
                         let slot_message = Message::Slot(MessageSlot {

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -31,7 +31,7 @@ use {
     },
     anyhow::Context as _,
     bytesize::ByteSize,
-    futures::Stream,
+    futures::{Stream, StreamExt},
     log::{error, info},
     prost_types::Timestamp,
     rustls::{

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1267,7 +1267,7 @@ impl GrpcService {
                         let msg_block = Message::Block(frozen_block.get_message_block());
                         let _ = broadcast_tx.send((commitment_level, Arc::new(vec![msg_block, block_meta])));
 
-                        let slot_message = Message::Slot(MessageSlot {
+                        let slot_message = Message::Slot(Arc::new(MessageSlot {
                             slot: slot_update.slot,
                             parent: slot_update.parent_slot,
                             status: match slot_update.commitment {
@@ -1277,7 +1277,8 @@ impl GrpcService {
                             },
                             dead_error: None,
                             created_at: Timestamp::from(SystemTime::now())
-                        });
+                        }));
+
                         let slot_message_singleton_vec = Arc::new(vec![slot_message]);
                         for commitment_level in ALL_COMMITMENT_LEVELS {
                             let _ = broadcast_tx.send((commitment_level, Arc::clone(&slot_message_singleton_vec)));
@@ -1319,7 +1320,7 @@ impl GrpcService {
 
                         // 3rd Put slot status
                         for slot_update in replayed_slot.slot_status_messages.iter() {
-                            let slot_message = Message::Slot(MessageSlot {
+                            let slot_message = Message::Slot(Arc::new(MessageSlot {
                                 slot: slot_update.slot,
                                 parent: slot_update.parent_slot,
                                 status: match slot_update.commitment {
@@ -1329,7 +1330,7 @@ impl GrpcService {
                                 },
                                 dead_error: None,
                                 created_at,
-                            });
+                            }));
                             replayed_messages.push(ReplayResponseMessageType::Single(slot_message));
                         }
                     }
@@ -2461,13 +2462,13 @@ mod tests {
         drop(stream_rx);
 
         // broadcast so client_loop hits try_send -> Closed
-        let msg = Message::Slot(MessageSlot {
+        let msg = Message::Slot(Arc::new(MessageSlot {
             slot: 100,
             parent: Some(99),
             status: SlotStatus::Processed,
             dead_error: None,
             created_at: Timestamp::from(SystemTime::now()),
-        });
+        }));
         let _ = broadcast_tx.send((CommitmentLevel::Processed, Arc::new(vec![msg])));
 
         tokio::time::timeout(Duration::from_secs(2), handle)
@@ -2628,13 +2629,13 @@ mod tests {
         }
 
         fn make_slot(slot: u64, status: SlotStatus, parent: Option<u64>) -> Message {
-            Message::Slot(MessageSlot {
+            Message::Slot(Arc::new(MessageSlot {
                 slot,
                 parent,
                 status,
                 dead_error: None,
                 created_at: Timestamp::from(SystemTime::now()),
-            })
+            }))
         }
 
         #[tokio::test]

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -114,14 +114,6 @@ lazy_static::lazy_static! {
         .buckets(vec![5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 10000.0])
     ).unwrap();
 
-    pub static ref GEYSER_BATCH_SIZE: Histogram = Histogram::with_opts(
-        HistogramOpts::new(
-            "yellowstone_grpc_geyser_batch_size",
-            "Size of processed message batches"
-        )
-        .buckets(vec![1.0, 4.0, 8.0, 16.0, 24.0, 31.0])
-    ).unwrap();
-
     static ref PRE_ENCODED_CACHE_HIT: IntCounterVec = IntCounterVec::new(
         Opts::new("yellowstone_grpc_geyser_pre_encoded_cache_hit", "Pre-encoded cache hits by message type"),
         &["type"]
@@ -264,7 +256,6 @@ impl PrometheusService {
             register!(GEYSER_ACCOUNT_UPDATE_RECEIVED);
             register!(GRPC_SUBSCRIBER_SEND_BANDWIDTH_LOAD);
             register!(GRPC_SUBSCRIBER_QUEUE_SIZE);
-            register!(GEYSER_BATCH_SIZE);
             register!(GRPC_CLIENT_DISCONNECTS);
             register!(PRE_ENCODED_CACHE_HIT);
             register!(PRE_ENCODED_CACHE_MISS);

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -296,7 +296,6 @@ impl GeyserPlugin for Plugin {
     ) -> PluginResult<()> {
         self.with_inner(|inner| {
             let message = Message::Slot(MessageSlot::from_geyser(slot, parent, status));
-
             if matches!(
                 status,
                 SlotStatus::Processed | SlotStatus::Confirmed | SlotStatus::Rooted

--- a/yellowstone-grpc-geyser/src/plugin/entry.rs
+++ b/yellowstone-grpc-geyser/src/plugin/entry.rs
@@ -295,7 +295,7 @@ impl GeyserPlugin for Plugin {
         status: &SlotStatus,
     ) -> PluginResult<()> {
         self.with_inner(|inner| {
-            let message = Message::Slot(MessageSlot::from_geyser(slot, parent, status));
+            let message = Message::Slot(Arc::new(MessageSlot::from_geyser(slot, parent, status)));
             if matches!(
                 status,
                 SlotStatus::Processed | SlotStatus::Confirmed | SlotStatus::Rooted

--- a/yellowstone-grpc-geyser/src/plugin/filter/encoder.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/encoder.rs
@@ -3,7 +3,7 @@ use {
         filter::message::{
             prost_bytes_encode_raw, prost_bytes_encoded_len, prost_field_encoded_len,
         },
-        message::{Message, MessageAccountInfo, MessageTransactionInfo},
+        message::{MessageAccountInfo, MessageTransactionInfo},
     },
     solana_pubkey::Pubkey,
     solana_signature::Signature,
@@ -131,23 +131,5 @@ impl AccountEncoder {
             + account
                 .txn_signature
                 .map_or(0, |_| SIGNATURE_FIELD_ENCODED_LEN)
-    }
-}
-
-pub fn encode_messages(messages: &Vec<Message>) {
-    for msg in messages {
-        match msg {
-            Message::Transaction(tx) => {
-                if tx.transaction.pre_encoded.get().is_none() {
-                    TransactionEncoder::pre_encode(&tx.transaction);
-                }
-            }
-            Message::Account(acc) => {
-                if acc.account.pre_encoded.get().is_none() {
-                    AccountEncoder::pre_encode(&acc.account);
-                }
-            }
-            _ => {}
-        }
     }
 }

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -27,12 +27,7 @@ use {
     spl_token_2022_interface::{
         generic_token_account::GenericTokenAccount, state::Account as TokenAccount,
     },
-    std::{
-        collections::HashMap,
-        ops::Range,
-        str::FromStr,
-        sync::Arc,
-    },
+    std::{collections::HashMap, ops::Range, str::FromStr, sync::Arc},
     yellowstone_grpc_proto::{
         cuckoo::CuckooFilter,
         geyser::{

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -28,7 +28,7 @@ use {
         generic_token_account::GenericTokenAccount, state::Account as TokenAccount,
     },
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashMap,
         ops::Range,
         str::FromStr,
         sync::Arc,
@@ -347,7 +347,7 @@ impl Filter {
 
     fn decode_pubkeys<'a>(
         pubkeys: &'a [String],
-        limit: &'a HashSet<Pubkey>,
+        limit: &'a FoldHashSet<Pubkey>,
     ) -> impl Iterator<Item = FilterResult<Pubkey>> + 'a {
         pubkeys.iter().map(|value| {
             let pubkey = Pubkey::from_str(value)?;
@@ -358,7 +358,7 @@ impl Filter {
 
     fn decode_pubkeys_into_set(
         pubkeys: &[String],
-        limit: &HashSet<Pubkey>,
+        limit: &FoldHashSet<Pubkey>,
     ) -> FilterResult<FoldHashSet<Pubkey>> {
         Self::decode_pubkeys(pubkeys, limit).collect::<FilterResult<_>>()
     }
@@ -993,13 +993,13 @@ impl FilterTransactions {
                     .collect(),
                     account_exclude: Filter::decode_pubkeys_into_set(
                         &filter.account_exclude,
-                        &HashSet::new(),
+                        &FoldHashSet::new(),
                     )?
                     .into_iter()
                     .collect(),
                     account_required: Filter::decode_pubkeys_into_set(
                         &filter.account_required,
-                        &HashSet::new(),
+                        &FoldHashSet::new(),
                     )?
                     .into_iter()
                     .collect(),
@@ -1230,11 +1230,11 @@ impl FilterDeshredTransactions {
                     )?,
                     account_exclude: Filter::decode_pubkeys_into_set(
                         &filter.account_exclude,
-                        &HashSet::new(),
+                        &FoldHashSet::new(),
                     )?,
                     account_required: Filter::decode_pubkeys_into_set(
                         &filter.account_required,
-                        &HashSet::new(),
+                        &FoldHashSet::new(),
                     )?,
                 },
             );
@@ -1272,7 +1272,7 @@ impl FilterDeshredTransactions {
                 }
 
                 if !inner.account_required.is_empty() {
-                    let all_keys: HashSet<&Pubkey> = tx.all_account_keys().collect();
+                    let all_keys: FoldHashSet<&Pubkey> = tx.all_account_keys().collect();
                     if !inner
                         .account_required
                         .iter()

--- a/yellowstone-grpc-geyser/src/plugin/filter/limits.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/limits.rs
@@ -1,7 +1,7 @@
 use {
     serde::{de, Deserialize, Deserializer},
     solana_pubkey::Pubkey,
-    std::collections::HashSet,
+    foldhash::{HashSet as FoldHashSet, HashSetExt},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -56,7 +56,7 @@ impl FilterLimits {
         }
     }
 
-    pub fn check_pubkey_reject(pubkey: &Pubkey, set: &HashSet<Pubkey>) -> FilterLimitsCheckResult {
+    pub fn check_pubkey_reject(pubkey: &Pubkey, set: &FoldHashSet<Pubkey>) -> FilterLimitsCheckResult {
         if !set.contains(pubkey) {
             Ok(())
         } else {
@@ -72,10 +72,10 @@ pub struct FilterLimitsAccounts {
     pub any: bool,
     pub account_max: usize,
     #[serde(deserialize_with = "deserialize_pubkey_set")]
-    pub account_reject: HashSet<Pubkey>,
+    pub account_reject: FoldHashSet<Pubkey>,
     pub owner_max: usize,
     #[serde(deserialize_with = "deserialize_pubkey_set")]
-    pub owner_reject: HashSet<Pubkey>,
+    pub owner_reject: FoldHashSet<Pubkey>,
     pub data_slice_max: usize,
     pub cuckoo_max_size: usize,
 }
@@ -86,9 +86,9 @@ impl Default for FilterLimitsAccounts {
             max: usize::MAX,
             any: true,
             account_max: usize::MAX,
-            account_reject: HashSet::new(),
+            account_reject: FoldHashSet::new(),
             owner_max: usize::MAX,
-            owner_reject: HashSet::new(),
+            owner_reject: FoldHashSet::new(),
             data_slice_max: usize::MAX,
             cuckoo_max_size: usize::MAX,
         }
@@ -117,7 +117,7 @@ pub struct FilterLimitsTransactions {
     #[serde(deserialize_with = "deserialize_usize_str")]
     pub account_include_max: usize,
     #[serde(deserialize_with = "deserialize_pubkey_set")]
-    pub account_include_reject: HashSet<Pubkey>,
+    pub account_include_reject: FoldHashSet<Pubkey>,
     #[serde(deserialize_with = "deserialize_usize_str")]
     pub account_exclude_max: usize,
     #[serde(deserialize_with = "deserialize_usize_str")]
@@ -130,7 +130,7 @@ impl Default for FilterLimitsTransactions {
             max: usize::MAX,
             any: true,
             account_include_max: usize::MAX,
-            account_include_reject: HashSet::new(),
+            account_include_reject: FoldHashSet::new(),
             account_exclude_max: usize::MAX,
             account_required_max: usize::MAX,
         }
@@ -146,7 +146,7 @@ pub struct FilterLimitsBlocks {
     pub account_include_max: usize,
     pub account_include_any: bool,
     #[serde(deserialize_with = "deserialize_pubkey_set")]
-    pub account_include_reject: HashSet<Pubkey>,
+    pub account_include_reject: FoldHashSet<Pubkey>,
     pub include_transactions: bool,
     pub include_accounts: bool,
     pub include_entries: bool,
@@ -160,7 +160,7 @@ impl Default for FilterLimitsBlocks {
             max: usize::MAX,
             account_include_max: usize::MAX,
             account_include_any: true,
-            account_include_reject: HashSet::new(),
+            account_include_reject: FoldHashSet::new(),
             include_transactions: true,
             include_accounts: true,
             include_entries: true,
@@ -204,7 +204,7 @@ pub struct FilterLimitsDeshredTransactions {
     #[serde(deserialize_with = "deserialize_usize_str")]
     pub account_include_max: usize,
     #[serde(deserialize_with = "deserialize_pubkey_set")]
-    pub account_include_reject: HashSet<Pubkey>,
+    pub account_include_reject: FoldHashSet<Pubkey>,
     #[serde(deserialize_with = "deserialize_usize_str")]
     pub account_exclude_max: usize,
     #[serde(deserialize_with = "deserialize_usize_str")]
@@ -217,7 +217,7 @@ impl Default for FilterLimitsDeshredTransactions {
             max: usize::MAX,
             any: true,
             account_include_max: usize::MAX,
-            account_include_reject: HashSet::new(),
+            account_include_reject: FoldHashSet::new(),
             account_exclude_max: usize::MAX,
             account_required_max: usize::MAX,
         }
@@ -244,7 +244,7 @@ where
     }
 }
 
-fn deserialize_pubkey_set<'de, D>(deserializer: D) -> Result<HashSet<Pubkey>, D::Error>
+fn deserialize_pubkey_set<'de, D>(deserializer: D) -> Result<FoldHashSet<Pubkey>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/yellowstone-grpc-geyser/src/plugin/filter/limits.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/limits.rs
@@ -1,7 +1,7 @@
 use {
+    foldhash::{HashSet as FoldHashSet, HashSetExt},
     serde::{de, Deserialize, Deserializer},
     solana_pubkey::Pubkey,
-    foldhash::{HashSet as FoldHashSet, HashSetExt},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -56,7 +56,10 @@ impl FilterLimits {
         }
     }
 
-    pub fn check_pubkey_reject(pubkey: &Pubkey, set: &FoldHashSet<Pubkey>) -> FilterLimitsCheckResult {
+    pub fn check_pubkey_reject(
+        pubkey: &Pubkey,
+        set: &FoldHashSet<Pubkey>,
+    ) -> FilterLimitsCheckResult {
         if !set.contains(pubkey) {
             Ok(())
         } else {

--- a/yellowstone-grpc-geyser/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/message.rs
@@ -2,7 +2,11 @@ use {
     crate::{
         metrics,
         plugin::{
-            filter::{name::FilterName, FilterAccountsDataSlice},
+            filter::{
+                encoder::{AccountEncoder, TransactionEncoder},
+                name::FilterName,
+                FilterAccountsDataSlice,
+            },
             message::{
                 MessageAccount, MessageAccountInfo, MessageBlock, MessageBlockMeta,
                 MessageDeshredTransaction, MessageDeshredTransactionInfo, MessageEntry,
@@ -489,6 +493,12 @@ impl prost::Message for FilteredUpdateAccount {
     }
 }
 
+fn account_return_encoded(pre_encoded: &Vec<u8>, tag: u32, buf: &mut impl BufMut) {
+    encode_key(tag, WireType::LengthDelimited, buf);
+    encode_varint(pre_encoded.len() as u64, buf);
+    buf.put_slice(pre_encoded);
+}
+
 impl FilteredUpdateAccount {
     fn account_encode_raw(
         tag: u32,
@@ -500,12 +510,19 @@ impl FilteredUpdateAccount {
         if data_slice.as_ref().is_empty() {
             if let Some(pre_encoded) = account.get_pre_encoded() {
                 metrics::pre_encoded_cache_hit("account");
-                encode_key(tag, WireType::LengthDelimited, buf);
-                encode_varint(pre_encoded.len() as u64, buf);
-                buf.put_slice(pre_encoded);
+                account_return_encoded(pre_encoded, tag, buf);
                 return;
+            } else {
+                // lazyily pre-encode the account for future use
+                AccountEncoder::pre_encode(account);
+
+                metrics::pre_encoded_cache_miss("account");
+
+                if let Some(pre_encoded) = account.get_pre_encoded() {
+                    account_return_encoded(pre_encoded, tag, buf);
+                    return;
+                }
             }
-            metrics::pre_encoded_cache_miss("account");
         }
 
         // fallback: slice-aware encoding
@@ -691,15 +708,29 @@ impl prost::Message for FilteredUpdateTransaction {
     }
 }
 
+fn transaction_return_encoded(pre_encoded: &Vec<u8>, tag: u32, buf: &mut impl BufMut) {
+    encode_key(tag, WireType::LengthDelimited, buf);
+    encode_varint(pre_encoded.len() as u64, buf);
+    buf.put_slice(pre_encoded);
+}
+
 impl FilteredUpdateTransaction {
     fn tx_encode_raw(tag: u32, tx: &MessageTransactionInfo, buf: &mut impl BufMut) {
         // try to use pre-encoded bytes (fast path)
         if let Some(pre_encoded) = tx.get_pre_encoded() {
             metrics::pre_encoded_cache_hit("txn");
-            encode_key(tag, WireType::LengthDelimited, buf);
-            encode_varint(pre_encoded.len() as u64, buf);
-            buf.put_slice(pre_encoded);
+            transaction_return_encoded(pre_encoded, tag, buf);
             return;
+        } else {
+            // lazyly pre-encode the transaction for future use
+            TransactionEncoder::pre_encode(tx);
+
+            metrics::pre_encoded_cache_miss("txn");
+
+            if let Some(pre_encoded) = tx.get_pre_encoded() {
+                transaction_return_encoded(pre_encoded, tag, buf);
+                return;
+            }
         }
 
         metrics::pre_encoded_cache_miss("txn");

--- a/yellowstone-grpc-geyser/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/message.rs
@@ -493,7 +493,7 @@ impl prost::Message for FilteredUpdateAccount {
     }
 }
 
-fn account_return_encoded(pre_encoded: &Vec<u8>, tag: u32, buf: &mut impl BufMut) {
+fn account_return_encoded(pre_encoded: &[u8], tag: u32, buf: &mut impl BufMut) {
     encode_key(tag, WireType::LengthDelimited, buf);
     encode_varint(pre_encoded.len() as u64, buf);
     buf.put_slice(pre_encoded);
@@ -708,7 +708,7 @@ impl prost::Message for FilteredUpdateTransaction {
     }
 }
 
-fn transaction_return_encoded(pre_encoded: &Vec<u8>, tag: u32, buf: &mut impl BufMut) {
+fn transaction_return_encoded(pre_encoded: &[u8], tag: u32, buf: &mut impl BufMut) {
     encode_key(tag, WireType::LengthDelimited, buf);
     encode_varint(pre_encoded.len() as u64, buf);
     buf.put_slice(pre_encoded);

--- a/yellowstone-grpc-geyser/src/plugin/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/message.rs
@@ -681,7 +681,7 @@ impl MessageBlock {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Message {
-    Slot(MessageSlot),
+    Slot(Arc<MessageSlot>),
     Account(MessageAccount),
     Transaction(MessageTransaction),
     DeshredTransaction(MessageDeshredTransaction),
@@ -719,7 +719,9 @@ impl Message {
             UpdateOneof::Account(msg) => {
                 Self::Account(MessageAccount::from_update_oneof(msg, created_at)?)
             }
-            UpdateOneof::Slot(msg) => Self::Slot(MessageSlot::from_update_oneof(&msg, created_at)?),
+            UpdateOneof::Slot(msg) => {
+                Self::Slot(Arc::new(MessageSlot::from_update_oneof(&msg, created_at)?))
+            }
             UpdateOneof::Transaction(msg) => {
                 Self::Transaction(MessageTransaction::from_update_oneof(msg, created_at)?)
             }


### PR DESCRIPTION
Optimized geyser_loop by not pre-encoding all messages aggressively when not all messages are guaranteed to be sent to downstream subscribers, instead do it on a first visit basis while delivering to subscribers

Introduced Single/Batch for Replay messages to avoid cloning the messages of a slot

Wrap MessageSlot in an Arc to reduce overall size of 'Message' to 40 bytes down from 80, reducing amount of memory required during copy and allocate

Removed 'yellowstone_grpc_geyser_batch_size' metric due to geyser_loop overhead and unnecessary tracking