### PR TITLE
Fix dedup dropping messages after BlockMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+- yellowstone-grpc-client 13.2.2
+
+### Fixed
+
+- Dedup dropped every message that arrived after its slot's `BlockMeta`. Such a message was quarantined pending a second `BlockMeta` that only a replay produces, so in steady state it was never delivered. Quarantining is now limited to a replay window, opened on reconnect and closed once the stream passes the highest slot known at that point. Outside the window a late message, notably the freeze-time account writes noted on 2026-07-24, is forwarded. Anything still held when the window closes is released.
+- `DedupState.sealed` grew without bound. A slot whose first message is `BlockMeta` was never added to `slot_order`, and `prune()` only evicts what it pops from there. Affects subscriptions where no payload precedes `block_meta` for a slot, such as blocks_meta-only.
+- `DedupKey` was positional for transactions, transaction statuses and entries, and keyed blocks on the slot, so two blocks for one slot produced colliding keys. Keys are now content-addressed by signature, entry hash, blockhash and account `write_version`. This also stops separate writes to one account within a slot being collapsed into one.
+- Slots still in flight at reconnect lost their delivered keys, leaving no blockhash to compare against, so their replayed content was flushed wholesale and re-delivered as duplicates. The keys now survive promotion, and the first `BlockMeta` seen for such a slot is delivered rather than consumed as a replay verdict.
+- After a replay verdict settled, further replayed payloads for that slot were quarantined again and flushed as duplicates. They are now deduped against what was delivered, so content the disconnect cut off still reaches the user.
+
+### Misc
+
+- Added end-to-end reconnect coverage driving the client against an in-process gRPC server across forced disconnects, sweeping the disconnect point over the message timeline and asserting no loss and no duplicates.
+
 ## 2026-07-24
 
 - yellowstone-grpc-geyser 14.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "13.2.1"
+version = "13.2.2"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,6 +6303,7 @@ dependencies = [
  "pin-project",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-health",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.9.0", default-features = false }
 yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.2.2" }
-yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.2.1" }
+yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.2.2" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -34,7 +34,8 @@ tower = { workspace = true, features = ["util"] }
 yellowstone-grpc-proto = { workspace = true, features = ["tonic", "tonic-compression"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
+tokio-stream = { workspace = true, features = ["net"] }
 
 [lints]
 workspace = true

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "13.2.1"
+version = "13.2.2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Simple Client"

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -1,7 +1,7 @@
 use {
     futures::stream::{Stream, StreamExt},
     std::{
-        collections::{HashMap, HashSet, VecDeque},
+        collections::{BTreeMap, HashMap, HashSet, VecDeque},
         task::Poll,
     },
     tonic::Status,
@@ -26,25 +26,76 @@ pub(crate) enum Observation {
     ReplayComplete { same: bool },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    Pending,
+    SameBlock,
+    NewBlock,
+}
+
 #[derive(Debug, Clone)]
 struct SealedSlot {
     blockhash: Option<String>,
     statuses: HashSet<i32>,
+    delivered: HashSet<DedupKey>,
+    verdict: Verdict,
 }
 
-struct ReplayBuffer<T> {
-    quarantine: HashMap<u64, Vec<T>>,
-    flush_queue: VecDeque<T>,
-}
-
-impl<T> ReplayBuffer<T> {
-    fn new() -> Self {
+impl SealedSlot {
+    fn sealed(blockhash: String, statuses: HashSet<i32>) -> Self {
         Self {
-            quarantine: HashMap::new(),
-            flush_queue: VecDeque::new(),
+            blockhash: Some(blockhash),
+            statuses,
+            delivered: HashSet::new(),
+            verdict: Verdict::Pending,
         }
     }
 
+    fn partial() -> Self {
+        Self {
+            blockhash: None,
+            statuses: HashSet::new(),
+            delivered: HashSet::new(),
+            verdict: Verdict::Pending,
+        }
+    }
+
+    fn absorb(&mut self, state: SlotState) {
+        self.statuses.extend(state.statuses);
+        self.delivered.extend(state.keys);
+    }
+
+    fn dedup_delivered(&mut self, payload: DedupKey) -> Observation {
+        if self.delivered.insert(payload) {
+            Observation::New
+        } else {
+            Observation::Duplicate
+        }
+    }
+
+    fn observe_replayed(&mut self, payload: DedupKey) -> Observation {
+        match self.verdict {
+            Verdict::Pending if self.blockhash.is_some() => Observation::Replay,
+            _ => self.dedup_delivered(payload),
+        }
+    }
+}
+
+struct ReplayBuffer<T> {
+    quarantine: BTreeMap<u64, Vec<T>>,
+    flush_queue: VecDeque<T>,
+}
+
+impl<T> Default for ReplayBuffer<T> {
+    fn default() -> Self {
+        Self {
+            quarantine: BTreeMap::new(),
+            flush_queue: VecDeque::new(),
+        }
+    }
+}
+
+impl<T> ReplayBuffer<T> {
     fn hold(&mut self, slot: u64, msg: T) {
         self.quarantine.entry(slot).or_default().push(msg);
     }
@@ -58,6 +109,16 @@ impl<T> ReplayBuffer<T> {
 
     fn discard(&mut self, slot: u64) {
         self.quarantine.remove(&slot);
+    }
+
+    fn flush_all(&mut self) {
+        for (_, buffered) in std::mem::take(&mut self.quarantine) {
+            self.flush_queue.extend(buffered);
+        }
+    }
+
+    fn enqueue(&mut self, msg: T) {
+        self.flush_queue.push_back(msg);
     }
 
     fn drain_next(&mut self) -> Option<T> {
@@ -77,7 +138,7 @@ impl<S, T> DedupStream<S, T> {
         Self {
             state,
             inner,
-            replay: ReplayBuffer::new(),
+            replay: ReplayBuffer::default(),
         }
     }
 }
@@ -102,22 +163,33 @@ where
             match this.inner.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(msg))) => match msg.extract_key() {
                     None => return Poll::Ready(Some(Ok(msg))),
-                    Some((slot, key)) => match this.state.observe(slot, key) {
-                        Observation::New => return Poll::Ready(Some(Ok(msg))),
-                        Observation::Duplicate => continue,
-                        Observation::Replay => {
-                            this.replay.hold(slot, msg);
-                            continue;
+                    Some((slot, key)) => {
+                        let released = this.state.finish_replay_if_past(slot);
+                        if released {
+                            this.replay.flush_all();
                         }
-                        Observation::ReplayComplete { same: true } => {
-                            this.replay.discard(slot);
-                            continue;
+
+                        match this.state.observe(slot, key) {
+                            Observation::New if released => {
+                                this.replay.enqueue(msg);
+                                continue;
+                            }
+                            Observation::New => return Poll::Ready(Some(Ok(msg))),
+                            Observation::Duplicate => continue,
+                            Observation::Replay => {
+                                this.replay.hold(slot, msg);
+                                continue;
+                            }
+                            Observation::ReplayComplete { same: true } => {
+                                this.replay.discard(slot);
+                                continue;
+                            }
+                            Observation::ReplayComplete { same: false } => {
+                                this.replay.flush(slot, msg);
+                                continue;
+                            }
                         }
-                        Observation::ReplayComplete { same: false } => {
-                            this.replay.flush(slot, msg);
-                            continue;
-                        }
-                    },
+                    }
                 },
                 other => return other,
             }
@@ -127,14 +199,14 @@ where
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) enum DedupKey {
-    Slot(i32),                           // status
-    Account([u8; 32], Option<[u8; 64]>), // pubkey, txn_signature
-    Transaction(u64),                    // index
-    TransactionStatus(u64),              // index
-    Entry(u64),                          // index
-    BlockMeta(String),                   // blockhash,
-    Block(u64),
-    DeshredTransaction([u8; 64]), // signature
+    Slot(i32),                                // status
+    Account([u8; 32], Option<[u8; 64]>, u64), // pubkey, txn_signature, write_version
+    Transaction([u8; 64]),                    // signature
+    TransactionStatus([u8; 64]),              // signature
+    Entry(u64, [u8; 32]),                     // index, hash
+    BlockMeta(String),                        // blockhash
+    Block(String),                            // blockhash
+    DeshredTransaction([u8; 64]),             // signature
 }
 
 #[derive(Debug, Default, Clone)]
@@ -150,6 +222,8 @@ pub struct DedupState {
     sealed: HashMap<u64, SealedSlot>,
     slot_order: VecDeque<u64>,
     slot_retention: usize,
+    replaying: bool,
+    replay_high_water: u64,
 }
 
 impl Default for DedupState {
@@ -159,6 +233,8 @@ impl Default for DedupState {
             sealed: Default::default(),
             slot_order: Default::default(),
             slot_retention: DEFAULT_SLOT_RETENTION,
+            replaying: false,
+            replay_high_water: 0,
         }
     }
 }
@@ -181,18 +257,23 @@ impl Dedupable for SubscribeUpdate {
                     .txn_signature
                     .as_ref()
                     .and_then(|s| <[u8; 64]>::try_from(s.as_slice()).ok());
-                Some((m.slot, DedupKey::Account(pubkey, sig)))
+                Some((m.slot, DedupKey::Account(pubkey, sig, info.write_version)))
             }
             UpdateOneof::Transaction(m) => {
                 let info = m.transaction.as_ref()?;
-                Some((m.slot, DedupKey::Transaction(info.index)))
+                let sig = <[u8; 64]>::try_from(info.signature.as_slice()).ok()?;
+                Some((m.slot, DedupKey::Transaction(sig)))
             }
             UpdateOneof::TransactionStatus(m) => {
-                Some((m.slot, DedupKey::TransactionStatus(m.index)))
+                let sig = <[u8; 64]>::try_from(m.signature.as_slice()).ok()?;
+                Some((m.slot, DedupKey::TransactionStatus(sig)))
             }
-            UpdateOneof::Entry(m) => Some((m.slot, DedupKey::Entry(m.index))),
+            UpdateOneof::Entry(m) => {
+                let hash = <[u8; 32]>::try_from(m.hash.as_slice()).ok()?;
+                Some((m.slot, DedupKey::Entry(m.index, hash)))
+            }
             UpdateOneof::BlockMeta(m) => Some((m.slot, DedupKey::BlockMeta(m.blockhash.clone()))),
-            UpdateOneof::Block(m) => Some((m.slot, DedupKey::Block(m.slot))),
+            UpdateOneof::Block(m) => Some((m.slot, DedupKey::Block(m.blockhash.clone()))),
             UpdateOneof::Ping(_) | UpdateOneof::Pong(_) => None,
         }
     }
@@ -265,36 +346,42 @@ impl DedupState {
             }
 
             DedupKey::BlockMeta(blockhash) => {
-                // Replayed BlockMeta for a sealed slot: this is the verdict.
-                // Compare the stored blockhash to decide whether the block changed
-                // across the reconnect. If no blockhash is stored (slot was partial
-                // when we disconnected), treat as changed and flush always.
                 if let Some(sealed) = self.sealed.get_mut(&slot) {
-                    let same = sealed.blockhash.as_ref() == Some(&blockhash);
-                    sealed.blockhash = Some(blockhash);
+                    let Some(known) = sealed.blockhash.replace(blockhash.clone()) else {
+                        sealed.verdict = Verdict::SameBlock;
+                        return Observation::New;
+                    };
+
+                    let same = known == blockhash;
+                    sealed.verdict = if same {
+                        Verdict::SameBlock
+                    } else {
+                        sealed.delivered.clear();
+                        Verdict::NewBlock
+                    };
                     return Observation::ReplayComplete { same };
                 }
 
-                // First BlockMeta for this slot: seal it. The SlotState is destroyed;
-                // only the blockhash and statuses survive in the compressed SealedSlot.
+                // `slot_mut` is the only other writer of `slot_order`, and it
+                // does not run when BlockMeta is the first message seen for a slot.
+                if !self.inflight.contains_key(&slot) {
+                    self.slot_order.push_back(slot);
+                }
                 let state = self.inflight.remove(&slot).unwrap_or_default();
-                self.sealed.insert(
-                    slot,
-                    SealedSlot {
-                        blockhash: Some(blockhash),
-                        statuses: state.statuses,
-                    },
-                );
+                self.sealed
+                    .insert(slot, SealedSlot::sealed(blockhash, state.statuses));
                 self.prune();
                 Observation::New
             }
 
             // Accounts, transactions, entries, blocks, etc.
             payload => {
-                // Sealed slot: hold for quarantine. The verdict comes when the
-                // replayed BlockMeta arrives; until then we buffer without deduping.
-                if self.sealed.contains_key(&slot) {
-                    return Observation::Replay;
+                // Outside a replay this is late data, not a repeat. Quarantining
+                // it would drop it for good: no second BlockMeta is coming.
+                if self.replaying {
+                    if let Some(sealed) = self.sealed.get_mut(&slot) {
+                        return sealed.observe_replayed(payload);
+                    }
                 }
 
                 let state = self.slot_mut(slot);
@@ -321,19 +408,39 @@ impl DedupState {
         }
     }
 
-    /// Promote all inflight slots to sealed-without-blockhash before replay.
-    /// Replayed content for these slots will be quarantined and flushed at
-    /// BlockMeta (no stored blockhash to compare, so always flush).
+    /// Promotes inflight slots to sealed and opens the replay window.
     pub(crate) fn prepare_for_replay(&mut self) {
         for (slot, state) in self.inflight.drain() {
-            self.sealed.insert(
-                slot,
-                SealedSlot {
-                    blockhash: None,
-                    statuses: state.statuses,
-                },
-            );
+            self.sealed
+                .entry(slot)
+                .or_insert_with(SealedSlot::partial)
+                .absorb(state);
         }
+
+        for sealed in self.sealed.values_mut() {
+            sealed.verdict = Verdict::Pending;
+        }
+
+        self.replaying = true;
+        self.replay_high_water = self
+            .sealed
+            .keys()
+            .copied()
+            .max()
+            .unwrap_or(self.replay_high_water);
+    }
+
+    /// Closes the replay window. Returns true on the transition, so the caller
+    /// can release whatever is still quarantined.
+    pub(crate) fn finish_replay_if_past(&mut self, slot: u64) -> bool {
+        if !self.replaying || slot <= self.replay_high_water {
+            return false;
+        }
+        self.replaying = false;
+        for sealed in self.sealed.values_mut() {
+            sealed.delivered = HashSet::new();
+        }
+        true
     }
 
     pub(crate) fn clear_slot(&mut self, slot: u64) {
@@ -404,6 +511,37 @@ mod tests {
             )),
             created_at: None,
         }
+    }
+
+    fn make_tx_msg(slot: u64, index: u64, signature_byte: u8) -> SubscribeUpdate {
+        SubscribeUpdate {
+            filters: vec![],
+            update_oneof: Some(UpdateOneof::Transaction(
+                yellowstone_grpc_proto::prelude::SubscribeUpdateTransaction {
+                    transaction: Some(
+                        yellowstone_grpc_proto::prelude::SubscribeUpdateTransactionInfo {
+                            signature: vec![signature_byte; 64],
+                            is_vote: false,
+                            transaction: None,
+                            meta: None,
+                            index,
+                        },
+                    ),
+                    slot,
+                },
+            )),
+            created_at: None,
+        }
+    }
+
+    fn make_account_msg_with_pubkey(slot: u64, pubkey_byte: u8) -> SubscribeUpdate {
+        let mut msg = make_account_msg(slot);
+        if let Some(UpdateOneof::Account(account)) = msg.update_oneof.as_mut() {
+            if let Some(info) = account.account.as_mut() {
+                info.pubkey = vec![pubkey_byte; 32];
+            }
+        }
+        msg
     }
 
     fn make_account_msg(slot: u64) -> SubscribeUpdate {
@@ -582,11 +720,26 @@ mod tests {
         observe(&mut dedup, &make_slot_msg(300, 0));
         observe(&mut dedup, &make_block_meta_msg(300));
 
+        dedup.prepare_for_replay();
+
         // a replayed account for a sealed slot should be quarantined
         let account_msg = make_account_msg(300);
         assert!(matches!(
             observe(&mut dedup, &account_msg),
             Observation::Replay
+        ));
+    }
+
+    #[test]
+    fn test_late_payload_outside_replay_window_is_not_quarantined() {
+        let mut dedup = DedupState::default();
+
+        observe(&mut dedup, &make_slot_msg(300, 0));
+        observe(&mut dedup, &make_block_meta_msg(300));
+
+        assert!(matches!(
+            observe(&mut dedup, &make_account_msg(300)),
+            Observation::New
         ));
     }
 
@@ -621,37 +774,184 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_for_replay_promotes_partial_to_sealed() {
+    fn test_partial_slot_replay_dedups_on_delivered_keys() {
         let mut dedup = DedupState::default();
 
-        // slot 600 is inflight (no BlockMeta yet)
         observe(&mut dedup, &make_slot_msg(600, 0));
+        observe(&mut dedup, &make_account_msg(600));
 
         // simulate reconnect: promote all inflight to sealed-without-blockhash
         dedup.prepare_for_replay();
 
-        // replayed payload for the now-sealed slot should be quarantined
-        let account_msg = make_account_msg(600);
         assert!(matches!(
-            observe(&mut dedup, &account_msg),
-            Observation::Replay
+            observe(&mut dedup, &make_account_msg(600)),
+            Observation::Duplicate
+        ));
+
+        let unseen = make_account_msg_with_pubkey(600, 7);
+        assert!(matches!(observe(&mut dedup, &unseen), Observation::New));
+    }
+
+    #[test]
+    fn test_equivocated_partial_slot_delivers_new_block_content() {
+        let mut dedup = DedupState::default();
+
+        observe(&mut dedup, &make_slot_msg(900, 0));
+        observe(&mut dedup, &make_tx_msg(900, 0, 0xAA));
+
+        dedup.prepare_for_replay();
+
+        assert!(matches!(
+            observe(&mut dedup, &make_tx_msg(900, 0, 0xBB)),
+            Observation::New
+        ));
+
+        assert!(matches!(
+            observe(&mut dedup, &make_tx_msg(900, 0, 0xAA)),
+            Observation::Duplicate
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_released_backlog_is_emitted_before_the_newer_message() {
+        let mut state = DedupState::default();
+        observe(&mut state, &make_slot_msg(200, 0));
+        observe(&mut state, &make_block_meta_msg_with_hash(200, "h200"));
+        state.prepare_for_replay();
+
+        let messages = vec![Ok(make_account_msg(200)), Ok(make_slot_msg(201, 0))];
+
+        let inner = stream::iter(messages).boxed();
+        let got: Vec<_> = DedupStream::new(inner, state)
+            .filter_map(|r| async move { r.ok() })
+            .collect()
+            .await;
+
+        assert_eq!(got.len(), 2);
+        assert!(
+            matches!(got[0].update_oneof.as_ref(), Some(UpdateOneof::Account(_))),
+            "expected the released backlog first, got {:?}",
+            got[0].update_oneof
+        );
+        assert!(matches!(
+            got[1].update_oneof.as_ref(),
+            Some(UpdateOneof::Slot(_))
         ));
     }
 
     #[test]
-    fn test_partial_slot_always_flushes_on_replay_complete() {
+    fn test_partial_slot_block_meta_is_new_not_a_verdict() {
         let mut dedup = DedupState::default();
 
-        // slot 700 is inflight
         observe(&mut dedup, &make_slot_msg(700, 0));
-
-        // promote to sealed without blockhash
         dedup.prepare_for_replay();
 
-        // replayed BlockMeta: no stored hash to compare, always flush
         assert!(matches!(
             observe(&mut dedup, &make_block_meta_msg_with_hash(700, "any_hash")),
-            Observation::ReplayComplete { same: false }
+            Observation::New
+        ));
+    }
+
+    #[test]
+    fn test_post_block_meta_replay_is_deduped_not_blanket_dropped() {
+        let mut dedup = DedupState::default();
+
+        observe(&mut dedup, &make_slot_msg(800, 0));
+        observe(&mut dedup, &make_block_meta_msg_with_hash(800, "h800"));
+        observe(&mut dedup, &make_account_msg(800));
+
+        dedup.prepare_for_replay();
+
+        assert!(matches!(
+            observe(&mut dedup, &make_block_meta_msg_with_hash(800, "h800")),
+            Observation::ReplayComplete { same: true }
+        ));
+
+        assert!(matches!(
+            observe(&mut dedup, &make_account_msg(800)),
+            Observation::Duplicate
+        ));
+        assert!(matches!(
+            observe(&mut dedup, &make_account_msg_with_pubkey(800, 9)),
+            Observation::New
+        ));
+    }
+
+    #[test]
+    fn test_block_meta_only_slots_are_pruned() {
+        let mut dedup = DedupState::with_slot_retention(3);
+
+        for slot in 1..=10 {
+            observe(&mut dedup, &make_block_meta_msg(slot));
+        }
+
+        assert!(
+            dedup.sealed.len() <= 3,
+            "sealed grew past the retention window: {} entries",
+            dedup.sealed.len()
+        );
+        assert!(
+            !dedup.sealed.contains_key(&1),
+            "slot 1 should have been pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_late_payload_is_forwarded_in_steady_state() {
+        let messages = vec![
+            Ok(make_slot_msg(100, 0)),
+            Ok(make_block_meta_msg(100)),
+            Ok(make_account_msg(100)),
+            Ok(make_slot_msg(101, 0)),
+        ];
+
+        let inner = stream::iter(messages).boxed();
+        let got: Vec<_> = DedupStream::new(inner, DedupState::default())
+            .filter_map(|r| async move { r.ok() })
+            .collect()
+            .await;
+
+        assert_eq!(got.len(), 4, "late account update was dropped");
+        assert!(matches!(
+            got[2].update_oneof.as_ref(),
+            Some(UpdateOneof::Account(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_replay_window_closes_and_releases_quarantine() {
+        let mut state = DedupState::default();
+        observe(&mut state, &make_slot_msg(200, 0));
+        observe(&mut state, &make_block_meta_msg(200));
+        state.prepare_for_replay();
+
+        let messages = vec![Ok(make_account_msg(200)), Ok(make_slot_msg(201, 0))];
+
+        let inner = stream::iter(messages).boxed();
+        let got: Vec<_> = DedupStream::new(inner, state)
+            .filter_map(|r| async move { r.ok() })
+            .collect()
+            .await;
+
+        assert_eq!(
+            got.len(),
+            2,
+            "quarantined message was never released after the replay window closed"
+        );
+    }
+
+    #[test]
+    fn test_prepare_for_replay_keeps_known_blockhash() {
+        let mut dedup = DedupState::default();
+
+        observe(&mut dedup, &make_block_meta_msg_with_hash(300, "abc"));
+        observe(&mut dedup, &make_account_msg(300));
+
+        dedup.prepare_for_replay();
+
+        assert!(matches!(
+            observe(&mut dedup, &make_block_meta_msg_with_hash(300, "abc")),
+            Observation::ReplayComplete { same: true }
         ));
     }
 

--- a/yellowstone-grpc-client/tests/reconnect_e2e.rs
+++ b/yellowstone-grpc-client/tests/reconnect_e2e.rs
@@ -1,0 +1,517 @@
+//! Auto-reconnect and dedup over a real gRPC transport.
+//!
+//! Drives `GeyserGrpcClient` against an in-process Geyser server through forced
+//! disconnects. The server replays from the requested `from_slot`, so the client
+//! receives real duplicates and must suppress them without dropping anything.
+//!
+//! Each slot emits: account(wv=1), transaction, block_meta, account(wv=2),
+//! slot_status. The account after block_meta models a freeze-time write.
+
+use {
+    futures::StreamExt,
+    std::{
+        collections::HashMap,
+        net::SocketAddr,
+        pin::Pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+        time::Duration,
+    },
+    tokio::time::timeout,
+    tokio_stream::wrappers::TcpListenerStream,
+    tonic::{transport::Server, Request, Response, Status, Streaming},
+    yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig},
+    yellowstone_grpc_proto::{
+        geyser::{
+            geyser_server::{Geyser, GeyserServer},
+            SubscribeUpdateAccount, SubscribeUpdateAccountInfo,
+        },
+        prelude::{
+            subscribe_update::UpdateOneof, GetBlockHeightRequest, GetBlockHeightResponse,
+            GetLatestBlockhashRequest, GetLatestBlockhashResponse, GetSlotRequest, GetSlotResponse,
+            GetVersionRequest, GetVersionResponse, IsBlockhashValidRequest,
+            IsBlockhashValidResponse, PingRequest, PongResponse, SubscribeDeshredRequest,
+            SubscribeReplayInfoRequest, SubscribeReplayInfoResponse, SubscribeRequest,
+            SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta, SubscribeUpdate,
+            SubscribeUpdateBlockMeta, SubscribeUpdateDeshred, SubscribeUpdateSlot,
+            SubscribeUpdateTransaction, SubscribeUpdateTransactionInfo,
+        },
+    },
+};
+
+const FIRST_SLOT: u64 = 1_000;
+const LAST_SLOT: u64 = 1_040;
+
+type MsgId = (u64, &'static str, u64);
+
+fn identify(u: &SubscribeUpdate) -> Option<MsgId> {
+    match u.update_oneof.as_ref()? {
+        UpdateOneof::Account(m) => Some((m.slot, "account", m.account.as_ref()?.write_version)),
+        UpdateOneof::Transaction(m) => Some((m.slot, "transaction", m.transaction.as_ref()?.index)),
+        UpdateOneof::BlockMeta(m) => Some((m.slot, "block_meta", 0)),
+        UpdateOneof::Slot(m) => Some((m.slot, "slot_status", m.status as u64)),
+        _ => None,
+    }
+}
+
+fn account(slot: u64, write_version: u64, filters: &[&str]) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: filters.iter().map(|s| (*s).to_string()).collect(),
+        update_oneof: Some(UpdateOneof::Account(SubscribeUpdateAccount {
+            account: Some(SubscribeUpdateAccountInfo {
+                pubkey: vec![(write_version % 251) as u8; 32],
+                lamports: 1,
+                owner: vec![0; 32],
+                executable: false,
+                rent_epoch: 0,
+                data: vec![].into(),
+                write_version,
+                txn_signature: None,
+            }),
+            slot,
+            is_startup: false,
+        })),
+        created_at: None,
+    }
+}
+
+fn transaction(slot: u64, index: u64, filters: &[&str]) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: filters.iter().map(|s| (*s).to_string()).collect(),
+        update_oneof: Some(UpdateOneof::Transaction(SubscribeUpdateTransaction {
+            transaction: Some(SubscribeUpdateTransactionInfo {
+                signature: vec![(slot % 251) as u8; 64],
+                is_vote: false,
+                transaction: None,
+                meta: None,
+                index,
+            }),
+            slot,
+        })),
+        created_at: None,
+    }
+}
+
+fn block_meta(slot: u64, filters: &[&str]) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: filters.iter().map(|s| (*s).to_string()).collect(),
+        update_oneof: Some(UpdateOneof::BlockMeta(SubscribeUpdateBlockMeta {
+            slot,
+            blockhash: format!("hash-{slot}"),
+            parent_slot: slot - 1,
+            ..Default::default()
+        })),
+        created_at: None,
+    }
+}
+
+fn slot_status(slot: u64, filters: &[&str]) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: filters.iter().map(|s| (*s).to_string()).collect(),
+        update_oneof: Some(UpdateOneof::Slot(SubscribeUpdateSlot {
+            slot,
+            parent: Some(slot - 1),
+            status: 0,
+            dead_error: None,
+        })),
+        created_at: None,
+    }
+}
+
+#[derive(Clone)]
+struct Script {
+    payload_filter: String,
+    control_filter: String,
+}
+
+impl Script {
+    fn messages_for_slot(&self, slot: u64) -> Vec<SubscribeUpdate> {
+        let p = self.payload_filter.as_str();
+        let c = self.control_filter.as_str();
+        vec![
+            account(slot, slot * 10 + 1, &[p]),
+            transaction(slot, 0, &[p]),
+            block_meta(slot, &[c]),
+            account(slot, slot * 10 + 2, &[p]),
+            slot_status(slot, &[c]),
+        ]
+    }
+}
+
+struct MockGeyser {
+    script: Script,
+    abort_after: Vec<Option<usize>>,
+    connections: Arc<AtomicUsize>,
+    from_slots: Arc<Mutex<Vec<Option<u64>>>>,
+}
+
+type UpdateStream = Pin<Box<dyn futures::Stream<Item = Result<SubscribeUpdate, Status>> + Send>>;
+
+#[tonic::async_trait]
+impl Geyser for MockGeyser {
+    type SubscribeStream = UpdateStream;
+    type SubscribeDeshredStream =
+        Pin<Box<dyn futures::Stream<Item = Result<SubscribeUpdateDeshred, Status>> + Send>>;
+
+    async fn subscribe(
+        &self,
+        request: Request<Streaming<SubscribeRequest>>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let mut inbound = request.into_inner();
+        let first = inbound
+            .next()
+            .await
+            .ok_or_else(|| Status::invalid_argument("no subscribe request"))??;
+
+        let conn = self.connections.fetch_add(1, Ordering::SeqCst);
+        self.from_slots
+            .lock()
+            .expect("from_slots poisoned")
+            .push(first.from_slot);
+
+        let start = first.from_slot.unwrap_or(FIRST_SLOT).max(FIRST_SLOT);
+        let abort_after = self.abort_after.get(conn).copied().flatten();
+        let script = self.script.clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        tokio::spawn(async move {
+            let mut sent = 0usize;
+            'outer: for slot in start..=LAST_SLOT {
+                for msg in script.messages_for_slot(slot) {
+                    if let Some(limit) = abort_after {
+                        if sent >= limit {
+                            let _ = tx
+                                .send(Err(Status::unavailable("simulated disconnect")))
+                                .await;
+                            return;
+                        }
+                    }
+                    sent += 1;
+                    if tx.send(Ok(msg)).await.is_err() {
+                        break 'outer;
+                    }
+                }
+            }
+            // Keep the stream open without a clean EOF until the client leaves.
+            tx.closed().await;
+        });
+
+        Ok(Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
+    }
+
+    async fn subscribe_deshred(
+        &self,
+        _r: Request<Streaming<SubscribeDeshredRequest>>,
+    ) -> Result<Response<Self::SubscribeDeshredStream>, Status> {
+        Err(Status::unimplemented("not used"))
+    }
+    async fn subscribe_replay_info(
+        &self,
+        _r: Request<SubscribeReplayInfoRequest>,
+    ) -> Result<Response<SubscribeReplayInfoResponse>, Status> {
+        Ok(Response::new(SubscribeReplayInfoResponse {
+            first_available: Some(FIRST_SLOT),
+        }))
+    }
+    async fn ping(&self, _r: Request<PingRequest>) -> Result<Response<PongResponse>, Status> {
+        Ok(Response::new(PongResponse { count: 1 }))
+    }
+    async fn get_latest_blockhash(
+        &self,
+        _r: Request<GetLatestBlockhashRequest>,
+    ) -> Result<Response<GetLatestBlockhashResponse>, Status> {
+        Err(Status::unimplemented("not used"))
+    }
+    async fn get_block_height(
+        &self,
+        _r: Request<GetBlockHeightRequest>,
+    ) -> Result<Response<GetBlockHeightResponse>, Status> {
+        Err(Status::unimplemented("not used"))
+    }
+    async fn get_slot(
+        &self,
+        _r: Request<GetSlotRequest>,
+    ) -> Result<Response<GetSlotResponse>, Status> {
+        Err(Status::unimplemented("not used"))
+    }
+    async fn is_blockhash_valid(
+        &self,
+        _r: Request<IsBlockhashValidRequest>,
+    ) -> Result<Response<IsBlockhashValidResponse>, Status> {
+        Err(Status::unimplemented("not used"))
+    }
+    async fn get_version(
+        &self,
+        _r: Request<GetVersionRequest>,
+    ) -> Result<Response<GetVersionResponse>, Status> {
+        Ok(Response::new(GetVersionResponse {
+            version: "test".to_string(),
+        }))
+    }
+}
+
+struct Harness {
+    addr: SocketAddr,
+    connections: Arc<AtomicUsize>,
+    from_slots: Arc<Mutex<Vec<Option<u64>>>>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+async fn spawn_server(script: Script, abort_after: Vec<Option<usize>>) -> Harness {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+
+    let connections = Arc::new(AtomicUsize::new(0));
+    let from_slots = Arc::new(Mutex::new(Vec::new()));
+
+    let service = MockGeyser {
+        script,
+        abort_after,
+        connections: Arc::clone(&connections),
+        from_slots: Arc::clone(&from_slots),
+    };
+
+    let server = tokio::spawn(async move {
+        let _ = Server::builder()
+            .add_service(GeyserServer::new(service))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    Harness {
+        addr,
+        connections,
+        from_slots,
+        server,
+    }
+}
+
+fn expected_ids(script: &Script, user_sees_control: bool) -> Vec<MsgId> {
+    let mut out = Vec::new();
+    for slot in FIRST_SLOT..=LAST_SLOT {
+        for msg in script.messages_for_slot(slot) {
+            let is_control = matches!(
+                msg.update_oneof.as_ref(),
+                Some(UpdateOneof::BlockMeta(_)) | Some(UpdateOneof::Slot(_))
+            );
+            if is_control && !user_sees_control {
+                continue;
+            }
+            out.push(identify(&msg).expect("identifiable"));
+        }
+    }
+    out
+}
+
+async fn drive(addr: SocketAddr, request: SubscribeRequest, stop_at_slot: u64) -> Vec<MsgId> {
+    let mut client = GeyserGrpcClient::build_from_shared(format!("http://{addr}"))
+        .expect("endpoint")
+        .set_reconnect_config(ReconnectConfig::default().with_backoff(Backoff::new(
+            Duration::from_millis(1),
+            1.0,
+            10,
+        )))
+        .connect()
+        .await
+        .expect("connect");
+
+    let mut stream = client.subscribe_once(request).await.expect("subscribe");
+
+    let mut got = Vec::new();
+    while let Ok(Some(item)) = timeout(Duration::from_secs(10), stream.next()).await {
+        let update = item.expect("stream must not surface an error");
+        if let Some(id) = identify(&update) {
+            let slot = id.0;
+            got.push(id);
+            if slot >= stop_at_slot {
+                break;
+            }
+        }
+    }
+    got
+}
+
+fn assert_no_loss_no_dupes(got: &[MsgId], expected: &[MsgId], upto_slot: u64) {
+    let mut seen: HashMap<MsgId, usize> = HashMap::new();
+    for id in got {
+        *seen.entry(*id).or_default() += 1;
+    }
+
+    let dupes: Vec<_> = seen.iter().filter(|(_, n)| **n > 1).collect();
+    assert!(
+        dupes.is_empty(),
+        "duplicate messages delivered to the user: {dupes:?}"
+    );
+
+    let missing: Vec<_> = expected
+        .iter()
+        .filter(|(slot, _, _)| *slot <= upto_slot)
+        .filter(|id| !seen.contains_key(id))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "messages lost across reconnect ({} of them): {:?}",
+        missing.len(),
+        &missing[..missing.len().min(15)]
+    );
+}
+
+/// Without blocks_meta the client injects its own filters, so the user sees
+/// payloads only.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_reconnect_injected_filters_no_loss_no_dupes() {
+    let script = Script {
+        payload_filter: "user_payload".to_string(),
+        // must match reconnect.rs AUTORECONNECT_FILTER_KEY
+        control_filter: "__autoreconnect".to_string(),
+    };
+    let harness = spawn_server(script.clone(), vec![Some(37), Some(60)]).await;
+
+    let mut accounts = HashMap::new();
+    accounts.insert(
+        "user_payload".to_string(),
+        SubscribeRequestFilterAccounts::default(),
+    );
+    let request = SubscribeRequest {
+        accounts,
+        ..Default::default()
+    };
+
+    let got = drive(harness.addr, request, LAST_SLOT).await;
+
+    assert!(
+        harness.connections.load(Ordering::SeqCst) > 1,
+        "expected at least one reconnect, got {} connection(s)",
+        harness.connections.load(Ordering::SeqCst)
+    );
+    println!(
+        "connections={} from_slots={:?}",
+        harness.connections.load(Ordering::SeqCst),
+        harness.from_slots.lock().expect("poisoned")
+    );
+
+    let expected = expected_ids(&script, false);
+    assert_no_loss_no_dupes(&got, &expected, LAST_SLOT - 1);
+}
+
+/// Sweeps the disconnect point across the message timeline so the cut lands
+/// before, at and after block_meta, on slot boundaries and mid-slot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_reconnect_at_every_offset_no_loss_no_dupes() {
+    let script = Script {
+        payload_filter: "user_payload".to_string(),
+        control_filter: "user_bm".to_string(),
+    };
+    let expected = expected_ids(&script, true);
+
+    let mut accounts = HashMap::new();
+    accounts.insert(
+        "user_payload".to_string(),
+        SubscribeRequestFilterAccounts::default(),
+    );
+    let mut blocks_meta = HashMap::new();
+    blocks_meta.insert(
+        "user_bm".to_string(),
+        SubscribeRequestFilterBlocksMeta::default(),
+    );
+    let request = SubscribeRequest {
+        accounts,
+        blocks_meta,
+        ..Default::default()
+    };
+
+    // Five messages per slot. The second cut exercises nested replay windows.
+    for first_cut in 6..=60usize {
+        let harness = spawn_server(
+            script.clone(),
+            vec![Some(first_cut), Some(first_cut + 17), None],
+        )
+        .await;
+
+        let got = drive(harness.addr, request.clone(), LAST_SLOT).await;
+
+        assert!(
+            harness.connections.load(Ordering::SeqCst) > 1,
+            "cut at {first_cut}: expected a reconnect"
+        );
+
+        let mut seen: HashMap<MsgId, usize> = HashMap::new();
+        for id in &got {
+            *seen.entry(*id).or_default() += 1;
+        }
+        let dupes: Vec<_> = seen.iter().filter(|(_, n)| **n > 1).collect();
+        assert!(
+            dupes.is_empty(),
+            "cut at {first_cut} (from_slots={:?}): duplicates {dupes:?}",
+            harness.from_slots.lock().expect("poisoned")
+        );
+        let missing: Vec<_> = expected
+            .iter()
+            .filter(|(slot, _, _)| *slot < LAST_SLOT)
+            .filter(|id| !seen.contains_key(id))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "cut at {first_cut} (from_slots={:?}): lost {} message(s): {:?}",
+            harness.from_slots.lock().expect("poisoned"),
+            missing.len(),
+            &missing[..missing.len().min(10)]
+        );
+    }
+}
+
+/// With blocks_meta subscribed and slots not, nothing is injected and
+/// block_meta is the first message seen per slot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_reconnect_user_blocks_meta_no_loss_no_dupes() {
+    let script = Script {
+        payload_filter: "user_payload".to_string(),
+        control_filter: "user_bm".to_string(),
+    };
+    let harness = spawn_server(script.clone(), vec![Some(43), None]).await;
+
+    let mut accounts = HashMap::new();
+    accounts.insert(
+        "user_payload".to_string(),
+        SubscribeRequestFilterAccounts::default(),
+    );
+    let mut blocks_meta = HashMap::new();
+    blocks_meta.insert(
+        "user_bm".to_string(),
+        SubscribeRequestFilterBlocksMeta::default(),
+    );
+    let request = SubscribeRequest {
+        accounts,
+        blocks_meta,
+        ..Default::default()
+    };
+
+    let got = drive(harness.addr, request, LAST_SLOT).await;
+
+    assert!(
+        harness.connections.load(Ordering::SeqCst) > 1,
+        "expected at least one reconnect"
+    );
+    println!(
+        "connections={} from_slots={:?}",
+        harness.connections.load(Ordering::SeqCst),
+        harness.from_slots.lock().expect("poisoned")
+    );
+
+    let expected = expected_ids(&script, true);
+    assert_no_loss_no_dupes(&got, &expected, LAST_SLOT - 1);
+}


### PR DESCRIPTION
Follow-up to #717 and #753. DedupStream wraps every subscription, reconnect enabled or not. Four pre-existing bugs:

1. Messages arriving after their slot's BlockMeta were quarantined pending a second BlockMeta that only a replay produces, so in steady state they were dropped. This swallowed the freeze-time account writes #838 fixed server-side.
2. DedupState.sealed grew without bound: a slot whose first message is BlockMeta never entered slot_order, which is all prune() evicts from.
3. DedupKey was positional for transactions, transaction statuses and entries, so two blocks for one slot collided. Now content-addressed.
4. Slots in flight at reconnect lost their delivered keys, so replayed content was flushed wholesale and re-delivered.

Testing

New e2e drives the client against an in-process Geyser server through forced disconnects. Against master: 40 lost messages plus duplicates. Sweeps 55 disconnect offsets, passes at each.

Review notes

- #753 owner please confirm. Partial slots now dedup on delivered keys instead of flushing wholesale.
- Account dedup assumes write_version is stable across a replay. True here (grpc.rs:1403); a server that regenerates messages would emit duplicates.
- Two existing tests asserted the old partial-slot behaviour and were replaced