### PR TITLE
Reconstruct V1 messages in convert_from instead of downgrading them to V0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+- yellowstone-grpc-geyser 15.1.1
+
 ### Fixes
 
 - plugin: reconstruct V1 messages in `convert_from::create_message` instead of downgrading them to V0. `convert_to` already emits `Message.config` for V1, but `convert_from` only checked the `versioned` boolean, which is true for both V0 and V1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+### Fixes
+
+- plugin: reconstruct V1 messages in `convert_from::create_message` instead of downgrading them to V0. `convert_to` already emits `Message.config` for V1, but `convert_from` only checked the `versioned` boolean, which is true for both V0 and V1
+
 ## 2026-08-10
 
 - yellowstone-grpc-proto 12.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "15.1.0"
+version = "15.1.1"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "15.1.0"
+version = "15.1.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"

--- a/yellowstone-grpc-geyser/src/plugin/convert_from.rs
+++ b/yellowstone-grpc-geyser/src/plugin/convert_from.rs
@@ -5,6 +5,7 @@ use {
     solana_message::{
         compiled_instruction::CompiledInstruction,
         v0::{LoadedAddresses, Message as MessageV0, MessageAddressTableLookup},
+        v1::{Message as MessageV1, TransactionConfig},
         Message, MessageHeader, VersionedMessage,
     },
     solana_pubkey::Pubkey,
@@ -104,8 +105,27 @@ pub fn create_message(message: proto::Message) -> CreateResult<VersionedMessage>
             .map_err(|_| "failed to parse num_readonly_unsigned_accounts")?,
     };
 
-    if message.recent_blockhash.len() != HASH_BYTES {
+    let Ok(blockhash) = <[u8; HASH_BYTES]>::try_from(message.recent_blockhash.as_slice()) else {
         return Err("failed to parse hash");
+    };
+    let recent_blockhash = Hash::new_from_array(blockhash);
+
+    // `config` is set only for V1 messages, whose lifetime specifier is carried in
+    // `recent_blockhash` and which have no address table lookups. `versioned` is
+    // true for both V0 and V1, so it cannot tell them apart on its own.
+    if let Some(config) = message.config {
+        return Ok(VersionedMessage::V1(MessageV1 {
+            header,
+            config: TransactionConfig {
+                priority_fee: config.priority_fee,
+                compute_unit_limit: config.compute_unit_limit,
+                loaded_accounts_data_size_limit: config.loaded_accounts_data_size_limit,
+                heap_size: config.heap_size,
+            },
+            lifetime_specifier: recent_blockhash,
+            account_keys: create_pubkey_vec(message.account_keys)?,
+            instructions: create_message_instructions(message.instructions)?,
+        }));
     }
 
     Ok(if message.versioned {
@@ -122,9 +142,7 @@ pub fn create_message(message: proto::Message) -> CreateResult<VersionedMessage>
         VersionedMessage::V0(MessageV0 {
             header,
             account_keys: create_pubkey_vec(message.account_keys)?,
-            recent_blockhash: Hash::new_from_array(
-                <[u8; HASH_BYTES]>::try_from(message.recent_blockhash.as_slice()).unwrap(),
-            ),
+            recent_blockhash,
             instructions: create_message_instructions(message.instructions)?,
             address_table_lookups,
         })
@@ -132,9 +150,7 @@ pub fn create_message(message: proto::Message) -> CreateResult<VersionedMessage>
         VersionedMessage::Legacy(Message {
             header,
             account_keys: create_pubkey_vec(message.account_keys)?,
-            recent_blockhash: Hash::new_from_array(
-                <[u8; HASH_BYTES]>::try_from(message.recent_blockhash.as_slice()).unwrap(),
-            ),
+            recent_blockhash,
             instructions: create_message_instructions(message.instructions)?,
         })
     })


### PR DESCRIPTION
## The problem

`convert_to::create_message` already emits `Message.config` for V1 messages ([`convert_to.rs:50-62`](https://github.com/rpcpool/yellowstone-grpc/blob/master/yellowstone-grpc-geyser/src/plugin/convert_to.rs#L50)), but `convert_from::create_message` never reads it back. It picks between V0 and Legacy on the `versioned` boolean alone:

```rust
Ok(if message.versioned {
    // ... V0
} else {
    // ... Legacy
})
```

`versioned` is `true` for **both** V0 and V1 — `convert_to` sets it that way for V1 too. So every V1 message round-trips into `VersionedMessage::V0`.

The failure is silent, not loud:

- signatures are correct
- the message version is wrong
- the SIMD-0385 inline budget config is dropped
- the reconstructed message no longer corresponds to the bytes that were signed

Presence of `config` is the only signal on the wire that distinguishes the two, since V1 also carries no address table lookups — so a V1 message is otherwise byte-indistinguishable from a V0 message with an empty lookup list.

## The fix

Check `config` before falling through to the `versioned` branch, and reconstruct `VersionedMessage::V1`. The mapping is lossless in both directions: `convert_to` writes `lifetime_specifier` into `recent_blockhash` and V1 has no address table lookups, so nothing else needs to be recovered.

Legacy and V0 paths are unchanged.

One incidental change worth flagging so it doesn't read as unrelated drift: the blockhash parse is hoisted into a `let ... else` because three branches now need the value. That replaces the length pre-check and removes the two existing `.unwrap()` calls, rather than adding a third.

## Verification

Run from a clean clone of `master` with the change applied:

- `cargo check -p yellowstone-grpc-geyser` — exit 0
- `cargo clippy -p yellowstone-grpc-geyser --all-targets` — exit 0, no warnings
- `cargo +nightly fmt --all -- --check` — exit 0

The last two are the commands from `.github/workflows/test.yml`.

## Notes

There is no test module under `yellowstone-grpc-geyser/src/plugin/`, so this change adds none. Happy to add a `convert_to` → `convert_from` round-trip test if you would like one — it would need a new test module, so I left that to your preference rather than introducing one unasked.

This is dormant until SIMD-0385 activates, since no V1 transaction exists on chain yet. It seemed better to fix it before that rather than after.
