### PR TITLE
Tonic optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## 2026-08-06
+
+- yellowstone-grpc-geyser 14.2.4
+
+### Misc
+
+- plugin perf: use tonic's vectored writes for less overhead and copying when using TLS
+
 ## 2026-08-04
 
 - yellowstone-grpc-geyser 14.2.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "14.2.3"
+version = "14.2.4"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ spl-token-2022-interface = "2.1.0"
 
 # Yellowstone
 yellowstone-block-machine = { version = "0.9.0", default-features = false }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.2.3" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "14.2.4" }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.3.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.5.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "14.2.3"
+version = "14.2.4"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-tools/src/server/tls.rs
+++ b/yellowstone-grpc-tools/src/server/tls.rs
@@ -445,6 +445,18 @@ impl AsyncWrite for TlsIO {
         self.project().inner.poll_write(cx, buf)
     }
 
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
         self.project().inner.poll_flush(cx)
     }
@@ -545,7 +557,7 @@ mod tests {
         super::*,
         std::{
             fs::{self, File},
-            io::{ErrorKind, Write},
+            io::{ErrorKind, IoSlice, Write},
             path::PathBuf,
             sync::{
                 atomic::{AtomicU64, Ordering},
@@ -553,7 +565,7 @@ mod tests {
             },
             time::{Duration, SystemTime, UNIX_EPOCH},
         },
-        tokio::io::AsyncWriteExt,
+        tokio::io::{AsyncReadExt, AsyncWriteExt},
         tokio_rustls::{
             rustls::{
                 self,
@@ -815,13 +827,19 @@ sF+HCDt5QXFY9Up3hhtWqKee6Sfd+kGC2cUKNhTZ2Q5VAc4uzJ7TpBU/DX6W+DU0
             let server_name = ServerName::try_from("localhost")
                 .expect("localhost should be a valid TLS server name");
 
-            good_connector
+            let mut stream = good_connector
                 .connect(server_name, stream)
                 .await
                 .expect("TLS handshake should succeed");
+            let mut buf = [0; 11];
+            stream
+                .read_exact(&mut buf)
+                .await
+                .expect("TLS client should read server bytes");
+            assert_eq!(&buf, b"hello world");
         });
 
-        let accepted = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut accepted = tokio::time::timeout(Duration::from_secs(5), async {
             match tls_incoming.next().await {
                 Some(Ok(io)) => io,
                 Some(Err(err)) => panic!("unexpected stream error: {err}"),
@@ -830,6 +848,10 @@ sF+HCDt5QXFY9Up3hhtWqKee6Sfd+kGC2cUKNhTZ2Q5VAc4uzJ7TpBU/DX6W+DU0
         })
         .await
         .expect("TlsIncoming should yield a successful stream in time");
+
+        assert!(accepted.is_write_vectored());
+        let bufs = [IoSlice::new(b"hello"), IoSlice::new(b" world")];
+        assert_eq!(accepted.write_vectored(&bufs).await.unwrap(), 11);
 
         bad_client
             .await

--- a/yellowstone-grpc-tools/src/server/tonic/ratelimit/transport.rs
+++ b/yellowstone-grpc-tools/src/server/tonic/ratelimit/transport.rs
@@ -129,6 +129,18 @@ where
         Pin::new(&mut this.wrappee).poll_write(cx, buf)
     }
 
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().wrappee).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.wrappee.is_write_vectored()
+    }
+
     /// Flushes the wrapped IO.
     fn poll_flush(
         self: std::pin::Pin<&mut Self>,
@@ -252,7 +264,11 @@ where
 mod tests {
     use {
         super::*,
-        std::{io, task::Poll},
+        std::{
+            io::{self, IoSlice},
+            task::Poll,
+        },
+        tokio::io::AsyncWriteExt,
     };
 
     #[derive(Default)]
@@ -297,6 +313,18 @@ mod tests {
             Poll::Ready(Ok(buf.len()))
         }
 
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            true
+        }
+
         fn poll_flush(
             self: Pin<&mut Self>,
             _cx: &mut std::task::Context<'_>,
@@ -310,6 +338,26 @@ mod tests {
         ) -> Poll<io::Result<()>> {
             Poll::Ready(Ok(()))
         }
+    }
+
+    #[tokio::test]
+    async fn rate_limited_io_preserves_vectored_writes() {
+        let remote_addr: SocketAddr = "192.168.1.42:50051".parse().expect("valid socket addr");
+        let active_conn_map = Arc::new(Mutex::new(HashMap::new()));
+        let callbacks = NoopCallbacks;
+        let mut io = RateLimitedIO::try_new(
+            MockIo {
+                remote_addr: Some(remote_addr),
+            },
+            1,
+            active_conn_map,
+            &callbacks,
+        )
+        .expect("connection should be accepted");
+        let bufs = [IoSlice::new(b"hello"), IoSlice::new(b" world")];
+
+        assert!(io.is_write_vectored());
+        assert_eq!(io.write_vectored(&bufs).await.unwrap(), 11);
     }
 
     #[test]


### PR DESCRIPTION
Vectored write support was hidden within RateLimitedIO's trait. This meant that Tonic was using scalar copy, which would copy memory 3 times more than necessary for h2 frame prefixes.