### PR TITLE
fix(e2e): disable http2_adaptive_window; publish yellowstone-e2e binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,19 @@ builds:
           post:
               - cmd: strip {{ .Path }}
 
+    - id: e2e
+      builder: rust
+      binary: yellowstone-e2e
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=yellowstone-grpc-intg-test
+          - --bin=yellowstone-e2e
+      hooks:
+          post:
+              - cmd: strip {{ .Path }}
+
 archives:
     - id: geyser
       ids: [geyser]
@@ -70,6 +83,11 @@ archives:
       formats: [binary]
       ids: [config-check]
       name_template: config-check-linux-amd64
+
+    - id: e2e
+      formats: [binary]
+      ids: [e2e]
+      name_template: yellowstone-e2e-linux-amd64
 
 release:
     github:

--- a/yellowstone-grpc-e2e-test/src/grpc.rs
+++ b/yellowstone-grpc-e2e-test/src/grpc.rs
@@ -29,7 +29,10 @@ pub async fn new_client(config: &RunConfig) -> Result<GeyserGrpcClient> {
         .max_decoding_message_size(100_000_000)
         .initial_connection_window_size(10_000_000)
         .initial_stream_window_size(8_000_000)
-        .http2_adaptive_window(true)
+        // adaptive window overrides the explicit windows above down to the h2 default
+        // 65535, which deadlocks multiplexed subscribes behind haproxy while the
+        // firehose stream is unconsumed (haproxy mux-h2 parks HEADERS behind conn window)
+        .http2_adaptive_window(false)
         .accept_compressed(yellowstone_grpc_proto::tonic::codec::CompressionEncoding::Zstd);
 
     if let Some(dial) = config.dial.clone() {


### PR DESCRIPTION
<!-- Human summary goes here -->

<details>
<summary>AI description, click for details</summary>

The blockmachine e2e scenario fails intermittently (~5%, bursty) against the shared
load balancers with `Reset(StreamId(3), REFUSED_STREAM)` after exactly 25s, while
direct-to-node runs never fail.

Root cause (full report: `/workspaces/str-blockmachine-haproxy-deadlock/REPORT.md`
in the ops codespace): hyper's `http2_adaptive_window(true)` silently overrides the
explicit `initial_connection_window_size(10MB)` / `initial_stream_window_size(8MB)`
down to the h2 default 65,535. The firehose stream exhausts that connection window
within ~2ms while the client is still awaiting the second `subscribe_once`'s
response headers — and haproxy's mux-h2 (3.3.x through master) never emits those
flow-control-exempt response HEADERS while its connection send window is exhausted
(`h2_resume_each_sending_h2s` gates `send_list` on `mws <= 0`). Deadlock; haproxy's
per-stream `timeout client 25s` then kills the connection (logs as 200/`cD--`).

With adaptive off, the configured 10MB/8MB windows actually apply and the deadlock
window disappears.

Validation (paired, same time windows, via `api.rpcpool.com`):
- this fix (adaptive off): **60/60 pass**
- concurrent adaptive-on control: **58/60** — 2 failures in a burst at
  10:37–10:38 UTC, i.e. failure conditions were live while the fixed binary passed
- plus 0/100 vs 2/128 in earlier instrumented A/B runs

Second commit adds `yellowstone-e2e` to `.goreleaser.yaml` — the nomad dispatch job
downloads `yellowstone-e2e-linux-amd64` from GCS, but no release build ever
published it (only ad-hoc branch builds did). Builds `v0.0.0-dev.g7876b7b0` (this
branch) and `v0.0.0-dev.g5d06f1d1` (master + goreleaser only, as control) are
published and dispatchable once rpcpool/terraform#2452 (dispatch job interpolation
fix) is applied.

Consider also whether `GeyserGrpcClient::build_from_shared` should keep
`http2_adaptive_window(true)` as the library default (lib.rs:666) — every library
user multiplexing subscribes through the LBs is exposed to the same deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bvh6RqUBere5tXBfWtnzj

</details>
