### PR TITLE
geyser: decrement message_queue_size when draining BlockMeta partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `yellowstone_grpc_geyser_message_queue_size` leaking one count per slot: since [#838](https://github.com/rpcpool/yellowstone-grpc/pull/838) `BlockMeta` messages are diverted into a separate partition in the geyser loop, but the drain path only decremented the gauge for the regular message batch, so the gauge grew unboundedly (~2.5/s) and stopped reflecting real queue depth. Closes [#840](https://github.com/rpcpool/yellowstone-grpc/issues/840)
+
 ## 2026-07-24
 
 - yellowstone-grpc-geyser 14.2.2

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1267,6 +1267,7 @@ impl GrpcService {
             }
 
             if let Some(blockmeta_message) = buffer.blockmeta_batch.take() {
+                metrics::message_queue_size_dec();
                 if block_reconstruction_tx
                     .send(BlockReconstructionMessage::Single(blockmeta_message))
                     .is_ok()


### PR DESCRIPTION
Fixes #840.

#838 diverts `Message::BlockMeta` into its own partition (`blockmeta_batch`) in `geyser_loop`'s `PartitionedBuffer`, but the drain path only decrements `message_queue_size` for the regular `message_batch` (`dec_by`). The `blockmeta_batch.take()` branch forwarded the message to block reconstruction without decrementing, so the gauge leaked exactly **+1 per slot (~2.5/s)** and stopped reflecting real queue depth.

The enqueue side (`PluginInner::send_message`) increments the gauge for every message sent to the geyser loop, including `BlockMeta` — so the `take()` branch must decrement. This mirrors the accounting of the batch branch: decrement on drain, regardless of the downstream send result.

Verified against tags: `v14.2.0`/`v14.2.1` (pre-partition, single batch with uniform `dec_by`) account correctly; the regression is `v14.2.2`-only. Observed on a production node running `v14.2.2+solana.4.1.0`: gauge growth 2.4/s matching slot rate, reading ≈ plugin uptime × 2.5, while `block_reconstruction_queue_size` and subscriber queues stayed at zero backlog.

Also adds a CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
