### PR TITLE
STR-620: refactor(client) - decouple reconnect from gap recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- Added `ReconnectionPolicy::NoReplay` so a subscription can auto-reconnect from the tip without paying for replay or dedup.
+- Added `ReconnectionPolicy` so a subscription can choose whether or not to auto-reconnect from the tip without paying for replay or dedup.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - yellowstone-grpc-client 13.3.0
 - yellowstone-grpc-client-simple-12.3.1
+- yellowstone-grpc-client-nodejs-5.1.0
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ## [Unreleased]
 
 - yellowstone-grpc-client 13.3.0
+- yellowstone-grpc-client-simple-12.3.1
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- Fixed the internal `__autoreconnect` filter being stripped from the stored subscription when a user changed filters mid-stream, which silently disabled checkpointing for every subsequent reconnect.
+- Fixed the internal `__autoreconnect` filter being stripped from the stored subscription when a user changed filters mid-stream, which silently prevented data recovery on every subsequent reconnect.
 
 ### Breaking
 - Changed `AutoReconnect::new` to take the raw stream instead of `DedupStream<S>`; `DedupStream` now wraps `AutoReconnect` rather than being wrapped by it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+- yellowstone-grpc-client 13.3.0
+
+### Features
+
+- Added `ReconnectionPolicy::NoReplay` so a subscription can auto-reconnect from the tip without paying for replay or dedup.
+
+### Fixes
+
+- Fixed the internal `__autoreconnect` filter being stripped from the stored subscription when a user changed filters mid-stream, which silently disabled checkpointing for every subsequent reconnect.
+
+### Breaking
+- Changed `AutoReconnect::new` to take the raw stream instead of `DedupStream<S>`; `DedupStream` now wraps `AutoReconnect` rather than being wrapped by it.
+- Changed `reconnect_config` to `Option<ReconnectConfig>` and removed `ReconnectConfig::no_reconnect()`; `None` now expresses "no reconnect".
+- Moved `slot_retention` from `ReconnectConfig` into `ReconnectionPolicy::Replay`.
+
 ## 2026-07-24
 
 - yellowstone-grpc-geyser 14.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6311,10 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client-simple"
-version = "12.3.0"
+version = "12.3.1"
 dependencies = [
  "anyhow",
- "arc-swap",
  "backoff",
  "bs58",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "13.2.1"
+version = "13.3.0"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6314,6 +6314,7 @@ name = "yellowstone-grpc-client-simple"
 version = "12.3.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "backoff",
  "bs58",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.9.0", default-features = false }
 yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.2.2" }
-yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.2.1" }
+yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.3.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -14,6 +14,7 @@ name = "client"
 
 [dependencies]
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 backoff = { workspace = true, features = ["tokio"] }
 bs58 = { workspace = true }
 chrono = { workspace = true }
@@ -38,7 +39,7 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 
 # Yellowstone
-yellowstone-grpc-client = { workspace = true }
+yellowstone-grpc-client = { workspace = true, features = ["test-tools"] }
 yellowstone-grpc-geyser = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client-simple"
-version = "12.3.0"
+version = "12.3.1"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
@@ -14,7 +14,6 @@ name = "client"
 
 [dependencies]
 anyhow = { workspace = true }
-arc-swap = { workspace = true }
 backoff = { workspace = true, features = ["tokio"] }
 bs58 = { workspace = true }
 chrono = { workspace = true }
@@ -39,7 +38,7 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 
 # Yellowstone
-yellowstone-grpc-client = { workspace = true, features = ["test-tools"] }
+yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-geyser = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/examples/rust/src/bin/client_with_reconnect.rs
+++ b/examples/rust/src/bin/client_with_reconnect.rs
@@ -3,7 +3,9 @@ use {
     futures::stream::StreamExt,
     log::info,
     std::collections::HashMap,
-    yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig, ReconnectionPolicy, DEFAULT_SLOT_RETENTION},
+    yellowstone_grpc_client::{
+        Backoff, GeyserGrpcClient, ReconnectConfig, ReconnectionPolicy, DEFAULT_SLOT_RETENTION,
+    },
     yellowstone_grpc_proto::prelude::{
         subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
         SubscribeRequestFilterAccounts, SubscribeRequestFilterSlots,

--- a/examples/rust/src/bin/client_with_reconnect.rs
+++ b/examples/rust/src/bin/client_with_reconnect.rs
@@ -3,7 +3,7 @@ use {
     futures::stream::StreamExt,
     log::info,
     std::collections::HashMap,
-    yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig, ReconnectionPolicy},
+    yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig, ReconnectionPolicy, DEFAULT_SLOT_RETENTION},
     yellowstone_grpc_proto::prelude::{
         subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
         SubscribeRequestFilterAccounts, SubscribeRequestFilterSlots,
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
         backoff: Backoff::default(),
         policy: match args.policy {
             Policy::Recover => ReconnectionPolicy::RecoverMissedData {
-                slot_retention: 250,
+                slot_retention: DEFAULT_SLOT_RETENTION,
             },
             Policy::Skip => ReconnectionPolicy::SkipMissedData,
         },

--- a/examples/rust/src/bin/client_with_reconnect.rs
+++ b/examples/rust/src/bin/client_with_reconnect.rs
@@ -1,15 +1,23 @@
 use {
-    clap::Parser,
+    clap::{Parser, ValueEnum},
     futures::stream::StreamExt,
     log::info,
     std::collections::HashMap,
-    yellowstone_grpc_client::{GeyserGrpcClient, ReconnectConfig},
+    yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig, ReconnectionPolicy},
     yellowstone_grpc_proto::prelude::{
         subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
         SubscribeRequestFilterAccounts, SubscribeRequestFilterSlots,
         SubscribeRequestFilterTransactions,
     },
 };
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Policy {
+    /// Re-request data produced while disconnected. No gap in the stream.
+    Recover,
+    /// Continue from the newest data. Anything missed is lost.
+    Skip,
+}
 
 #[derive(Debug, Clone, Parser)]
 #[clap(author, version, about = "Yellowstone gRPC client with auto-reconnect")]
@@ -28,6 +36,10 @@ struct Args {
 
     #[clap(long)]
     transactions: bool,
+
+    /// What happens to data produced while the connection was down.
+    #[clap(long, value_enum, default_value_t = Policy::Recover)]
+    policy: Policy,
 }
 
 #[tokio::main]
@@ -35,9 +47,19 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
 
+    let reconnect_config = ReconnectConfig {
+        backoff: Backoff::default(),
+        policy: match args.policy {
+            Policy::Recover => ReconnectionPolicy::RecoverMissedData {
+                slot_retention: 250,
+            },
+            Policy::Skip => ReconnectionPolicy::SkipMissedData,
+        },
+    };
+
     let mut client = GeyserGrpcClient::build_from_shared(args.endpoint)?
         .x_token(args.x_token)?
-        .set_reconnect_config(ReconnectConfig::default())
+        .set_reconnect_config(reconnect_config)
         .connect()
         .await?;
 
@@ -73,10 +95,11 @@ async fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    info!("connecting with auto-reconnect enabled");
+    info!("connecting with policy={:?}", args.policy);
     let mut stream = client.subscribe_once(request).await?;
     let mut count = 0u64;
 
+    // Reconnects happen underneath this loop. Nothing here needs to know.
     while let Some(msg) = stream.next().await {
         match msg {
             Ok(update) => {

--- a/yellowstone-grpc-client-nodejs/napi/index.d.ts
+++ b/yellowstone-grpc-client-nodejs/napi/index.d.ts
@@ -148,6 +148,13 @@ export interface JsReconnectConfig {
   enabled?: boolean
   backoff?: JsReconnectBackoff
   slotRetention?: number
+  /** Omitted defaults to RecoverMissedData. */
+  policy?: JsReconnectPolicy
+}
+
+export declare const enum JsReconnectPolicy {
+  RecoverMissedData = 'RecoverMissedData',
+  SkipMissedData = 'SkipMissedData'
 }
 
 export declare const enum WasmUiTransactionEncoding {

--- a/yellowstone-grpc-client-nodejs/napi/index.js
+++ b/yellowstone-grpc-client-nodejs/napi/index.js
@@ -585,4 +585,5 @@ module.exports.decodeTxError = nativeBinding.decodeTxError
 module.exports.encodeDeshredTx = nativeBinding.encodeDeshredTx
 module.exports.encodeTx = nativeBinding.encodeTx
 module.exports.JsCompressionAlgorithm = nativeBinding.JsCompressionAlgorithm
+module.exports.JsReconnectPolicy = nativeBinding.JsReconnectPolicy
 module.exports.WasmUiTransactionEncoding = nativeBinding.WasmUiTransactionEncoding

--- a/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
@@ -47,6 +47,13 @@ pub struct JsChannelOptions {
   pub grpc_tcp_nodelay: Option<bool>,
 }
 
+#[napi(string_enum)]
+#[derive(Deserialize, Debug, Clone)]
+pub enum JsReconnectPolicy {
+  RecoverMissedData,
+  SkipMissedData,
+}
+
 #[napi(object)]
 #[derive(Deserialize, Debug, Clone)]
 pub struct JsReconnectBackoff {
@@ -63,6 +70,8 @@ pub struct JsReconnectConfig {
   pub enabled: Option<bool>,
   pub backoff: Option<JsReconnectBackoff>,
   pub slot_retention: Option<u32>,
+  /// Omitted defaults to RecoverMissedData.
+  pub policy: Option<JsReconnectPolicy>,
 }
 
 impl Default for JsChannelOptions {

--- a/yellowstone-grpc-client-nodejs/napi/src/utils.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/utils.rs
@@ -1,7 +1,11 @@
-use crate::bindings::{JsChannelOptions, JsCompressionAlgorithm, JsReconnectConfig};
+use crate::bindings::{
+  JsChannelOptions, JsCompressionAlgorithm, JsReconnectConfig, JsReconnectPolicy,
+};
 use napi::bindgen_prelude::{Result, Status};
 use std::time::Duration;
-use yellowstone_grpc_client::{Backoff, ClientTlsConfig, GeyserGrpcBuilder, ReconnectConfig};
+use yellowstone_grpc_client::{
+  Backoff, ClientTlsConfig, GeyserGrpcBuilder, ReconnectConfig, ReconnectionPolicy,
+};
 use yellowstone_grpc_proto::tonic::codec::CompressionEncoding;
 
 fn to_napi_cause(status: Status, source: &dyn std::error::Error) -> napi::Error {
@@ -38,13 +42,20 @@ fn reconnect_config_from_js(
 
   let mut native_config = ReconnectConfig::default();
 
-  if let Some(slot_retention) = reconnect_config.slot_retention {
+  if matches!(
+    reconnect_config.policy,
+    Some(JsReconnectPolicy::SkipMissedData)
+  ) {
+    native_config.policy = ReconnectionPolicy::SkipMissedData;
+  } else if let Some(slot_retention) = reconnect_config.slot_retention {
     if slot_retention == 0 {
       return Err(invalid_arg(
         "invalid reconnect.slotRetention: expected a positive integer",
       ));
     }
-    native_config = native_config.with_slot_retention(slot_retention as usize);
+    native_config.policy = ReconnectionPolicy::RecoverMissedData {
+      slot_retention: slot_retention as usize,
+    };
   }
 
   if let Some(backoff) = reconnect_config.backoff {
@@ -247,6 +258,7 @@ pub async fn get_client_builder(
 #[cfg(test)]
 mod tests {
   use super::get_client_builder;
+  use yellowstone_grpc_client::ReconnectionPolicy;
 
   #[tokio::test]
   async fn get_client_builder_invalid_endpoint_includes_cause() {
@@ -302,18 +314,25 @@ mod tests {
           max_retries: Some(8),
         }),
         slot_retention: Some(300),
+        policy: None,
       }),
     )
     .await
     .expect("valid reconnect config should build");
 
-    assert_eq!(
-      builder.reconnect_config.backoff.initial_interval,
-      Duration::from_millis(125)
-    );
-    assert_eq!(builder.reconnect_config.backoff.multiplier, 1.5);
-    assert_eq!(builder.reconnect_config.backoff.max_retries, 8);
-    assert_eq!(builder.reconnect_config.slot_retention, 300);
+    let config = builder
+      .reconnect_config
+      .expect("reconnect config must be set");
+
+    assert_eq!(config.backoff.initial_interval, Duration::from_millis(125));
+    assert_eq!(config.backoff.multiplier, 1.5);
+    assert_eq!(config.backoff.max_retries, 8);
+    assert!(matches!(
+      config.policy,
+      ReconnectionPolicy::RecoverMissedData {
+        slot_retention: 300
+      }
+    ));
   }
 
   #[tokio::test]
@@ -332,6 +351,7 @@ mod tests {
           max_retries: None,
         }),
         slot_retention: None,
+        policy: None,
       }),
     )
     .await

--- a/yellowstone-grpc-client-nodejs/package.json
+++ b/yellowstone-grpc-client-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triton-one/yellowstone-grpc",
-  "version": "5.0.9",
+  "version": "5.1.0",
   "license": "Apache-2.0",
   "author": "Triton One",
   "description": "Yellowstone gRPC Geyser Node.js Client",

--- a/yellowstone-grpc-client-nodejs/src/index.ts
+++ b/yellowstone-grpc-client-nodejs/src/index.ts
@@ -110,6 +110,7 @@ export interface ReconnectOptions {
     maxRetries?: number;
   };
   slotRetention?: number;
+  policy?: napi.JsReconnectPolicy;
 }
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-client"
-version = "13.2.1"
+version = "13.3.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Simple Client"

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -74,7 +74,7 @@ pub struct DedupStream<S, T = SubscribeUpdate> {
     pub(crate) state: DedupState,
     inner: S,
     replay: ReplayBuffer<T>,
-    last_reconnect_count: u32, 
+    last_reconnect_count: u32,
 }
 
 impl<S, T> DedupStream<S, T> {
@@ -83,7 +83,7 @@ impl<S, T> DedupStream<S, T> {
             state,
             inner,
             replay: ReplayBuffer::new(),
-            last_reconnect_count: 0
+            last_reconnect_count: 0,
         }
     }
 }
@@ -383,7 +383,6 @@ mod tests {
         }
     }
 
-
     impl<S> ReconnectCounter for TestStream<S> {
         fn reconnect_count(&self) -> u32 {
             self.count
@@ -591,7 +590,10 @@ mod tests {
             Ok(make_slot_msg(101, 0)),
         ];
 
-        let inner = TestStream { inner: stream::iter(messages).boxed(), count: 0 };
+        let inner = TestStream {
+            inner: stream::iter(messages).boxed(),
+            count: 0,
+        };
 
         let mut dedup = DedupStream::new(inner, DedupState::default());
 

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -15,7 +15,7 @@ use {
     },
 };
 
-pub(crate) const DEFAULT_SLOT_RETENTION: usize = 250;
+pub const DEFAULT_SLOT_RETENTION: usize = 250;
 
 const CREATED_BANK_STATUS: i32 = SlotStatus::SlotCreatedBank as i32;
 

--- a/yellowstone-grpc-client/src/dedup.rs
+++ b/yellowstone-grpc-client/src/dedup.rs
@@ -65,11 +65,16 @@ impl<T> ReplayBuffer<T> {
     }
 }
 
+pub trait ReconnectCounter {
+    fn reconnect_count(&self) -> u32;
+}
+
 /// Wrapper stream that filters out duplicate subscribe updates.
 pub struct DedupStream<S, T = SubscribeUpdate> {
     pub(crate) state: DedupState,
     inner: S,
     replay: ReplayBuffer<T>,
+    last_reconnect_count: u32, 
 }
 
 impl<S, T> DedupStream<S, T> {
@@ -78,6 +83,7 @@ impl<S, T> DedupStream<S, T> {
             state,
             inner,
             replay: ReplayBuffer::new(),
+            last_reconnect_count: 0
         }
     }
 }
@@ -85,7 +91,7 @@ impl<S, T> DedupStream<S, T> {
 impl<S, T> Stream for DedupStream<S, T>
 where
     T: Dedupable + Unpin,
-    S: Stream<Item = Result<T, Status>> + Unpin,
+    S: Stream<Item = Result<T, Status>> + ReconnectCounter + Unpin,
 {
     type Item = Result<T, Status>;
 
@@ -100,25 +106,33 @@ where
             }
 
             match this.inner.poll_next_unpin(cx) {
-                Poll::Ready(Some(Ok(msg))) => match msg.extract_key() {
-                    None => return Poll::Ready(Some(Ok(msg))),
-                    Some((slot, key)) => match this.state.observe(slot, key) {
-                        Observation::New => return Poll::Ready(Some(Ok(msg))),
-                        Observation::Duplicate => continue,
-                        Observation::Replay => {
-                            this.replay.hold(slot, msg);
-                            continue;
-                        }
-                        Observation::ReplayComplete { same: true } => {
-                            this.replay.discard(slot);
-                            continue;
-                        }
-                        Observation::ReplayComplete { same: false } => {
-                            this.replay.flush(slot, msg);
-                            continue;
-                        }
-                    },
-                },
+                Poll::Ready(Some(Ok(msg))) => {
+                    let count = this.inner.reconnect_count();
+                    if count != this.last_reconnect_count {
+                        this.state.prepare_for_replay();
+                        this.last_reconnect_count = count;
+                    }
+
+                    match msg.extract_key() {
+                        None => return Poll::Ready(Some(Ok(msg))),
+                        Some((slot, key)) => match this.state.observe(slot, key) {
+                            Observation::New => return Poll::Ready(Some(Ok(msg))),
+                            Observation::Duplicate => continue,
+                            Observation::Replay => {
+                                this.replay.hold(slot, msg);
+                                continue;
+                            }
+                            Observation::ReplayComplete { same: true } => {
+                                this.replay.discard(slot);
+                                continue;
+                            }
+                            Observation::ReplayComplete { same: false } => {
+                                this.replay.flush(slot, msg);
+                                continue;
+                            }
+                        },
+                    }
+                }
                 other => return other,
             }
         }
@@ -353,6 +367,29 @@ mod tests {
         },
     };
 
+    struct TestStream<S> {
+        inner: S,
+        count: u32,
+    }
+
+    impl<S: Stream + Unpin> Stream for TestStream<S> {
+        type Item = S::Item;
+
+        fn poll_next(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            std::pin::Pin::new(&mut self.inner).poll_next(cx)
+        }
+    }
+
+
+    impl<S> ReconnectCounter for TestStream<S> {
+        fn reconnect_count(&self) -> u32 {
+            self.count
+        }
+    }
+
     fn make_slot_msg(slot: u64, status: i32) -> SubscribeUpdate {
         SubscribeUpdate {
             filters: vec![],
@@ -554,7 +591,8 @@ mod tests {
             Ok(make_slot_msg(101, 0)),
         ];
 
-        let inner = stream::iter(messages).boxed();
+        let inner = TestStream { inner: stream::iter(messages).boxed(), count: 0 };
+
         let mut dedup = DedupStream::new(inner, DedupState::default());
 
         let msg1 = dedup

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -487,7 +487,7 @@ impl GeyserGrpcClient {
                         );
                         match config.policy {
                             ReconnectionPolicy::SkipMissedData => {
-                                InnerStream::NoReplay(reconnect_stream)
+                                InnerStream::NoReplay(reconnect_stream.without_checkpoint())
                             }
                             ReconnectionPolicy::RecoverMissedData { slot_retention } => {
                                 InnerStream::Replay(DedupStream::new(

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -119,7 +119,7 @@ pub enum ReconnectionPolicy {
 /// - `backoff`: 10 ms initial interval, 2.0 multiplier, 3 retries
 ///   (10 ms, 20 ms, 40 ms, then give up)
 /// - `policy`: [`ReconnectionPolicy::RecoverMissedData`] default
-///     recovers data lost during the reconnection gap with a slot_retention number of 250
+///   recovers data lost during the reconnection gap with a slot_retention number of 250
 ///
 /// # Example
 ///
@@ -248,6 +248,7 @@ pub struct GeyserStream {
     inner: InnerStream,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum InnerStream {
     NoReconnect(Streaming<SubscribeUpdate>),
     Replay(DedupStream<AutoReconnect<Streaming<SubscribeUpdate>, TonicGrpcConnector>>),

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -3,7 +3,6 @@ mod reconnect;
 
 use {
     crate::{
-        dedup::DEFAULT_SLOT_RETENTION,
         reconnect::{TonicGeyserClientOptions, AUTORECONNECT_FILTER_KEY},
     },
     arc_swap::ArcSwap,
@@ -41,7 +40,7 @@ use {
 };
 pub use {
     crate::{
-        dedup::{DedupState, DedupStream},
+        dedup::{DedupState, DedupStream, DEFAULT_SLOT_RETENTION},
         reconnect::{AutoReconnect, Backoff, GrpcConnector, TonicGrpcConnector},
     },
     tonic::{service::Interceptor, transport::ClientTlsConfig},
@@ -118,15 +117,15 @@ pub enum ReconnectionPolicy {
 ///
 /// - `backoff`: 10 ms initial interval, 2.0 multiplier, 3 retries
 ///   (10 ms, 20 ms, 40 ms, then give up)
-/// - `policy`: [`ReconnectionPolicy::RecoverMissedData`] default
-///   recovers data lost during the reconnection gap with a slot_retention number of 250
+/// - `policy`: [`ReconnectionPolicy::RecoverMissedData`] with a `slot_retention`
+///   of [`DEFAULT_SLOT_RETENTION`]
 ///
 /// # Example
 ///
 /// ```no_run
 /// # use std::time::Duration;
 /// # use yellowstone_grpc_client::{Backoff, ReconnectConfig, ReconnectionPolicy};
-/// let default = ReconnectConfig::default();
+/// let default = ReconnectConfig::default(); // Recovers messages in the gap by default
 ///
 /// let no_gap_reconnection = ReconnectConfig {
 ///     backoff: Backoff::new(Duration::from_millis(50), 2.0, 5),

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -3,40 +3,21 @@ mod reconnect;
 
 use {
     crate::{
-        dedup::DEFAULT_SLOT_RETENTION,
-        reconnect::{TonicGeyserClientOptions, AUTORECONNECT_FILTER_KEY},
-    },
-    arc_swap::ArcSwap,
-    bytes::Bytes,
-    futures::{
+        dedup::DEFAULT_SLOT_RETENTION, reconnect::{AUTORECONNECT_FILTER_KEY, TonicGeyserClientOptions},
+    }, arc_swap::ArcSwap, bytes::Bytes, futures::{
         channel::mpsc,
         sink::{Sink, SinkExt},
         stream::Stream,
-    },
-    std::{
+    }, std::{
         path::PathBuf,
         sync::{Arc, Mutex},
         time::Duration,
-    },
-    tokio::net::UnixStream,
-    tonic::{
-        codec::{CompressionEncoding, Streaming},
-        metadata::{errors::InvalidMetadataValue, AsciiMetadataValue, MetadataValue},
-        service::interceptor::InterceptedService,
-        transport::{
-            channel::{Channel, Endpoint},
-            Uri,
+    }, tokio::net::UnixStream, tonic::{
+        Request, Response, Status, codec::{CompressionEncoding, Streaming}, metadata::{AsciiMetadataValue, MetadataValue, errors::InvalidMetadataValue}, service::interceptor::InterceptedService, transport::{
+            Uri, channel::{Channel, Endpoint},
         },
-        Request, Response, Status,
-    },
-    tonic_health::pb::{health_client::HealthClient, HealthCheckRequest, HealthCheckResponse},
-    yellowstone_grpc_proto::prelude::{
-        geyser_client::GeyserClient, CommitmentLevel, GetBlockHeightRequest,
-        GetBlockHeightResponse, GetLatestBlockhashRequest, GetLatestBlockhashResponse,
-        GetSlotRequest, GetSlotResponse, GetVersionRequest, GetVersionResponse,
-        IsBlockhashValidRequest, IsBlockhashValidResponse, PingRequest, PongResponse,
-        SubscribeDeshredRequest, SubscribeReplayInfoRequest, SubscribeReplayInfoResponse,
-        SubscribeRequest, SubscribeUpdate, SubscribeUpdateDeshred,
+    }, tonic_health::pb::{HealthCheckRequest, HealthCheckResponse, health_client::HealthClient}, yellowstone_grpc_proto::prelude::{
+        CommitmentLevel, GetBlockHeightRequest, GetBlockHeightResponse, GetLatestBlockhashRequest, GetLatestBlockhashResponse, GetSlotRequest, GetSlotResponse, GetVersionRequest, GetVersionResponse, IsBlockhashValidRequest, IsBlockhashValidResponse, PingRequest, PongResponse, SubscribeDeshredRequest, SubscribeReplayInfoRequest, SubscribeReplayInfoResponse, SubscribeRequest, SubscribeUpdate, SubscribeUpdateDeshred, geyser_client::GeyserClient,
     },
 };
 pub use {
@@ -83,36 +64,37 @@ pub enum GeyserGrpcClientError {
 pub type GeyserGrpcClientResult<T> = Result<T, GeyserGrpcClientError>;
 
 #[derive(Clone, Debug)]
+pub enum ReconnectionPolicy {
+    NoReplay,
+    Replay { slot_retention: usize },
+}
+
+#[derive(Clone, Debug)]
 /// Configuration for automatic subscribe reconnect behavior.
 pub struct ReconnectConfig {
     pub backoff: Backoff,
-    pub slot_retention: usize,
+    pub policy: ReconnectionPolicy,
 }
 
 impl Default for ReconnectConfig {
     fn default() -> Self {
         Self {
             backoff: Backoff::default(),
-            slot_retention: DEFAULT_SLOT_RETENTION,
+            policy: ReconnectionPolicy::Replay {
+                slot_retention: DEFAULT_SLOT_RETENTION,
+            },
         }
     }
 }
 
 impl ReconnectConfig {
-    pub const fn no_reconnect() -> Self {
-        Self {
-            backoff: Backoff::new(Duration::from_millis(0), 1.0, 0),
-            slot_retention: 0,
-        }
-    }
-
     pub const fn with_backoff(mut self, backoff: Backoff) -> Self {
         self.backoff = backoff;
         self
     }
 
     pub const fn with_slot_retention(mut self, slot_retention: usize) -> Self {
-        self.slot_retention = slot_retention;
+        self.policy = ReconnectionPolicy::Replay { slot_retention };
         self
     }
 }
@@ -124,7 +106,7 @@ impl ReconnectConfig {
 pub struct GeyserGrpcClient {
     pub health: HealthClient<InterceptedService<Channel, InterceptorXToken>>,
     pub geyser: GeyserClient<InterceptedService<Channel, InterceptorXToken>>,
-    reconnect_config: ReconnectConfig,
+    reconnect_config: Option<ReconnectConfig>,
     geyser_client_opts: TonicGeyserClientOptions,
     reconnect_endpoint: Option<Endpoint>,
     reconnect_x_token: Option<AsciiMetadataValue>,
@@ -196,7 +178,13 @@ impl Sink<SubscribeDeshredRequest> for SubscribeDeshredRequestSink {
 /// The stream yields [`SubscribeUpdate`] from the server.
 ///
 pub struct GeyserStream {
-    inner: AutoReconnect<Streaming<SubscribeUpdate>, TonicGrpcConnector>,
+    inner: InnerStream,
+}
+
+enum InnerStream {
+    NoReconnect(Streaming<SubscribeUpdate>),
+    Replay(DedupStream<AutoReconnect<Streaming<SubscribeUpdate>, TonicGrpcConnector>>),
+    NoReplay(AutoReconnect<Streaming<SubscribeUpdate>, TonicGrpcConnector>),
 }
 
 ///
@@ -226,7 +214,11 @@ impl Stream for GeyserStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        std::pin::Pin::new(&mut self.inner).poll_next(cx)
+        match &mut self.inner {
+            InnerStream::NoReconnect(stream) => std::pin::Pin::new(stream).poll_next(cx),
+            InnerStream::Replay(stream) => std::pin::Pin::new(stream).poll_next(cx),
+            InnerStream::NoReplay(stream) => std::pin::Pin::new(stream).poll_next(cx),
+        }
     }
 }
 
@@ -278,11 +270,8 @@ impl Sink<SubscribeRequest> for SubscribeRequestSink {
             .lock()
             .expect("subscribe request sink mutex poisoned");
 
-        if item.blocks_meta.is_empty() {
-            item.blocks_meta
-                .insert(AUTORECONNECT_FILTER_KEY.to_string(), Default::default());
-            item.slots
-                .insert(AUTORECONNECT_FILTER_KEY.to_string(), Default::default());
+        if self.shared.load().blocks_meta.contains_key(AUTORECONNECT_FILTER_KEY) {
+            reconnect::inject_autoreconnect_filter(&mut item);
         }
 
         inner
@@ -323,7 +312,7 @@ impl GeyserGrpcClient {
         Self {
             health,
             geyser,
-            reconnect_config: ReconnectConfig::no_reconnect(),
+            reconnect_config: None,
             reconnect_endpoint: None,
             reconnect_x_token: None,
             geyser_client_opts: TonicGeyserClientOptions {
@@ -368,27 +357,26 @@ impl GeyserGrpcClient {
     ) -> GeyserGrpcClientResult<(SubscribeRequestSink, Streaming<SubscribeUpdate>)> {
         let (mut subscribe_tx, subscribe_rx) = mpsc::channel(1000);
 
-        let request = request.map(|mut req| {
-            if req.blocks_meta.is_empty() {
-                req.blocks_meta
-                    .insert(AUTORECONNECT_FILTER_KEY.to_string(), Default::default());
-                req.slots
-                    .insert(AUTORECONNECT_FILTER_KEY.to_string(), Default::default());
-            }
-            req
-        });
+        let mut request = request.unwrap_or_default();
 
-        if let Some(request) = request.clone() {
-            subscribe_tx
-                .send(request)
-                .await
-                .expect("channel cannot be disconnected or full at this point");
+        if matches!(
+            self.reconnect_config.as_ref().map(|c| &c.policy),
+            Some(ReconnectionPolicy::Replay { .. })
+        ) {
+            reconnect::inject_autoreconnect_filter(&mut request);
         }
+
+        subscribe_tx
+            .send(request.clone())
+            .await
+            .expect("channel cannot be disconnected or full at this point");
+
         let response: Response<Streaming<SubscribeUpdate>> =
             self.geyser.subscribe(subscribe_rx).await?;
+
         let sink = SubscribeRequestSink {
             inner: Arc::new(Mutex::new(subscribe_tx)),
-            shared: Arc::new(ArcSwap::new(Arc::new(request.unwrap_or_default()))),
+            shared: Arc::new(ArcSwap::new(Arc::new(request))),
         };
         Ok((sink, response.into_inner()))
     }
@@ -403,26 +391,38 @@ impl GeyserGrpcClient {
             .clone()
             .unwrap_or_else(|| Endpoint::from_static("http://127.0.0.1:0"));
         let reconnect_x_token = self.reconnect_x_token.clone();
+        let client_opts = self.geyser_client_opts.clone();
 
         self.subscribe_raw(request.clone())
             .await
             .map(|(sink, stream)| {
-                let connector = TonicGrpcConnector::new(
-                    endpoint,
-                    reconnect_config.clone(),
-                    reconnect_x_token,
-                    self.geyser_client_opts.clone(),
-                    Arc::clone(&sink.inner),
-                );
-                let inner = AutoReconnect::new(
-                    DedupStream::new(
-                        stream,
-                        DedupState::with_slot_retention(reconnect_config.slot_retention),
-                    ),
-                    connector,
-                    Arc::clone(&sink.shared),
-                    reconnect_config.backoff.clone(),
-                );
+                let inner = match reconnect_config {
+                    None => InnerStream::NoReconnect(stream),
+                    Some(config) => {
+                        let connector = TonicGrpcConnector::new(
+                            endpoint,
+                            config.clone(),
+                            reconnect_x_token,
+                            client_opts,
+                            Arc::clone(&sink.inner),
+                        );
+                        let reconnect_stream = AutoReconnect::new(
+                            stream,
+                            connector,
+                            Arc::clone(&sink.shared),
+                            config.backoff.clone(),
+                        );
+                        match config.policy {
+                            ReconnectionPolicy::NoReplay => InnerStream::NoReplay(reconnect_stream),
+                            ReconnectionPolicy::Replay { slot_retention } => {
+                                InnerStream::Replay(DedupStream::new(
+                                    reconnect_stream,
+                                    DedupState::with_slot_retention(slot_retention),
+                                ))
+                            }
+                        }
+                    }
+                };
                 (sink, GeyserStream { inner })
             })
     }
@@ -571,7 +571,7 @@ pub struct GeyserGrpcBuilder {
     pub accept_compressed: Option<CompressionEncoding>,
     pub max_decoding_message_size: Option<usize>,
     pub max_encoding_message_size: Option<usize>,
-    pub reconnect_config: ReconnectConfig,
+    pub reconnect_config: Option<ReconnectConfig>,
 }
 
 impl GeyserGrpcBuilder {
@@ -585,7 +585,7 @@ impl GeyserGrpcBuilder {
             accept_compressed: None,
             max_decoding_message_size: None,
             max_encoding_message_size: None,
-            reconnect_config: ReconnectConfig::no_reconnect(),
+            reconnect_config: None,
         }
     }
 
@@ -836,7 +836,7 @@ impl GeyserGrpcBuilder {
 
     pub fn set_reconnect_config(self, config: ReconnectConfig) -> Self {
         Self {
-            reconnect_config: config,
+            reconnect_config: Some(config),
             ..self
         }
     }
@@ -845,10 +845,7 @@ impl GeyserGrpcBuilder {
 #[cfg(test)]
 mod tests {
     use {
-        super::{GeyserGrpcClient, SubscribeRequest, SubscribeRequestSink},
-        arc_swap::ArcSwap,
-        futures::{channel::mpsc, FutureExt, SinkExt, StreamExt},
-        std::sync::{Arc, Mutex},
+        super::{GeyserGrpcClient, SubscribeRequest, SubscribeRequestSink}, crate::reconnect::{AUTORECONNECT_FILTER_KEY, inject_autoreconnect_filter}, arc_swap::ArcSwap, futures::{FutureExt, SinkExt, StreamExt, channel::mpsc}, std::sync::{Arc, Mutex},
     };
 
     #[tokio::test]
@@ -964,5 +961,35 @@ mod tests {
             Some(Some(_)) => panic!("old receiver must not get requests after sender swap"),
         }
         assert_eq!(shared.load_full().from_slot, Some(22));
+    }
+
+    #[tokio::test]
+    async fn test_sink_preserves_autoreconnect_filter_across_sends() {
+        let (tx, mut rx) = mpsc::channel(8);
+
+        // shared starts with the injected key, as subscribe_raw would leave it
+        let mut initial = SubscribeRequest::default();
+        inject_autoreconnect_filter(&mut initial);
+
+        let shared = Arc::new(ArcSwap::new(Arc::new(initial)));
+        let mut sink = SubscribeRequestSink {
+            inner: Arc::new(Mutex::new(tx)),
+            shared: Arc::clone(&shared),
+        };
+
+        // user sends a request that does not carry the key
+        sink.send(SubscribeRequest::default())
+            .await
+            .expect("send must succeed");
+
+        let sent = rx.next().await.expect("receiver should get the request");
+        assert!(
+            sent.blocks_meta.contains_key(AUTORECONNECT_FILTER_KEY),
+            "internal filter must survive a user filter change on the wire"
+        );
+        assert!(
+            shared.load().blocks_meta.contains_key(AUTORECONNECT_FILTER_KEY),
+            "internal filter must survive in stored state, reconnect reads this"
+        );
     }
 }

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -2,9 +2,7 @@ mod dedup;
 mod reconnect;
 
 use {
-    crate::{
-        reconnect::{TonicGeyserClientOptions, AUTORECONNECT_FILTER_KEY},
-    },
+    crate::reconnect::{TonicGeyserClientOptions, AUTORECONNECT_FILTER_KEY},
     arc_swap::ArcSwap,
     bytes::Bytes,
     futures::{

--- a/yellowstone-grpc-client/src/lib.rs
+++ b/yellowstone-grpc-client/src/lib.rs
@@ -3,21 +3,40 @@ mod reconnect;
 
 use {
     crate::{
-        dedup::DEFAULT_SLOT_RETENTION, reconnect::{AUTORECONNECT_FILTER_KEY, TonicGeyserClientOptions},
-    }, arc_swap::ArcSwap, bytes::Bytes, futures::{
+        dedup::DEFAULT_SLOT_RETENTION,
+        reconnect::{TonicGeyserClientOptions, AUTORECONNECT_FILTER_KEY},
+    },
+    arc_swap::ArcSwap,
+    bytes::Bytes,
+    futures::{
         channel::mpsc,
         sink::{Sink, SinkExt},
         stream::Stream,
-    }, std::{
+    },
+    std::{
         path::PathBuf,
         sync::{Arc, Mutex},
         time::Duration,
-    }, tokio::net::UnixStream, tonic::{
-        Request, Response, Status, codec::{CompressionEncoding, Streaming}, metadata::{AsciiMetadataValue, MetadataValue, errors::InvalidMetadataValue}, service::interceptor::InterceptedService, transport::{
-            Uri, channel::{Channel, Endpoint},
+    },
+    tokio::net::UnixStream,
+    tonic::{
+        codec::{CompressionEncoding, Streaming},
+        metadata::{errors::InvalidMetadataValue, AsciiMetadataValue, MetadataValue},
+        service::interceptor::InterceptedService,
+        transport::{
+            channel::{Channel, Endpoint},
+            Uri,
         },
-    }, tonic_health::pb::{HealthCheckRequest, HealthCheckResponse, health_client::HealthClient}, yellowstone_grpc_proto::prelude::{
-        CommitmentLevel, GetBlockHeightRequest, GetBlockHeightResponse, GetLatestBlockhashRequest, GetLatestBlockhashResponse, GetSlotRequest, GetSlotResponse, GetVersionRequest, GetVersionResponse, IsBlockhashValidRequest, IsBlockhashValidResponse, PingRequest, PongResponse, SubscribeDeshredRequest, SubscribeReplayInfoRequest, SubscribeReplayInfoResponse, SubscribeRequest, SubscribeUpdate, SubscribeUpdateDeshred, geyser_client::GeyserClient,
+        Request, Response, Status,
+    },
+    tonic_health::pb::{health_client::HealthClient, HealthCheckRequest, HealthCheckResponse},
+    yellowstone_grpc_proto::prelude::{
+        geyser_client::GeyserClient, CommitmentLevel, GetBlockHeightRequest,
+        GetBlockHeightResponse, GetLatestBlockhashRequest, GetLatestBlockhashResponse,
+        GetSlotRequest, GetSlotResponse, GetVersionRequest, GetVersionResponse,
+        IsBlockhashValidRequest, IsBlockhashValidResponse, PingRequest, PongResponse,
+        SubscribeDeshredRequest, SubscribeReplayInfoRequest, SubscribeReplayInfoResponse,
+        SubscribeRequest, SubscribeUpdate, SubscribeUpdateDeshred,
     },
 };
 pub use {
@@ -65,14 +84,62 @@ pub type GeyserGrpcClientResult<T> = Result<T, GeyserGrpcClientError>;
 
 #[derive(Clone, Debug)]
 pub enum ReconnectionPolicy {
-    NoReplay,
-    Replay { slot_retention: usize },
+    /// Resumes at the latest slot after a disconnect.
+    ///
+    /// # Warning
+    ///
+    /// Data produced during the outage is not delivered and cannot be recovered
+    /// later. Only use this when your application acts on the current tip and has
+    /// no use for history.
+    SkipMissedData,
+    /// Re-requests data produced during the outage and filters the duplicates
+    /// this creates. Costs per-message bookkeeping over `slot_retention` slots.
+    RecoverMissedData { slot_retention: usize },
 }
 
+/// Configuration for automatic reconnect on a subscribe stream.
+///
+/// Pass to [`GeyserGrpcBuilder::set_reconnect_config`]. When no config is set,
+/// the stream ends when the connection drops.
+///
+/// # Choosing a policy
+///
+/// [`ReconnectionPolicy::RecoverMissedData`] re-requests whatever the server
+/// produced while you were disconnected, so the stream has no gap. Costs
+/// per-message bookkeeping and holds state for `slot_retention` slots.
+///
+/// [`ReconnectionPolicy::SkipMissedData`] reconnects and continues from the
+/// newest data. Anything produced during the outage is lost. Use this when
+/// your application only acts on current data.
+///
+/// # Defaults
+///
+/// [`ReconnectConfig::default`] uses:
+///
+/// - `backoff`: 10 ms initial interval, 2.0 multiplier, 3 retries
+///   (10 ms, 20 ms, 40 ms, then give up)
+/// - `policy`: [`ReconnectionPolicy::RecoverMissedData`] default
+///     recovers data lost during the reconnection gap with a slot_retention number of 250
+///
+/// # Example
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # use yellowstone_grpc_client::{Backoff, ReconnectConfig, ReconnectionPolicy};
+/// let default = ReconnectConfig::default();
+///
+/// let no_gap_reconnection = ReconnectConfig {
+///     backoff: Backoff::new(Duration::from_millis(50), 2.0, 5),
+///     policy: ReconnectionPolicy::SkipMissedData,
+/// };
+/// ```
 #[derive(Clone, Debug)]
-/// Configuration for automatic subscribe reconnect behavior.
 pub struct ReconnectConfig {
+    /// Retry schedule for reconnect attempts. Resets after each successful
+    /// connection, so the budget is per outage, not per stream.
     pub backoff: Backoff,
+
+    /// Whether data produced during an outage is recovered or skipped.
     pub policy: ReconnectionPolicy,
 }
 
@@ -80,7 +147,7 @@ impl Default for ReconnectConfig {
     fn default() -> Self {
         Self {
             backoff: Backoff::default(),
-            policy: ReconnectionPolicy::Replay {
+            policy: ReconnectionPolicy::RecoverMissedData {
                 slot_retention: DEFAULT_SLOT_RETENTION,
             },
         }
@@ -94,7 +161,7 @@ impl ReconnectConfig {
     }
 
     pub const fn with_slot_retention(mut self, slot_retention: usize) -> Self {
-        self.policy = ReconnectionPolicy::Replay { slot_retention };
+        self.policy = ReconnectionPolicy::RecoverMissedData { slot_retention };
         self
     }
 }
@@ -270,7 +337,12 @@ impl Sink<SubscribeRequest> for SubscribeRequestSink {
             .lock()
             .expect("subscribe request sink mutex poisoned");
 
-        if self.shared.load().blocks_meta.contains_key(AUTORECONNECT_FILTER_KEY) {
+        if self
+            .shared
+            .load()
+            .blocks_meta
+            .contains_key(AUTORECONNECT_FILTER_KEY)
+        {
             reconnect::inject_autoreconnect_filter(&mut item);
         }
 
@@ -361,7 +433,7 @@ impl GeyserGrpcClient {
 
         if matches!(
             self.reconnect_config.as_ref().map(|c| &c.policy),
-            Some(ReconnectionPolicy::Replay { .. })
+            Some(ReconnectionPolicy::RecoverMissedData { .. })
         ) {
             reconnect::inject_autoreconnect_filter(&mut request);
         }
@@ -413,8 +485,10 @@ impl GeyserGrpcClient {
                             config.backoff.clone(),
                         );
                         match config.policy {
-                            ReconnectionPolicy::NoReplay => InnerStream::NoReplay(reconnect_stream),
-                            ReconnectionPolicy::Replay { slot_retention } => {
+                            ReconnectionPolicy::SkipMissedData => {
+                                InnerStream::NoReplay(reconnect_stream)
+                            }
+                            ReconnectionPolicy::RecoverMissedData { slot_retention } => {
                                 InnerStream::Replay(DedupStream::new(
                                     reconnect_stream,
                                     DedupState::with_slot_retention(slot_retention),
@@ -845,7 +919,11 @@ impl GeyserGrpcBuilder {
 #[cfg(test)]
 mod tests {
     use {
-        super::{GeyserGrpcClient, SubscribeRequest, SubscribeRequestSink}, crate::reconnect::{AUTORECONNECT_FILTER_KEY, inject_autoreconnect_filter}, arc_swap::ArcSwap, futures::{FutureExt, SinkExt, StreamExt, channel::mpsc}, std::sync::{Arc, Mutex},
+        super::{GeyserGrpcClient, SubscribeRequest, SubscribeRequestSink},
+        crate::reconnect::{inject_autoreconnect_filter, AUTORECONNECT_FILTER_KEY},
+        arc_swap::ArcSwap,
+        futures::{channel::mpsc, FutureExt, SinkExt, StreamExt},
+        std::sync::{Arc, Mutex},
     };
 
     #[tokio::test]
@@ -988,7 +1066,10 @@ mod tests {
             "internal filter must survive a user filter change on the wire"
         );
         assert!(
-            shared.load().blocks_meta.contains_key(AUTORECONNECT_FILTER_KEY),
+            shared
+                .load()
+                .blocks_meta
+                .contains_key(AUTORECONNECT_FILTER_KEY),
             "internal filter must survive in stored state, reconnect reads this"
         );
     }

--- a/yellowstone-grpc-client/src/reconnect.rs
+++ b/yellowstone-grpc-client/src/reconnect.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        dedup::{DedupState, DedupStream},
-        GeyserGrpcClientError, InterceptorXToken, ReconnectConfig,
-    },
+    crate::{dedup::ReconnectCounter, GeyserGrpcClientError, InterceptorXToken, ReconnectConfig},
     arc_swap::ArcSwap,
     futures::{channel::mpsc, sink::SinkExt, stream::Stream},
     std::{
@@ -31,7 +28,7 @@ const CHECKPOINT_SLOT_BUFFER: u64 = 2;
 pub const AUTORECONNECT_FILTER_KEY: &str = "__autoreconnect";
 
 type ConnectFuture<S> =
-    Pin<Box<dyn Future<Output = Result<DedupStream<S>, GeyserGrpcClientError>> + Send + 'static>>;
+    Pin<Box<dyn Future<Output = Result<S, GeyserGrpcClientError>> + Send + 'static>>;
 
 #[derive(Debug, Clone)]
 pub struct Backoff {
@@ -352,8 +349,9 @@ pub struct AutoReconnect<GrpcStream, Connector> {
     stop: bool,
     connector: Connector,
     backoff: Backoff,
-    inner_stream: Option<DedupStream<GrpcStream>>,
+    inner_stream: Option<GrpcStream>,
     pending_connecting_task: Option<ConnectFuture<GrpcStream>>,
+    reconnect_count: u32,
 }
 
 impl<S, Connector> AutoReconnect<S, Connector>
@@ -362,7 +360,7 @@ where
     Connector: GrpcConnector<Stream = S, ConnectError = GeyserGrpcClientError>,
 {
     pub fn new(
-        stream: DedupStream<S>,
+        stream: S,
         connector: Connector,
         request: Arc<ArcSwap<SubscribeRequest>>,
         backoff: Backoff,
@@ -375,18 +373,22 @@ where
             stop: false,
             connector,
             backoff,
+            reconnect_count: 0,
         }
     }
 
-    fn make_connection_future(&self, dedup_state: DedupState) -> ConnectFuture<S> {
+    fn make_connection_future(&self) -> ConnectFuture<S> {
         let connector = self.connector.clone();
         let request = self.request.load_full();
         let from_slot = self.last_checkpoint;
-        let fut = async move {
-            let stream = connector.connect(request, from_slot).await?;
-            Ok(DedupStream::new(stream, dedup_state))
-        };
+        let fut = async move { connector.connect(request, from_slot).await };
         Box::pin(fut)
+    }
+}
+
+impl<S, Connector> ReconnectCounter for AutoReconnect<S, Connector> {
+    fn reconnect_count(&self) -> u32 {
+        self.reconnect_count
     }
 }
 
@@ -460,9 +462,7 @@ where
                             me.last_checkpoint
                         );
 
-                        let mut dedup_state = stream.state;
-                        dedup_state.prepare_for_replay();
-                        me.pending_connecting_task = Some(me.make_connection_future(dedup_state));
+                        me.pending_connecting_task = Some(me.make_connection_future());
                     }
                     Poll::Ready(Some(Err(e))) => {
                         me.stop = true;
@@ -483,6 +483,7 @@ where
                 match fut.as_mut().poll(cx) {
                     Poll::Ready(result) => match result {
                         Ok(stream) => {
+                            me.reconnect_count += 1;
                             me.inner_stream = Some(stream);
                         }
                         Err(error) => {
@@ -554,10 +555,20 @@ pub(crate) fn extract_slot(msg: &SubscribeUpdate) -> Option<u64> {
     }
 }
 
+pub(crate) fn inject_autoreconnect_filter(req: &mut SubscribeRequest) {
+    if req.blocks_meta.is_empty() {
+        req.blocks_meta
+            .insert(AUTORECONNECT_FILTER_KEY.to_string(), Default::default());
+        req.slots
+            .insert(AUTORECONNECT_FILTER_KEY.to_string(), Default::default());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::*,
+        crate::{DedupState, DedupStream},
         futures::{stream, StreamExt},
         std::{
             collections::VecDeque,
@@ -644,6 +655,27 @@ mod tests {
 
     fn request_state(request: SubscribeRequest) -> Arc<ArcSwap<SubscribeRequest>> {
         Arc::new(ArcSwap::new(Arc::new(request)))
+    }
+
+    fn make_account_msg(slot: u64) -> SubscribeUpdate {
+        SubscribeUpdate {
+            filters: vec![],
+            update_oneof: Some(UpdateOneof::Account(SubscribeUpdateAccount {
+                account: Some(SubscribeUpdateAccountInfo {
+                    pubkey: vec![1; 32],
+                    lamports: 100,
+                    owner: vec![0; 32],
+                    executable: false,
+                    rent_epoch: 0,
+                    data: vec![].into(),
+                    write_version: 1,
+                    txn_signature: Some(vec![0; 64]),
+                }),
+                slot,
+                is_startup: false,
+            })),
+            created_at: None,
+        }
     }
 
     #[test]
@@ -870,7 +902,7 @@ mod tests {
         }]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(1),
@@ -890,7 +922,7 @@ mod tests {
         let connector = MockGrpcConnector::new(vec![]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(0),
@@ -950,7 +982,7 @@ mod tests {
         }]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(1),
@@ -982,11 +1014,14 @@ mod tests {
             ]),
         }]);
 
-        let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
-            connector.clone(),
-            request_state(SubscribeRequest::default()),
-            backoff_with_retries(1),
+        let mut auto = DedupStream::new(
+            AutoReconnect::new(
+                initial,
+                connector.clone(),
+                request_state(SubscribeRequest::default()),
+                backoff_with_retries(1),
+            ),
+            DedupState::default(),
         );
 
         let msg1 = auto
@@ -1005,6 +1040,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_interrupted_slot_payload_quarantined_not_dropped() {
+        // slot 100 is inflight (account seen, no BlockMeta) when the connection dies
+        let initial = stream::iter(vec![
+            Ok(make_account_msg(100)),
+            Err(Status::unavailable("disconnect")),
+        ])
+        .boxed();
+
+        // replay re-sends the same account, then the BlockMeta that settles slot 100
+        let connector = MockGrpcConnector::new(vec![ConnectPlan {
+            expected_from_slot: None,
+            result: Ok(vec![
+                Ok(make_account_msg(100)),
+                Ok(make_block_meta_msg(100)),
+                Ok(make_slot_msg(101, 0)),
+            ]),
+        }]);
+
+        let mut stream = DedupStream::new(
+            AutoReconnect::new(
+                initial,
+                connector.clone(),
+                request_state(SubscribeRequest::default()),
+                backoff_with_retries(1),
+            ),
+            DedupState::default(),
+        );
+
+        let m1 = stream.next().await.expect("item").expect("ok");
+        assert!(matches!(m1.update_oneof, Some(UpdateOneof::Account(_))));
+
+        // Without prepare_for_replay, slot 100 is still inflight and this account
+        // matches the existing key -> dropped as Duplicate. With it, slot 100 is
+        // sealed with blockhash None, so the account is quarantined and released
+        // when the BlockMeta arrives (no stored hash -> always flush).
+        let m2 = stream.next().await.expect("item").expect("ok");
+        assert!(matches!(m2.update_oneof, Some(UpdateOneof::Account(_))));
+
+        let m3 = stream.next().await.expect("item").expect("ok");
+        assert!(matches!(m3.update_oneof, Some(UpdateOneof::BlockMeta(_))));
+
+        let m4 = stream.next().await.expect("item").expect("ok");
+        assert_eq!(extract_slot(&m4), Some(101));
+    }
+
+    #[tokio::test]
     async fn test_autoreconnect_checkpoint_buffer() {
         let block_meta_msg = make_block_meta_msg(100);
 
@@ -1020,7 +1101,7 @@ mod tests {
         }]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(1),
@@ -1049,7 +1130,7 @@ mod tests {
         let connector = MockGrpcConnector::new(vec![]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(1),
@@ -1100,7 +1181,7 @@ mod tests {
         }]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(1),
@@ -1142,7 +1223,7 @@ mod tests {
         }]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(1),
@@ -1182,7 +1263,7 @@ mod tests {
         ]);
 
         let mut auto = AutoReconnect::new(
-            DedupStream::new(initial, DedupState::default()),
+            initial,
             connector.clone(),
             request_state(SubscribeRequest::default()),
             backoff_with_retries(2), // 2 retries allowed

--- a/yellowstone-grpc-client/src/reconnect.rs
+++ b/yellowstone-grpc-client/src/reconnect.rs
@@ -352,6 +352,7 @@ pub struct AutoReconnect<GrpcStream, Connector> {
     inner_stream: Option<GrpcStream>,
     pending_connecting_task: Option<ConnectFuture<GrpcStream>>,
     reconnect_count: u32,
+    resume_from_checkpoint: bool,
 }
 
 impl<S, Connector> AutoReconnect<S, Connector>
@@ -374,13 +375,18 @@ where
             connector,
             backoff,
             reconnect_count: 0,
+            resume_from_checkpoint: true,
         }
     }
 
     fn make_connection_future(&self) -> ConnectFuture<S> {
         let connector = self.connector.clone();
         let request = self.request.load_full();
-        let from_slot = self.last_checkpoint;
+        let from_slot = if self.resume_from_checkpoint {
+            self.last_checkpoint
+        } else {
+            None
+        };
         let fut = async move { connector.connect(request, from_slot).await };
         Box::pin(fut)
     }
@@ -389,6 +395,14 @@ where
 impl<S, Connector> ReconnectCounter for AutoReconnect<S, Connector> {
     fn reconnect_count(&self) -> u32 {
         self.reconnect_count
+    }
+}
+
+impl<S, Connector> AutoReconnect<S, Connector> {
+    /// Never resume from a checkpoint. Reconnects start from the live head.
+    pub const fn without_checkpoint(mut self) -> Self {
+        self.resume_from_checkpoint = false;
+        self
     }
 }
 
@@ -458,8 +472,12 @@ where
                         }
 
                         log::warn!(
-                            "stream error: {status}. starting reconnect from slot {:?}",
-                            me.last_checkpoint
+                            "stream error: {status}. reconnecting from slot {:?}",
+                            if me.resume_from_checkpoint {
+                                me.last_checkpoint
+                            } else {
+                                None
+                            }
                         );
 
                         me.pending_connecting_task = Some(me.make_connection_future());
@@ -1276,5 +1294,36 @@ mod tests {
 
         // Stream should end
         assert!(auto.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_skip_missed_data_never_sends_from_slot() {
+        let initial = stream::iter(vec![
+            Ok(make_block_meta_msg(100)),
+            Err(Status::unavailable("disconnect")),
+        ])
+        .boxed();
+
+        let connector = MockGrpcConnector::new(vec![ConnectPlan {
+            expected_from_slot: Some(None),
+            result: Ok(vec![Ok(make_slot_msg(105, 0))]),
+        }]);
+
+        let mut auto = AutoReconnect::new(
+            initial,
+            connector.clone(),
+            request_state(SubscribeRequest::default()),
+            backoff_with_retries(1),
+        )
+        .without_checkpoint();
+
+        let _ = auto.next().await;
+        let _ = auto.next().await;
+
+        assert_eq!(
+            connector.calls(),
+            vec![None],
+            "SkipMissedData must not replay even after a BlockMeta set a checkpoint"
+        );
     }
 }


### PR DESCRIPTION
Today users who opt out of auto-reconnect are still coupled to it internally, so they pay for dedup they never use. This splits GeyserStream into variants, one of which is the bare gRPC stream, so opting out actually opts you out. It also
lifts DedupStream out of AutoReconnect, which deletes the state handoff between them and gives us a third variant almost for free: reconnect without dedup, for consumers that want to auto-reconnect but have no use for the messages lost in disconnection gap.

Extends and Closes #STR-620