### PR TITLE
geyser: fix missing `Message::Block` in `from_slot` replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+### Fixes
+
+- Fixed `from_slot` replay never delivering `Message::Block`: subscribers with a `blocks` filter had their replay request accepted but received zero replayed messages (the filter matches none of the raw Account/Transaction/Entry/BlockMeta messages), silently resuming from the live head with a state gap. Replay now emits the precomputed block message between block content and `BlockMeta`, mirroring the live broadcast path. Regression from [#750](https://github.com/rpcpool/yellowstone-grpc/pull/750); the fix was originally part of [#810](https://github.com/rpcpool/yellowstone-grpc/pull/810) but was not imported by [#809](https://github.com/rpcpool/yellowstone-grpc/pull/809). Closes [#830](https://github.com/rpcpool/yellowstone-grpc/issues/830).
+
 ## 2026-07-08
 
 - yellowstone-grpc-geyser 14.2.0

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1364,7 +1364,9 @@ impl GrpcService {
                         // 1st Put data (account/txn/entries)
                         replayed_messages.push(ReplayResponseMessageType::Batch(replayed_slot.frozen_block.messages()));
 
-                        // 2nd Put block summary
+                        // 2nd Put the reconstructed block, then the block summary — mirrors the
+                        // live broadcast path so `blocks` subscribers can resume via `from_slot`
+                        replayed_messages.push(ReplayResponseMessageType::Single(Message::Block(replayed_slot.frozen_block.get_message_block())));
                         replayed_messages.push(ReplayResponseMessageType::Single(Message::BlockMeta(replayed_slot.frozen_block.get_block_meta())));
 
                         // 3rd Put slot status


### PR DESCRIPTION
Closes #830

### Problem

`from_slot` replay never delivers `Message::Block`. The replay handler assembles, per replayed slot, the raw `frozen_block.messages()` (Account/Transaction/Entry), a `Message::BlockMeta`, and the slot statuses — but the reconstructed block itself is never emitted (`get_message_block()` had exactly one call site: the live broadcast path).

Since `Filter::get_updates` routes strictly by message type, a subscriber with only a `blocks` filter has its `from_slot` request accepted, receives **zero** replayed messages, and silently resumes from the live head — an undetectable state gap on every reconnect. See #830 for the full analysis and production logs.

### Fix

Emit the precomputed block between block content and `BlockMeta`, mirroring the live broadcast path (`msg_block` before `block_meta`) and the documented delivery contract ("block content before `Message::Block` before slot status"). One line plus a CHANGELOG entry:

```rust
replayed_messages.push(ReplayResponseMessageType::Single(Message::Block(replayed_slot.frozen_block.get_message_block())));
```

`get_message_block()` returns the precomputed `Arc<MessageBlock>`, so this adds no reconstruction cost to replay.

### History

This is a regression from the #750 block-machine refactor (pre-#750, the sealed `Message::Block` lived in the per-slot message container that replay drained). @Ozodimgba's #810 contained this fix as part of `extend_messages()` ("Block/BlockMeta inclusion"), but #809 imported only the BlockMeta / ordering / parent_slot parts and #810 was closed — this piece never landed.

### Testing

- `cargo check -p yellowstone-grpc-geyser` clean
- `cargo test -p yellowstone-grpc-geyser`: 118 passed; the single failure (`auth::tests::repository_without_cache_hits_server_every_time`, HTTP 502 from the local mock) also fails on unpatched master in my environment and is unrelated to this change
