### PR TITLE
Account filtering performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+## 2026-08-17
+
+- yellowstone-grpc-geyser 15.1.2
+
+### Fixes
+
+- plugin: performance optimization of account update filtering
+
+## 2026-08-13
+
 - yellowstone-grpc-geyser 15.1.1
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-geyser"
-version = "15.1.1"
+version = "15.1.2"
 dependencies = [
  "affinity",
  "agave-geyser-plugin-interface",
@@ -6506,6 +6506,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "dashmap",
+ "fastrand",
  "foldhash 0.2.0",
  "futures",
  "git-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1358,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2554,7 +2554,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3147,7 +3147,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3408,7 +3408,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3467,7 +3467,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3771,7 +3771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5334,7 +5334,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6103,7 +6103,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ spl-token-2022-interface = "2.1.0"
 # Yellowstone
 yellowstone-block-machine = { version = "0.9.0", default-features = false }
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "13.3.0" }
-yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "15.1.0" }
+yellowstone-grpc-geyser = { path = "yellowstone-grpc-geyser", version = "15.1.2" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "12.6.0", default-features = false }
 yellowstone-grpc-e2e-macros = { path = "yellowstone-grpc-e2e-macros", version = "0.1.0" }
 yellowstone-grpc-tools = { path = "yellowstone-grpc-tools", version = "0.1.0" }

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-geyser"
-version = "15.1.1"
+version = "15.1.2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Yellowstone gRPC Geyser Plugin"
@@ -117,6 +117,7 @@ vergen = { workspace = true, features = ["build", "rustc"] }
 [dev-dependencies]
 bytes = { workspace = true }
 criterion = { workspace = true }
+fastrand = { workspace = true }
 solana-keypair = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/yellowstone-grpc-geyser/benches/filter.rs
+++ b/yellowstone-grpc-geyser/benches/filter.rs
@@ -1,128 +1,158 @@
 use {
-    bytes::Bytes,
     criterion::{criterion_group, criterion_main, BenchmarkId, Criterion},
-    prost_types::Timestamp,
-    solana_hash::Hash,
-    solana_keypair::Keypair,
-    solana_message::{Message as SolMessage, MessageHeader},
     solana_pubkey::Pubkey,
-    solana_signer::Signer,
-    solana_transaction::{versioned::VersionedTransaction, Transaction},
-    solana_transaction_status::TransactionStatusMeta,
-    std::{
-        collections::HashMap,
-        hint::black_box,
-        sync::{Arc, OnceLock},
-        time::{Duration, SystemTime},
-    },
+    solana_signature::Signature,
+    std::{collections::HashMap, hint::black_box, time::Duration},
     yellowstone_grpc_geyser::plugin::{
-        convert_to,
-        filter::{limits::FilterLimits, name::FilterNames, Filter},
-        message::{
-            Message, MessageAccount, MessageAccountInfo, MessageTransaction, MessageTransactionInfo,
-        },
+        filter::{fixtures, limits::FilterLimits, Filter},
+        message::Message,
     },
-    yellowstone_grpc_proto::geyser::{
-        SubscribeRequest, SubscribeRequestFilterAccounts, SubscribeRequestFilterSlots,
-        SubscribeRequestFilterTransactions,
+    yellowstone_grpc_proto::{
+        cuckoo::CuckooFilter,
+        geyser::{
+            CuckooFilter as ProtoCuckooFilter, SubscribeRequest, SubscribeRequestFilterAccounts,
+            SubscribeRequestFilterSlots, SubscribeRequestFilterTransactions,
+        },
     },
 };
 
-fn filter_names() -> FilterNames {
-    FilterNames::new(64, 1024, Duration::from_secs(1))
+const FILTER_COUNTS: [usize; 6] = [1, 2, 8, 64, 65, 256];
+const PUBKEYS_PER_FILTER: [usize; 3] = [1, 100, 10_000];
+
+fn unlimited() -> FilterLimits {
+    FilterLimits::default()
 }
 
-fn create_message_account(pubkey: Pubkey, owner: Pubkey) -> Arc<MessageAccount> {
-    Arc::new(MessageAccount {
-        account: MessageAccountInfo {
-            pubkey,
-            lamports: 1000,
-            owner,
-            executable: false,
-            rent_epoch: 0,
-            data: Bytes::new(),
-            write_version: 1,
-            txn_signature: None,
-            pre_encoded: OnceLock::new(),
-        },
-        slot: 100,
-        is_startup: false,
-        created_at: Timestamp::from(SystemTime::now()),
-    })
+fn build_filter(request: SubscribeRequest) -> Filter {
+    Filter::new(&request, &unlimited(), &mut fixtures::filter_names()).expect("filter builds")
 }
 
-fn create_message_transaction(
-    keypair: &Keypair,
-    account_keys: Vec<Pubkey>,
-) -> Arc<MessageTransaction> {
-    let message = SolMessage {
-        header: MessageHeader {
-            num_required_signatures: 1,
-            ..MessageHeader::default()
-        },
-        account_keys,
-        ..SolMessage::default()
-    };
-    let versioned_transaction =
-        VersionedTransaction::from(Transaction::new(&[keypair], message, Hash::default()));
-    let meta = convert_to::create_transaction_meta(&TransactionStatusMeta {
-        status: Ok(()),
-        ..TransactionStatusMeta::default()
-    });
-    let sig = *versioned_transaction
-        .signatures
-        .first()
-        .expect("no signature");
-    let account_keys = versioned_transaction
-        .message
-        .static_account_keys()
-        .iter()
-        .copied()
-        .collect();
-
-    Arc::new(MessageTransaction {
-        transaction: MessageTransactionInfo {
-            signature: sig,
-            is_vote: false,
-            transaction: convert_to::create_transaction(&versioned_transaction),
-            meta,
-            index: 1,
-            account_keys,
-            pre_encoded: OnceLock::new(),
-            token_owners_all: OnceLock::new(),
-            token_owners_changed: OnceLock::new(),
-        },
-        slot: 100,
-        created_at: Timestamp::from(SystemTime::now()),
-    })
+fn account_request(
+    n_filters: usize,
+    pubkeys_per_filter: usize,
+    pool: &[Pubkey],
+    owner: Pubkey,
+) -> SubscribeRequest {
+    let mut accounts = HashMap::with_capacity(n_filters);
+    for i in 0..n_filters {
+        let start = (i * pubkeys_per_filter) % pool.len();
+        let keys = (0..pubkeys_per_filter)
+            .map(|k| pool[(start + k) % pool.len()].to_string())
+            .collect::<Vec<_>>();
+        accounts.insert(
+            format!("filter-{i}"),
+            SubscribeRequestFilterAccounts {
+                account: keys,
+                owner: vec![owner.to_string()],
+                ..Default::default()
+            },
+        );
+    }
+    SubscribeRequest {
+        accounts,
+        ..Default::default()
+    }
 }
 
-fn tx_with_30_keys(keypair: &Keypair) -> Vec<Pubkey> {
-    let mut keys = vec![keypair.pubkey()];
-    keys.extend((0..29).map(|_| Pubkey::new_unique()));
-    keys
+fn accounts_by_filter_count(c: &mut Criterion) {
+    let pool = fixtures::deterministic_pubkeys(1, 20_000);
+    let owner = Pubkey::new_from_array([9; 32]);
+    let stranger = Pubkey::new_from_array([8; 32]);
+
+    for pubkeys_per_filter in PUBKEYS_PER_FILTER {
+        let mut group = c.benchmark_group(format!("accounts/scan_{pubkeys_per_filter}"));
+        for n_filters in FILTER_COUNTS {
+            let filter = build_filter(account_request(n_filters, pubkeys_per_filter, &pool, owner));
+
+            let hit = Message::Account(fixtures::simple_message_account(pool[0], owner));
+            let miss = Message::Account(fixtures::simple_message_account(stranger, stranger));
+            let near_miss = Message::Account(fixtures::simple_message_account(stranger, owner));
+
+            for (label, message) in [("hit", &hit), ("miss", &miss), ("near_miss", &near_miss)] {
+                group.bench_with_input(BenchmarkId::new(label, n_filters), &n_filters, |b, _| {
+                    b.iter(|| black_box(filter.get_updates(black_box(message), None)))
+                });
+            }
+        }
+        group.finish();
+    }
 }
 
-/// Client subscribed to slots only. Account updates still reach its
-/// client_loop, so the account path runs and returns empty every time.
-/// This is the case the early return skips.
-fn slots_only_client(c: &mut Criterion) {
-    let mut slots = HashMap::new();
-    slots.insert("s".to_owned(), SubscribeRequestFilterSlots::default());
+fn accounts_with_cuckoo(c: &mut Criterion) {
+    let pool = fixtures::deterministic_pubkeys(2, 10_000);
+    let owner = Pubkey::new_from_array([9; 32]);
+    let stranger = Pubkey::new_from_array([8; 32]);
 
-    let filter = Filter::new(
-        &SubscribeRequest {
-            slots,
+    let mut cuckoo = CuckooFilter::<[u8; 32]>::with_capacity(pool.len()).unwrap();
+    for key in &pool {
+        cuckoo.insert(&key.to_bytes()).unwrap();
+    }
+    let proto = ProtoCuckooFilter::from(&cuckoo);
+
+    let mut group = c.benchmark_group("accounts/cuckoo");
+    for n_filters in [1usize, 8, 64] {
+        let mut accounts = HashMap::new();
+        for i in 0..n_filters {
+            accounts.insert(
+                format!("filter-{i}"),
+                SubscribeRequestFilterAccounts {
+                    cuckoo_accounts_filter: Some(proto.clone()),
+                    ..Default::default()
+                },
+            );
+        }
+        let filter = build_filter(SubscribeRequest {
+            accounts,
             ..Default::default()
-        },
-        &FilterLimits::default(),
-        &mut filter_names(),
-    )
-    .unwrap();
+        });
 
-    let message = Message::Account(create_message_account(
-        Pubkey::new_unique(),
-        Pubkey::new_unique(),
+        let hit = Message::Account(fixtures::simple_message_account(pool[0], owner));
+        let miss = Message::Account(fixtures::simple_message_account(stranger, stranger));
+        for (label, message) in [("hit", &hit), ("miss", &miss)] {
+            group.bench_with_input(BenchmarkId::new(label, n_filters), &n_filters, |b, _| {
+                b.iter(|| black_box(filter.get_updates(black_box(message), None)))
+            });
+        }
+    }
+    group.finish();
+}
+
+fn subscribe_filter_new(c: &mut Criterion) {
+    let pool = fixtures::deterministic_pubkeys(3, 100_000);
+    let owner = Pubkey::new_from_array([9; 32]);
+
+    let mut group = c.benchmark_group("subscribe/filter_new");
+    group.sample_size(20);
+    for (n_filters, pubkeys_per_filter) in [(1usize, 1_000usize), (1, 10_000), (10, 10_000)] {
+        let request = account_request(n_filters, pubkeys_per_filter, &pool, owner);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{n_filters}x{pubkeys_per_filter}")),
+            &request,
+            |b, request| {
+                b.iter(|| {
+                    black_box(
+                        Filter::new(
+                            black_box(request),
+                            &unlimited(),
+                            &mut fixtures::filter_names(),
+                        )
+                        .unwrap(),
+                    )
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn slots_only_client(c: &mut Criterion) {
+    let filter = build_filter(SubscribeRequest {
+        slots: HashMap::from([("s".to_owned(), SubscribeRequestFilterSlots::default())]),
+        ..Default::default()
+    });
+    let message = Message::Account(fixtures::simple_message_account(
+        Pubkey::new_from_array([1; 32]),
+        Pubkey::new_from_array([2; 32]),
     ));
 
     c.bench_function("slots_only/account", |b| {
@@ -130,117 +160,64 @@ fn slots_only_client(c: &mut Criterion) {
     });
 }
 
-/// Control for the early return: a client that does have account filters
-/// must not pay for the guard.
-fn one_account_filter(c: &mut Criterion) {
-    let owner = Pubkey::new_unique();
-
-    let mut accounts = HashMap::new();
-    accounts.insert(
-        "a".to_owned(),
-        SubscribeRequestFilterAccounts {
-            owner: vec![owner.to_string()],
-            ..Default::default()
-        },
-    );
-
-    let filter = Filter::new(
-        &SubscribeRequest {
-            accounts,
-            ..Default::default()
-        },
-        &FilterLimits::default(),
-        &mut filter_names(),
-    )
-    .unwrap();
-
-    let message = Message::Account(create_message_account(Pubkey::new_unique(), owner));
-
-    c.bench_function("one_account_filter/account", |b| {
-        b.iter(|| black_box(filter.get_updates(black_box(&message), None)))
-    });
+fn transaction_keys() -> Vec<Pubkey> {
+    fixtures::deterministic_pubkeys(4, 30)
 }
 
-/// One transaction filter whose account_include holds N pubkeys, matched
-/// against a 30-key transaction containing none of them. Worst case: no
-/// short-circuit, so the full comparison runs.
-fn sweep_account_include(c: &mut Criterion) {
-    let keypair = Keypair::new();
-    let message = Message::Transaction(create_message_transaction(
-        &keypair,
-        tx_with_30_keys(&keypair),
+fn transaction_account_include(c: &mut Criterion) {
+    let keys = transaction_keys();
+    let message = Message::Transaction(fixtures::message_transaction(
+        Signature::default(),
+        keys.clone(),
+        false,
+        Default::default(),
     ));
+    let pool = fixtures::deterministic_pubkeys(5, 10_000);
 
-    let mut group = c.benchmark_group("sweep/account_include");
+    let mut group = c.benchmark_group("transactions/account_include");
     for n in [1usize, 10, 100, 1_000, 10_000] {
-        let include: Vec<String> = (0..n).map(|_| Pubkey::new_unique().to_string()).collect();
-
-        let mut transactions = HashMap::new();
-        transactions.insert(
-            "t".to_owned(),
-            SubscribeRequestFilterTransactions {
-                account_include: include,
+        for (label, include) in [
+            (
+                "miss",
+                pool[..n].iter().map(|k| k.to_string()).collect::<Vec<_>>(),
+            ),
+            (
+                "hit",
+                pool[..n.saturating_sub(1)]
+                    .iter()
+                    .map(|k| k.to_string())
+                    .chain(std::iter::once(keys[15].to_string()))
+                    .collect::<Vec<_>>(),
+            ),
+        ] {
+            let filter = build_filter(SubscribeRequest {
+                transactions: HashMap::from([(
+                    "t".to_owned(),
+                    SubscribeRequestFilterTransactions {
+                        account_include: include,
+                        ..Default::default()
+                    },
+                )]),
                 ..Default::default()
-            },
-        );
-
-        let mut limits = FilterLimits::default();
-        limits.transactions.account_include_max = usize::MAX;
-
-        let filter = Filter::new(
-            &SubscribeRequest {
-                transactions,
-                ..Default::default()
-            },
-            &limits,
-            &mut filter_names(),
-        )
-        .unwrap();
-
-        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
-            b.iter(|| black_box(filter.get_updates(black_box(&message), None)))
-        });
+            });
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
+                b.iter(|| black_box(filter.get_updates(black_box(&message), None)))
+            });
+        }
     }
     group.finish();
 }
 
-/// A one-pubkey include list that the transaction does touch,
-/// so the comparison short-circuits on the hit.
-fn small_include_matching(c: &mut Criterion) {
-    let keypair = Keypair::new();
-    let tx_keys = tx_with_30_keys(&keypair);
-    let hit = tx_keys[15];
-    let message = Message::Transaction(create_message_transaction(&keypair, tx_keys));
-
-    let mut transactions = HashMap::new();
-    transactions.insert(
-        "t".to_owned(),
-        SubscribeRequestFilterTransactions {
-            account_include: vec![hit.to_string()],
-            ..Default::default()
-        },
-    );
-
-    let filter = Filter::new(
-        &SubscribeRequest {
-            transactions,
-            ..Default::default()
-        },
-        &FilterLimits::default(),
-        &mut filter_names(),
-    )
-    .unwrap();
-
-    c.bench_function("small_include/matching", |b| {
-        b.iter(|| black_box(filter.get_updates(black_box(&message), None)))
-    });
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    targets =
+        accounts_by_filter_count,
+        accounts_with_cuckoo,
+        subscribe_filter_new,
+        slots_only_client,
+        transaction_account_include,
 }
-
-criterion_group!(
-    benches,
-    slots_only_client,
-    one_account_filter,
-    sweep_account_include,
-    small_include_matching,
-);
 criterion_main!(benches);

--- a/yellowstone-grpc-geyser/src/plugin/filter/encoder.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/encoder.rs
@@ -53,7 +53,6 @@ impl TransactionEncoder {
         let index = tx.index as u64;
 
         SIGNATURE_FIELD_ENCODED_LEN
-            + size_of::<Signature>()
             + if tx.is_vote {
                 prost::encoding::bool::encoded_len(2u32, &tx.is_vote)
             } else {
@@ -138,5 +137,82 @@ impl AccountEncoder {
             + account
                 .txn_signature
                 .map_or(0, |_| SIGNATURE_FIELD_ENCODED_LEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::plugin::filter::fixtures, solana_signature::Signature,
+        yellowstone_grpc_proto::solana::storage::confirmed_block,
+    };
+
+    #[test]
+    fn transaction_encoded_len_matches_the_bytes_actually_written() {
+        let keys = fixtures::deterministic_pubkeys(40, 6);
+
+        for (label, is_vote, meta) in [
+            (
+                "empty meta",
+                false,
+                confirmed_block::TransactionStatusMeta::default(),
+            ),
+            (
+                "vote with fee",
+                true,
+                confirmed_block::TransactionStatusMeta {
+                    fee: 5000,
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let message =
+                fixtures::message_transaction(Signature::default(), keys.clone(), is_vote, meta);
+            let tx = &message.transaction;
+
+            let mut buf = Vec::new();
+            TransactionEncoder::encode_raw(tx, &mut buf);
+
+            assert_eq!(
+                TransactionEncoder::encoded_len(tx),
+                buf.len(),
+                "{label}: encoded_len must equal the encoded byte count"
+            );
+        }
+    }
+
+    #[test]
+    fn account_encoded_len_matches_the_bytes_actually_written() {
+        let keys = fixtures::deterministic_pubkeys(41, 2);
+
+        for (label, data, lamports, signature) in [
+            ("empty", Vec::new(), 0u64, None),
+            (
+                "token account",
+                fixtures::token_account_data(None),
+                1000,
+                None,
+            ),
+            (
+                "with signature",
+                vec![7u8; 40],
+                u64::MAX,
+                Some(Signature::default()),
+            ),
+        ] {
+            let account = fixtures::account_info(keys[0], keys[1], data, lamports, signature);
+
+            AccountEncoder::pre_encode(&account);
+            let encoded = account
+                .pre_encoded
+                .get()
+                .expect("pre_encode fills the cache");
+
+            assert_eq!(
+                AccountEncoder::encoded_len(&account),
+                encoded.len(),
+                "{label}: encoded_len must equal the encoded byte count"
+            );
+        }
     }
 }

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -14,8 +14,9 @@ use {
             name::{FilterName, FilterNameError, FilterNames},
         },
         message::{
-            CommitmentLevel, Message, MessageAccount, MessageBlock, MessageBlockMeta,
-            MessageDeshredTransaction, MessageEntry, MessageSlot, MessageTransaction, SlotStatus,
+            CommitmentLevel, Message, MessageAccount, MessageAccountInfo, MessageBlock,
+            MessageBlockMeta, MessageDeshredTransaction, MessageEntry, MessageSlot,
+            MessageTransaction, SlotStatus,
         },
     },
     base64::{engine::general_purpose::STANDARD as base64_engine, Engine},
@@ -267,29 +268,6 @@ impl Filter {
     /// They do not depend on live traffic and are safe to call for logging,
     /// metrics, and debugging.
     pub fn get_filter_stats(&self) -> FilterStats {
-        // `accounts.account` is indexed by pubkey -> set(filter_name).
-        // For complexity we need the inverse shape (filter_name -> count(pubkeys)),
-        // so we accumulate how many pubkeys point to each filter.
-        let mut account_pubkey_hits = HashMap::new();
-        for filter_names in self.accounts.account.values() {
-            for filter_name in filter_names {
-                *account_pubkey_hits
-                    .entry(filter_name.clone())
-                    .or_insert(0usize) += 1;
-            }
-        }
-
-        // Same inversion for owner constraints: owner pubkey -> set(filter_name)
-        // becomes per-filter owner count.
-        let mut owner_pubkey_hits = HashMap::new();
-        for filter_names in self.accounts.owner.values() {
-            for filter_name in filter_names {
-                *owner_pubkey_hits
-                    .entry(filter_name.clone())
-                    .or_insert(0usize) += 1;
-            }
-        }
-
         // We iterate `aggregates` as the canonical list of account filters.
         // Reason: an account filter can exist without account/owner pubkeys
         // (for example only state checks or nonempty_txn_signature), and those
@@ -299,14 +277,15 @@ impl Filter {
             .aggregates
             .iter()
             .map(|aggregate| AccountFilterStats {
-                accounts_len: account_pubkey_hits
-                    .get(&aggregate.filter_name)
-                    .copied()
+                // `accounts.account` is indexed by pubkey -> set(filter_name).
+                // For complexity we need the inverse shape (filter_name -> count(pubkeys)),
+                // so we accumulate how many pubkeys point to each filter.
+                accounts_len: aggregate
+                    .accounts
+                    .as_ref()
+                    .map(|set| set.len())
                     .unwrap_or(0),
-                owners_len: owner_pubkey_hits
-                    .get(&aggregate.filter_name)
-                    .copied()
-                    .unwrap_or(0),
+                owners_len: aggregate.owners.as_ref().map(|set| set.len()).unwrap_or(0),
             })
             .collect();
 
@@ -463,52 +442,103 @@ impl Filter {
 #[derive(Debug, Clone)]
 struct FilterAccountAggregate {
     pub filter_name: FilterName,
-    pub require_non_empty_txn_signature: bool,
-    pub require_account: bool,
-    pub require_cuckoo: bool,
-    pub require_owner: bool,
-    pub require_state_check: bool,
+    pub txn_signature: Option<bool>,
+    pub accounts: Option<FoldHashSet<Pubkey>>,
+    pub accounts_cuckoo: Option<Arc<CuckooFilter<[u8; 32]>>>,
+    pub owners: Option<FoldHashSet<Pubkey>>,
+    pub account_state: Option<FilterAccountsState>,
 }
 
 impl FilterAccountAggregate {
+    pub const fn new(filter_name: FilterName) -> Self {
+        Self {
+            filter_name,
+            txn_signature: None,
+            accounts: None,
+            accounts_cuckoo: None,
+            owners: None,
+            account_state: None,
+        }
+    }
+
+    const fn match_txn_signature(&self, txn_signature: &Option<Signature>) -> bool {
+        if let Some(required_txn_signature) = self.txn_signature {
+            if required_txn_signature != txn_signature.is_some() {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn match_account(&self, pubkey: &Pubkey, matched_account: Option<bool>) -> bool {
+        if self.accounts.is_none() && self.accounts_cuckoo.is_none() {
+            return true;
+        }
+
+        if !self.accounts.as_ref().is_some_and(|accounts| {
+            if let Some(matched_account) = matched_account {
+                return matched_account;
+            }
+
+            accounts.contains(pubkey)
+        }) && !self
+            .accounts_cuckoo
+            .as_ref()
+            .is_some_and(|accounts_cuckoo| accounts_cuckoo.contains(&pubkey.to_bytes()))
+        {
+            return false;
+        }
+
+        true
+    }
+
+    fn match_owner(&self, pubkey: &Pubkey, matched_owner: Option<bool>) -> bool {
+        if let Some(owners) = &self.owners {
+            if let Some(matched_owner) = matched_owner {
+                return matched_owner;
+            }
+
+            if !owners.contains(pubkey) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn match_data_lamports(&self, data: &[u8], lamports: u64) -> bool {
+        if let Some(account_state) = &self.account_state {
+            if !account_state.is_match(data, lamports) {
+                return false;
+            }
+        }
+
+        true
+    }
+
     // Returns the filter name if all requirements are satisfied, otherwise returns None.
     // This is used to determine if a filter should be included in the filtered updates.
     // If a filter is not included, it means that the filter's requirements are not satisfied by the current message.
     // If no filters are satisfied by the current message, then the update will not be sent to the client.
-    pub fn satisfied(&self, accounts_match_condition: &FilterAccountsMatch) -> Option<FilterName> {
-        if self.require_non_empty_txn_signature
-            && !accounts_match_condition
-                .nonempty_txn_signature
-                .contains(self.filter_name.as_ref())
-        {
+    pub fn match_filter(
+        &self,
+        account: &MessageAccountInfo,
+        matched_account: Option<bool>,
+        matched_owner: Option<bool>,
+    ) -> Option<FilterName> {
+        if !self.match_txn_signature(&account.txn_signature) {
             return None;
         }
 
-        let needs_pubkey = self.require_account || self.require_cuckoo;
-        if needs_pubkey
-            && (!accounts_match_condition
-                .account
-                .is_some_and(|account| account.contains(self.filter_name.as_ref()))
-                && !accounts_match_condition
-                    .cuckoo
-                    .contains(self.filter_name.as_ref()))
-        {
+        if !self.match_account(&account.pubkey, matched_account) {
             return None;
         }
 
-        if self.require_owner
-            && !accounts_match_condition
-                .owner
-                .is_some_and(|owner| owner.contains(self.filter_name.as_ref()))
-        {
+        if !self.match_owner(&account.owner, matched_owner) {
             return None;
         }
 
-        if self.require_state_check
-            && !accounts_match_condition
-                .data
-                .contains(self.filter_name.as_ref())
-        {
+        if !self.match_data_lamports(&account.data, account.lamports) {
             return None;
         }
 
@@ -516,17 +546,228 @@ impl FilterAccountAggregate {
     }
 }
 
+#[derive(Debug, Clone)]
+struct FilterBitSet(Box<[u64]>);
+
+impl FilterBitSet {
+    const BITS_PER_WORD: usize = u64::BITS as usize;
+
+    fn new(bits: usize) -> Self {
+        Self(vec![0; bits.div_ceil(Self::BITS_PER_WORD)].into_boxed_slice())
+    }
+
+    fn insert(&mut self, index: usize) {
+        self.0[index / Self::BITS_PER_WORD] |= 1 << (index % Self::BITS_PER_WORD);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.iter().all(|word| *word == 0)
+    }
+
+    fn word(&self, index: usize) -> u64 {
+        self.0[index]
+    }
+
+    #[cfg(test)]
+    fn contains(&self, index: usize) -> bool {
+        self.word(index / Self::BITS_PER_WORD) & (1 << (index % Self::BITS_PER_WORD)) != 0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FilterAccountsIndex {
+    accounts: FoldHashMap<Pubkey, FilterBitSet>,
+    owners: FoldHashMap<Pubkey, FilterBitSet>,
+
+    account_fallback: FilterBitSet,
+    owner_fallback: FilterBitSet,
+
+    account_fallback_empty: bool,
+    owner_fallback_empty: bool,
+}
+
+impl FilterAccountsIndex {
+    const MAX_BITSET_BYTES: usize = 512 * 1024 * 1024;
+
+    fn new(aggregates: &[FilterAccountAggregate]) -> Option<Self> {
+        if aggregates.len() <= 1 {
+            return None;
+        }
+
+        let word_bytes = aggregates
+            .len()
+            .div_ceil(FilterBitSet::BITS_PER_WORD)
+            .saturating_mul(std::mem::size_of::<u64>());
+        let memberships = aggregates.iter().fold(0usize, |count, aggregate| {
+            count
+                .saturating_add(
+                    aggregate
+                        .accounts
+                        .as_ref()
+                        .map_or(0, |accounts| accounts.len()),
+                )
+                .saturating_add(aggregate.owners.as_ref().map_or(0, |owners| owners.len()))
+        });
+        if word_bytes.saturating_mul(memberships.saturating_add(2)) > Self::MAX_BITSET_BYTES {
+            return None;
+        }
+
+        let mut this = Self {
+            accounts: FoldHashMap::default(),
+            owners: FoldHashMap::default(),
+
+            account_fallback: FilterBitSet::new(aggregates.len()),
+            owner_fallback: FilterBitSet::new(aggregates.len()),
+
+            account_fallback_empty: true,
+            owner_fallback_empty: true,
+        };
+
+        for (index, aggregate) in aggregates.iter().enumerate() {
+            if let Some(accounts) = &aggregate.accounts {
+                for account in accounts {
+                    this.accounts
+                        .entry(*account)
+                        .or_insert_with(|| FilterBitSet::new(aggregates.len()))
+                        .insert(index);
+                }
+            }
+
+            if aggregate.accounts.is_none() || aggregate.accounts_cuckoo.is_some() {
+                this.account_fallback.insert(index);
+            }
+
+            if let Some(owners) = &aggregate.owners {
+                for owner in owners {
+                    this.owners
+                        .entry(*owner)
+                        .or_insert_with(|| FilterBitSet::new(aggregates.len()))
+                        .insert(index);
+                }
+            } else {
+                this.owner_fallback.insert(index);
+            }
+        }
+
+        if this.accounts.is_empty() && this.owners.is_empty() {
+            None
+        } else {
+            this.account_fallback_empty = this.account_fallback.is_empty();
+            this.owner_fallback_empty = this.owner_fallback.is_empty();
+            Some(this)
+        }
+    }
+
+    fn get_filters(
+        &self,
+        aggregates: &[FilterAccountAggregate],
+        account: &MessageAccountInfo,
+    ) -> FilteredUpdateFilters {
+        let matched_accounts = self.accounts.get(&account.pubkey);
+        if matched_accounts.is_none() && self.account_fallback_empty {
+            return FilteredUpdateFilters::new();
+        }
+
+        let matched_owners = self.owners.get(&account.owner);
+        if matched_owners.is_none() && self.owner_fallback_empty {
+            return FilteredUpdateFilters::new();
+        }
+
+        let mut filters = FilteredUpdateFilters::new();
+        for word_index in 0..self.account_fallback.0.len() {
+            let matched_accounts_word = matched_accounts
+                .map(|bitset| bitset.word(word_index))
+                .unwrap_or_default();
+            let matched_owners_word = matched_owners
+                .map(|bitset| bitset.word(word_index))
+                .unwrap_or_default();
+            let mut candidates = (matched_accounts_word | self.account_fallback.word(word_index))
+                & (matched_owners_word | self.owner_fallback.word(word_index));
+
+            while candidates != 0 {
+                let bit_index = candidates.trailing_zeros() as usize;
+                let aggregate_index = word_index * FilterBitSet::BITS_PER_WORD + bit_index;
+                let bit = 1 << bit_index;
+
+                if let Some(filter) = aggregates[aggregate_index].match_filter(
+                    account,
+                    Some(matched_accounts_word & bit != 0),
+                    Some(matched_owners_word & bit != 0),
+                ) {
+                    filters.push(filter);
+                }
+
+                candidates &= candidates - 1;
+            }
+        }
+
+        filters
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 struct FilterAccounts {
-    nonempty_txn_signature: Vec<(FilterName, Option<bool>)>,
-    account: FoldHashMap<Pubkey, FoldHashSet<FilterName>>,
-    account_cuckoo: FoldHashMap<FilterName, Arc<CuckooFilter<[u8; 32]>>>,
-    owner: FoldHashMap<Pubkey, FoldHashSet<FilterName>>,
-    state_check: FoldHashMap<FilterName, FilterAccountsState>,
     aggregates: Vec<FilterAccountAggregate>,
+
+    // bitset matching algorithm, capped at 512MB of usage. if the requested filter goes above this, it will fall back to non indexed algo.
+    index: Option<Arc<FilterAccountsIndex>>,
+
+    // non indexed (slightly slower) algorithm, used when the index is not available or when the filter is too large to be indexed.
+    // query multiple filters by account, each usize inside of the Vec represents an 'aggregate' index in the FilterAccounts::aggregates Vec.
+    accounts: FoldHashMap<Pubkey, Vec<usize>>,
+    owners: FoldHashMap<Pubkey, Vec<usize>>,
+
+    // aggregates unconstrained on each axis, which therefore stay candidates for every
+    // message. one carrying a cuckoo belongs in account_any even when it also has an
+    // explicit account list, because match_account still probes the cuckoo after the
+    // explicit set misses.
+    account_any: Vec<usize>,
+    owner_any: Vec<usize>,
+}
+
+#[inline]
+fn next_union(
+    hits: &[usize],
+    unconstrained: &[usize],
+    hits_cursor: &mut usize,
+    unconstrained_cursor: &mut usize,
+) -> Option<(usize, bool)> {
+    let next_hit = hits.get(*hits_cursor).copied();
+    let next_unconstrained = unconstrained.get(*unconstrained_cursor).copied();
+
+    match (next_hit, next_unconstrained) {
+        (Some(hit), Some(unconstrained)) if hit < unconstrained => {
+            *hits_cursor += 1;
+            Some((hit, true))
+        }
+        (Some(hit), Some(unconstrained)) if unconstrained < hit => {
+            *unconstrained_cursor += 1;
+            Some((unconstrained, false))
+        }
+        (Some(hit), Some(_)) => {
+            *hits_cursor += 1;
+            *unconstrained_cursor += 1;
+            Some((hit, true))
+        }
+        (Some(hit), None) => {
+            *hits_cursor += 1;
+            Some((hit, true))
+        }
+        (None, Some(unconstrained)) => {
+            *unconstrained_cursor += 1;
+            Some((unconstrained, false))
+        }
+        (None, None) => None,
+    }
 }
 
 impl FilterAccounts {
+    // Below this many aggregates the two hash lookups cost more than asking each
+    // aggregate directly. Construction and get_updates MUST test the same constant: if
+    // the lists are absent the candidate walk would see two empty unions and wrongly
+    // conclude that nothing can match.
+    const DIRECT_SCAN_LIMIT: usize = 4;
+
     fn new(
         configs: &HashMap<String, SubscribeRequestFilterAccounts>,
         limits: &FilterLimitsAccounts,
@@ -546,71 +787,78 @@ impl FilterAccounts {
             FilterLimits::check_pubkey_max(filter.owner.len(), limits.owner_max)?;
 
             let filter_name = names.get(name)?;
+            let mut filter_aggregate = FilterAccountAggregate::new(filter_name);
 
             if filter.nonempty_txn_signature.is_some() {
-                filter_accounts_result
-                    .nonempty_txn_signature
-                    .push((filter_name.clone(), filter.nonempty_txn_signature));
+                filter_aggregate.txn_signature = filter.nonempty_txn_signature;
             }
 
-            Self::set(
-                &mut filter_accounts_result.account,
-                filter_name.clone(),
-                Filter::decode_pubkeys(&filter.account, &limits.account_reject),
-            )?;
+            if !filter.account.is_empty() {
+                let accounts =
+                    Filter::decode_pubkeys_into_set(&filter.account, &limits.account_reject)?;
+                if !accounts.is_empty() {
+                    filter_aggregate.accounts = Some(accounts);
+                }
+            }
 
-            Self::set(
-                &mut filter_accounts_result.owner,
-                filter_name.clone(),
-                Filter::decode_pubkeys(&filter.owner, &limits.owner_reject),
-            )?;
+            if !filter.owner.is_empty() {
+                let owners = Filter::decode_pubkeys_into_set(&filter.owner, &limits.owner_reject)?;
+                if !owners.is_empty() {
+                    filter_aggregate.owners = Some(owners);
+                }
+            }
 
             let filter_accounts_state = FilterAccountsState::new(&filter.filters)?;
 
             let require_state_check = !filter_accounts_state.is_empty();
             if require_state_check {
-                filter_accounts_result
-                    .state_check
-                    .insert(filter_name.clone(), filter_accounts_state);
+                filter_aggregate.account_state = Some(filter_accounts_state);
             }
 
-            let mut require_cuckoo = false;
             if let Some(proto_cuckoo) = &filter.cuckoo_accounts_filter {
                 FilterLimits::check_max(proto_cuckoo.data.len(), limits.cuckoo_max_size)?;
-                let cuckoo = Arc::new(CuckooFilter::from(proto_cuckoo));
-                filter_accounts_result
-                    .account_cuckoo
-                    .insert(filter_name.clone(), cuckoo);
-                require_cuckoo = true;
+                filter_aggregate.accounts_cuckoo = Some(Arc::new(CuckooFilter::from(proto_cuckoo)));
             }
 
-            filter_accounts_result
-                .aggregates
-                .push(FilterAccountAggregate {
-                    filter_name: filter_name.clone(),
-                    require_non_empty_txn_signature: filter.nonempty_txn_signature.is_some(),
-                    require_account: !filter.account.is_empty(),
-                    require_cuckoo,
-                    require_owner: !filter.owner.is_empty(),
-                    require_state_check,
-                });
+            filter_accounts_result.aggregates.push(filter_aggregate);
+        }
+
+        filter_accounts_result.index =
+            FilterAccountsIndex::new(&filter_accounts_result.aggregates).map(Arc::new);
+
+        if filter_accounts_result.index.is_none()
+            && filter_accounts_result.aggregates.len() > Self::DIRECT_SCAN_LIMIT
+        {
+            for (index, aggregate) in filter_accounts_result.aggregates.iter().enumerate() {
+                if let Some(accounts) = &aggregate.accounts {
+                    for account in accounts {
+                        filter_accounts_result
+                            .accounts
+                            .entry(*account)
+                            .or_insert_with(Vec::new)
+                            .push(index);
+                    }
+                }
+
+                if aggregate.accounts.is_none() || aggregate.accounts_cuckoo.is_some() {
+                    filter_accounts_result.account_any.push(index);
+                }
+
+                if let Some(owners) = &aggregate.owners {
+                    for owner in owners {
+                        filter_accounts_result
+                            .owners
+                            .entry(*owner)
+                            .or_insert_with(Vec::new)
+                            .push(index);
+                    }
+                } else {
+                    filter_accounts_result.owner_any.push(index);
+                }
+            }
         }
 
         Ok(filter_accounts_result)
-    }
-
-    fn set(
-        map: &mut FoldHashMap<Pubkey, FoldHashSet<FilterName>>,
-        filter_name: FilterName,
-        keys: impl Iterator<Item = FilterResult<Pubkey>>,
-    ) -> FilterResult<()> {
-        for maybe_key in keys {
-            map.entry(maybe_key?)
-                .or_default()
-                .insert(filter_name.clone());
-        }
-
-        Ok(())
     }
 
     fn get_updates(
@@ -622,13 +870,174 @@ impl FilterAccounts {
             return FilteredUpdates::new();
         }
 
-        let mut filter = FilterAccountsMatch::new(self);
-        filter.match_txn_signature(&message.account.txn_signature);
-        filter.match_account(&message.account.pubkey);
-        filter.match_cuckoo(&message.account.pubkey);
-        filter.match_owner(&message.account.owner);
-        filter.match_data_lamports(&message.account.data, message.account.lamports);
-        let filters = filter.get_filters();
+        let filters = if let Some(index) = &self.index {
+            index.get_filters(&self.aggregates, &message.account)
+        } else if self.aggregates.len() <= Self::DIRECT_SCAN_LIMIT {
+            self.aggregates
+                .iter()
+                .filter_map(|aggregate| aggregate.match_filter(&message.account, None, None))
+                .collect()
+        } else if self.account_any.len() == self.aggregates.len()
+            && self.owner_any.len() == self.aggregates.len()
+        {
+            let account_hits = if self.accounts.is_empty() {
+                &[][..]
+            } else {
+                self.accounts
+                    .get(&message.account.pubkey)
+                    .map_or(&[][..], |v| v.as_slice())
+            };
+            let owner_hits = if self.owners.is_empty() {
+                &[][..]
+            } else {
+                self.owners
+                    .get(&message.account.owner)
+                    .map_or(&[][..], |v| v.as_slice())
+            };
+
+            let (mut account_hits_cursor, mut owner_hits_cursor) = (0usize, 0usize);
+            self.aggregates
+                .iter()
+                .enumerate()
+                .filter_map(|(index, aggregate)| {
+                    let matched_account = if account_hits_cursor < account_hits.len()
+                        && account_hits[account_hits_cursor] == index
+                    {
+                        account_hits_cursor += 1;
+                        true
+                    } else {
+                        false
+                    };
+                    let matched_owner = if owner_hits_cursor < owner_hits.len()
+                        && owner_hits[owner_hits_cursor] == index
+                    {
+                        owner_hits_cursor += 1;
+                        true
+                    } else {
+                        false
+                    };
+                    aggregate.match_filter(
+                        &message.account,
+                        Some(matched_account),
+                        Some(matched_owner),
+                    )
+                })
+                .collect()
+        } else {
+            let account_hits = if self.accounts.is_empty() {
+                &[][..]
+            } else {
+                self.accounts
+                    .get(&message.account.pubkey)
+                    .map_or(&[][..], |v| v.as_slice())
+            };
+            let owner_hits = if self.owners.is_empty() {
+                &[][..]
+            } else {
+                self.owners
+                    .get(&message.account.owner)
+                    .map_or(&[][..], |v| v.as_slice())
+            };
+
+            if (account_hits.is_empty() && self.account_any.is_empty())
+                || (owner_hits.is_empty() && self.owner_any.is_empty())
+            {
+                return FilteredUpdates::new();
+            }
+
+            let account_unbounded = self.account_any.len() == self.aggregates.len();
+            let owner_unbounded = self.owner_any.len() == self.aggregates.len();
+            if account_unbounded != owner_unbounded {
+                let (hits, any, matched_is_account) = if owner_unbounded {
+                    (account_hits, self.account_any.as_slice(), true)
+                } else {
+                    (owner_hits, self.owner_any.as_slice(), false)
+                };
+                let (mut hits_cursor, mut any_cursor) = (0usize, 0usize);
+                let mut filters = FilteredUpdateFilters::new();
+                while let Some((index, matched)) =
+                    next_union(hits, any, &mut hits_cursor, &mut any_cursor)
+                {
+                    let (matched_account, matched_owner) = if matched_is_account {
+                        (matched, false)
+                    } else {
+                        (false, matched)
+                    };
+                    if let Some(name) = self.aggregates[index].match_filter(
+                        &message.account,
+                        Some(matched_account),
+                        Some(matched_owner),
+                    ) {
+                        filters.push(name);
+                    }
+                }
+                return filtered_updates_once_owned!(
+                    filters,
+                    FilteredUpdateOneof::account(Arc::clone(message), accounts_data_slice.clone()),
+                    message.created_at
+                );
+            }
+
+            let mut account_hits_cursor = 0;
+            let mut account_any_cursor = 0;
+            let mut owner_hits_cursor = 0;
+            let mut owner_any_cursor = 0;
+            let mut account = next_union(
+                account_hits,
+                &self.account_any,
+                &mut account_hits_cursor,
+                &mut account_any_cursor,
+            );
+            let mut owner = next_union(
+                owner_hits,
+                &self.owner_any,
+                &mut owner_hits_cursor,
+                &mut owner_any_cursor,
+            );
+
+            let mut filters = FilteredUpdateFilters::new();
+            while let (Some((account_index, matched_account)), Some((owner_index, matched_owner))) =
+                (account, owner)
+            {
+                if account_index < owner_index {
+                    account = next_union(
+                        account_hits,
+                        &self.account_any,
+                        &mut account_hits_cursor,
+                        &mut account_any_cursor,
+                    );
+                } else if owner_index < account_index {
+                    owner = next_union(
+                        owner_hits,
+                        &self.owner_any,
+                        &mut owner_hits_cursor,
+                        &mut owner_any_cursor,
+                    );
+                } else {
+                    if let Some(name) = self.aggregates[account_index].match_filter(
+                        &message.account,
+                        Some(matched_account),
+                        Some(matched_owner),
+                    ) {
+                        filters.push(name);
+                    }
+                    account = next_union(
+                        account_hits,
+                        &self.account_any,
+                        &mut account_hits_cursor,
+                        &mut account_any_cursor,
+                    );
+                    owner = next_union(
+                        owner_hits,
+                        &self.owner_any,
+                        &mut owner_hits_cursor,
+                        &mut owner_any_cursor,
+                    );
+                }
+            }
+            filters
+        };
+
         filtered_updates_once_owned!(
             filters,
             FilteredUpdateOneof::account(Arc::clone(message), accounts_data_slice.clone()),
@@ -779,88 +1188,6 @@ impl FilterAccountsLamports {
             Self::Lt(value) => value > lamports,
             Self::Gt(value) => value < lamports,
         }
-    }
-}
-
-#[derive(Debug)]
-struct FilterAccountsMatch<'a> {
-    filter: &'a FilterAccounts,
-    nonempty_txn_signature: FoldHashSet<&'a str>,
-    account: Option<&'a FoldHashSet<FilterName>>,
-    cuckoo: FoldHashSet<&'a str>,
-    owner: Option<&'a FoldHashSet<FilterName>>,
-    data: FoldHashSet<&'a str>,
-}
-
-impl<'a> FilterAccountsMatch<'a> {
-    fn new(filter: &'a FilterAccounts) -> Self {
-        Self {
-            filter,
-            nonempty_txn_signature: Default::default(),
-            account: None,
-            cuckoo: Default::default(),
-            owner: None,
-            data: Default::default(),
-        }
-    }
-
-    fn match_txn_signature(&mut self, txn_signature: &Option<Signature>) {
-        for (name, filter) in self.filter.nonempty_txn_signature.iter() {
-            if let Some(nonempty_txn_signature) = filter {
-                if *nonempty_txn_signature == txn_signature.is_some() {
-                    /* If the user has supplied a large list of filters, constantly growing the set can be expensive */
-                    if self.nonempty_txn_signature.is_empty() {
-                        self.nonempty_txn_signature
-                            .reserve(self.filter.nonempty_txn_signature.len());
-                    }
-                    self.nonempty_txn_signature.insert(name.as_ref());
-                }
-            }
-        }
-    }
-
-    fn match_account(&mut self, pubkey: &Pubkey) {
-        self.account = self.filter.account.get(pubkey)
-    }
-
-    fn match_cuckoo(&mut self, pubkey: &Pubkey) {
-        if self.filter.account_cuckoo.is_empty() {
-            return;
-        }
-        let bytes = pubkey.to_bytes();
-        for (name, cuckoo) in &self.filter.account_cuckoo {
-            if cuckoo.contains(&bytes) {
-                /* If the user has supplied a large list of filters, constantly growing the set can be expensive */
-                if self.cuckoo.is_empty() {
-                    self.cuckoo.reserve(self.filter.account_cuckoo.len());
-                }
-                self.cuckoo.insert(name.as_ref());
-            }
-        }
-    }
-
-    fn match_owner(&mut self, pubkey: &Pubkey) {
-        self.owner = self.filter.owner.get(pubkey)
-    }
-
-    fn match_data_lamports(&mut self, data: &[u8], lamports: u64) {
-        for (name, account_state) in self.filter.state_check.iter() {
-            if account_state.is_match(data, lamports) {
-                /* If the user has supplied a large list of filters, constantly growing the set can be expensive */
-                if self.data.is_empty() {
-                    self.data.reserve(self.filter.state_check.len());
-                }
-                self.data.insert(name.as_ref());
-            }
-        }
-    }
-
-    fn get_filters(&self) -> FilteredUpdateFilters {
-        self.filter
-            .aggregates
-            .iter()
-            .filter_map(|filter_aggregate| filter_aggregate.satisfied(self))
-            .collect()
     }
 }
 
@@ -1665,13 +1992,16 @@ impl FilterBlocksInner {
             return true;
         }
 
-        if !self.account_include.is_empty()
-            && self
-                .account_include
-                .intersection(account_keys)
-                .next()
-                .is_some()
-        {
+        let explicit_match = if self.account_include.len() <= account_keys.len() {
+            self.account_include
+                .iter()
+                .any(|pubkey| account_keys.contains(pubkey))
+        } else {
+            account_keys
+                .iter()
+                .any(|pubkey| self.account_include.contains(pubkey))
+        };
+        if explicit_match {
             return true;
         }
 
@@ -1822,7 +2152,7 @@ impl FilterAccountsDataSlice {
 #[cfg(test)]
 mod tests {
     use {
-        super::{DeshredFilter, Filter},
+        super::{DeshredFilter, Filter, FilterBitSet, FilterBlocksInner},
         crate::plugin::{
             convert_to,
             filter::{
@@ -1835,6 +2165,7 @@ mod tests {
                 MessageDeshredTransactionInfo, MessageTransaction, MessageTransactionInfo,
             },
         },
+        foldhash::HashSet as FoldHashSet,
         prost_types::Timestamp,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -1857,6 +2188,59 @@ mod tests {
 
     pub(super) fn create_filter_names() -> FilterNames {
         FilterNames::new(64, 1024, Duration::from_secs(1))
+    }
+
+    #[test]
+    fn filter_bitset_word_boundaries() {
+        for len in [1, 63, 64, 65, 127, 128, 129, 1023, 1024, 1025] {
+            let mut bitset = FilterBitSet::new(len);
+            let indexes = [0, len / 2, len - 1];
+            for index in indexes {
+                bitset.insert(index);
+            }
+
+            for index in 0..len {
+                assert_eq!(bitset.contains(index), indexes.contains(&index));
+            }
+        }
+    }
+
+    #[test]
+    fn block_explicit_account_matching_probes_the_smaller_side() {
+        let shared = Pubkey::new_unique();
+        let other_filter_keys = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let other_message_keys = [Pubkey::new_unique(), Pubkey::new_unique()];
+
+        // Probe the transaction-local set when the client filter is smaller.
+        let small_filter = FilterBlocksInner {
+            account_include: [shared].into_iter().collect::<FoldHashSet<_>>(),
+            account_cuckoo: None,
+            include_transactions: None,
+            include_accounts: None,
+            include_entries: None,
+        };
+        let message_keys = [shared, other_message_keys[0], other_message_keys[1]]
+            .into_iter()
+            .collect::<FoldHashSet<_>>();
+        assert!(small_filter.matches_any_in_set(&message_keys));
+
+        // Probe the client filter when the transaction-local set is smaller.
+        let large_filter = FilterBlocksInner {
+            account_include: [shared, other_filter_keys[0], other_filter_keys[1]]
+                .into_iter()
+                .collect::<FoldHashSet<_>>(),
+            account_cuckoo: None,
+            include_transactions: None,
+            include_accounts: None,
+            include_entries: None,
+        };
+        let matching_message_keys = [shared].into_iter().collect::<FoldHashSet<_>>();
+        assert!(large_filter.matches_any_in_set(&matching_message_keys));
+
+        let nonmatching_message_keys = [Pubkey::new_unique()]
+            .into_iter()
+            .collect::<FoldHashSet<_>>();
+        assert!(!large_filter.matches_any_in_set(&nonmatching_message_keys));
     }
 
     fn create_message_transaction(
@@ -2730,6 +3114,1646 @@ mod tests {
             .get_updates(&Message::Account(message), None)
             .is_empty());
     }
+
+    #[test]
+    fn account_bitset_index_matches_original_semantics() {
+        let account = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
+        let other_owner = Pubkey::new_unique();
+
+        let accounts = HashMap::from([
+            (
+                "account".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    account: vec![account.to_string()],
+                    ..Default::default()
+                },
+            ),
+            (
+                "account-and-owner".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    account: vec![account.to_string()],
+                    owner: vec![owner.to_string()],
+                    ..Default::default()
+                },
+            ),
+            (
+                "owner".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    owner: vec![owner.to_string()],
+                    ..Default::default()
+                },
+            ),
+            (
+                "other".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    account: vec![other_account.to_string()],
+                    owner: vec![other_owner.to_string()],
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let request = SubscribeRequest {
+            accounts: accounts.clone(),
+            ..Default::default()
+        };
+        let filter = Filter::new(
+            &request,
+            &FilterLimits::default(),
+            &mut create_filter_names(),
+        )
+        .unwrap();
+
+        let index = filter.accounts.index.as_ref().unwrap();
+        let account_matches = index.accounts.get(&account).unwrap();
+        let owner_matches = index.owners.get(&owner).unwrap();
+        assert_eq!(
+            account_matches
+                .0
+                .iter()
+                .map(|word| word.count_ones())
+                .sum::<u32>(),
+            2
+        );
+        assert_eq!(
+            owner_matches
+                .0
+                .iter()
+                .map(|word| word.count_ones())
+                .sum::<u32>(),
+            2
+        );
+
+        for (aggregate_index, aggregate) in filter.accounts.aggregates.iter().enumerate() {
+            assert_eq!(
+                index.account_fallback.contains(aggregate_index),
+                aggregate.accounts.is_none() || aggregate.accounts_cuckoo.is_some()
+            );
+            assert_eq!(
+                index.owner_fallback.contains(aggregate_index),
+                aggregate.owners.is_none()
+            );
+        }
+
+        let matched_names = |account, owner| {
+            let message = create_message_account(account, owner);
+            let updates = filter.get_updates(&Message::Account(message), None);
+            let mut names = updates
+                .first()
+                .map(|update| {
+                    update
+                        .filters
+                        .iter()
+                        .map(|name| name.as_ref().to_owned())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            names.sort_unstable();
+            names
+        };
+
+        assert_eq!(
+            matched_names(account, owner),
+            [
+                "account".to_owned(),
+                "account-and-owner".to_owned(),
+                "owner".to_owned(),
+            ]
+        );
+        assert_eq!(
+            matched_names(account, Pubkey::new_unique()),
+            ["account".to_owned()]
+        );
+        assert_eq!(
+            matched_names(other_account, other_owner),
+            ["other".to_owned()]
+        );
+        assert!(matched_names(Pubkey::new_unique(), Pubkey::new_unique()).is_empty());
+
+        let single_filter = Filter::new(
+            &SubscribeRequest {
+                accounts: HashMap::from([(
+                    "single".to_owned(),
+                    SubscribeRequestFilterAccounts {
+                        account: vec![account.to_string()],
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            },
+            &FilterLimits::default(),
+            &mut create_filter_names(),
+        )
+        .unwrap();
+        assert!(single_filter.accounts.index.is_none());
+    }
+}
+
+#[cfg(test)]
+mod account_filter_regression_tests {
+    use {
+        super::*,
+        bytes::Bytes,
+        prost_types::Timestamp,
+        std::sync::OnceLock,
+        yellowstone_grpc_proto::{
+            cuckoo::CuckooFilter,
+            geyser::{
+                CuckooFilter as ProtoCuckooFilter, SubscribeRequestFilterAccountsFilterLamports,
+                SubscribeRequestFilterAccountsFilterMemcmp,
+            },
+        },
+    };
+
+    const DATA_LEN: usize = 165;
+    const MEMCMP_OFFSET: usize = 4;
+    const MEMCMP_BYTES: &[u8] = b"match";
+
+    fn create_cuckoo(pubkeys: &[Pubkey]) -> ProtoCuckooFilter {
+        let mut filter = CuckooFilter::<[u8; 32]>::with_capacity(pubkeys.len().max(1)).unwrap();
+        for pubkey in pubkeys {
+            filter.insert(&pubkey.to_bytes()).unwrap();
+        }
+        ProtoCuckooFilter::from(&filter)
+    }
+
+    fn memcmp_filter(data: AccountsFilterMemcmpOneof) -> SubscribeRequestFilterAccountsFilter {
+        SubscribeRequestFilterAccountsFilter {
+            filter: Some(AccountsFilterDataOneof::Memcmp(
+                SubscribeRequestFilterAccountsFilterMemcmp {
+                    offset: MEMCMP_OFFSET as u64,
+                    data: Some(data),
+                },
+            )),
+        }
+    }
+
+    fn datasize_filter(size: usize) -> SubscribeRequestFilterAccountsFilter {
+        SubscribeRequestFilterAccountsFilter {
+            filter: Some(AccountsFilterDataOneof::Datasize(size as u64)),
+        }
+    }
+
+    fn token_state_filter() -> SubscribeRequestFilterAccountsFilter {
+        SubscribeRequestFilterAccountsFilter {
+            filter: Some(AccountsFilterDataOneof::TokenAccountState(true)),
+        }
+    }
+
+    fn lamports_filter(cmp: AccountsFilterLamports) -> SubscribeRequestFilterAccountsFilter {
+        SubscribeRequestFilterAccountsFilter {
+            filter: Some(AccountsFilterDataOneof::Lamports(
+                SubscribeRequestFilterAccountsFilterLamports { cmp: Some(cmp) },
+            )),
+        }
+    }
+
+    fn valid_token_data() -> Vec<u8> {
+        let mut data = vec![0; DATA_LEN];
+        data[MEMCMP_OFFSET..MEMCMP_OFFSET + MEMCMP_BYTES.len()].copy_from_slice(MEMCMP_BYTES);
+        data[108] = 1;
+        data
+    }
+
+    fn account_info(
+        pubkey: Pubkey,
+        owner: Pubkey,
+        data: Vec<u8>,
+        lamports: u64,
+        has_signature: bool,
+    ) -> MessageAccountInfo {
+        MessageAccountInfo {
+            pubkey,
+            lamports,
+            owner,
+            executable: false,
+            rent_epoch: 0,
+            data: Bytes::from(data),
+            write_version: 7,
+            txn_signature: has_signature.then(Signature::default),
+            pre_encoded: OnceLock::new(),
+        }
+    }
+
+    fn sorted_matches(filter: &Filter, account: MessageAccountInfo) -> Vec<String> {
+        let message = Arc::new(MessageAccount {
+            account,
+            slot: 42,
+            is_startup: false,
+            created_at: Timestamp::default(),
+        });
+        let updates = filter.get_updates(&Message::Account(message), None);
+        assert!(updates.len() <= 1);
+
+        let mut names = updates
+            .first()
+            .map(|update| {
+                update
+                    .filters
+                    .iter()
+                    .map(|name| name.as_ref().to_owned())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        names.sort_unstable();
+        names
+    }
+
+    #[test]
+    fn account_filter_truth_table_preserves_baseline_semantics() {
+        let account = Pubkey::new_from_array([1; 32]);
+        let cuckoo_account = Pubkey::new_from_array([2; 32]);
+        let other_account = Pubkey::new_from_array([3; 32]);
+        let owner = Pubkey::new_from_array([4; 32]);
+        let other_owner = Pubkey::new_from_array([5; 32]);
+        let data = valid_token_data();
+        let memcmp_base58 = bs58::encode(MEMCMP_BYTES).into_string();
+        let memcmp_base64 = base64_engine.encode(MEMCMP_BYTES);
+
+        let account_filter = |account: Vec<String>| SubscribeRequestFilterAccounts {
+            account,
+            ..Default::default()
+        };
+        let owner_filter = |owner: Vec<String>| SubscribeRequestFilterAccounts {
+            owner,
+            ..Default::default()
+        };
+        let state_filter = |filter| SubscribeRequestFilterAccounts {
+            filters: vec![filter],
+            ..Default::default()
+        };
+
+        let accounts = HashMap::from([
+            (
+                "wildcard".to_owned(),
+                SubscribeRequestFilterAccounts::default(),
+            ),
+            (
+                "account".to_owned(),
+                account_filter(vec![account.to_string()]),
+            ),
+            (
+                "account-duplicate".to_owned(),
+                account_filter(vec![account.to_string(), account.to_string()]),
+            ),
+            ("owner".to_owned(), owner_filter(vec![owner.to_string()])),
+            (
+                "owner-duplicate".to_owned(),
+                owner_filter(vec![owner.to_string(), owner.to_string()]),
+            ),
+            (
+                "account-or-cuckoo".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    account: vec![account.to_string()],
+                    cuckoo_accounts_filter: Some(create_cuckoo(&[cuckoo_account])),
+                    ..Default::default()
+                },
+            ),
+            (
+                "signature-present".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    nonempty_txn_signature: Some(true),
+                    ..Default::default()
+                },
+            ),
+            (
+                "signature-absent".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    nonempty_txn_signature: Some(false),
+                    ..Default::default()
+                },
+            ),
+            (
+                "datasize".to_owned(),
+                state_filter(datasize_filter(DATA_LEN)),
+            ),
+            (
+                "memcmp-bytes".to_owned(),
+                state_filter(memcmp_filter(AccountsFilterMemcmpOneof::Bytes(
+                    MEMCMP_BYTES.to_vec(),
+                ))),
+            ),
+            (
+                "memcmp-base58".to_owned(),
+                state_filter(memcmp_filter(AccountsFilterMemcmpOneof::Base58(
+                    memcmp_base58,
+                ))),
+            ),
+            (
+                "memcmp-base64".to_owned(),
+                state_filter(memcmp_filter(AccountsFilterMemcmpOneof::Base64(
+                    memcmp_base64,
+                ))),
+            ),
+            ("token-state".to_owned(), state_filter(token_state_filter())),
+            (
+                "lamports-eq".to_owned(),
+                state_filter(lamports_filter(AccountsFilterLamports::Eq(100))),
+            ),
+            (
+                "lamports-ne".to_owned(),
+                state_filter(lamports_filter(AccountsFilterLamports::Ne(99))),
+            ),
+            (
+                "lamports-lt".to_owned(),
+                state_filter(lamports_filter(AccountsFilterLamports::Lt(101))),
+            ),
+            (
+                "lamports-gt".to_owned(),
+                state_filter(lamports_filter(AccountsFilterLamports::Gt(99))),
+            ),
+            (
+                "combined".to_owned(),
+                SubscribeRequestFilterAccounts {
+                    nonempty_txn_signature: Some(true),
+                    account: vec![account.to_string()],
+                    owner: vec![owner.to_string()],
+                    filters: vec![
+                        datasize_filter(DATA_LEN),
+                        memcmp_filter(AccountsFilterMemcmpOneof::Bytes(MEMCMP_BYTES.to_vec())),
+                        token_state_filter(),
+                        lamports_filter(AccountsFilterLamports::Eq(100)),
+                    ],
+                    cuckoo_accounts_filter: None,
+                },
+            ),
+        ]);
+        let filter = Filter::new(
+            &SubscribeRequest {
+                accounts,
+                ..Default::default()
+            },
+            &FilterLimits::default(),
+            &mut tests::create_filter_names(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            sorted_matches(
+                &filter,
+                account_info(account, owner, data.clone(), 100, true)
+            ),
+            [
+                "account",
+                "account-duplicate",
+                "account-or-cuckoo",
+                "combined",
+                "datasize",
+                "lamports-eq",
+                "lamports-gt",
+                "lamports-lt",
+                "lamports-ne",
+                "memcmp-base58",
+                "memcmp-base64",
+                "memcmp-bytes",
+                "owner",
+                "owner-duplicate",
+                "signature-present",
+                "token-state",
+                "wildcard",
+            ]
+        );
+        assert_eq!(
+            sorted_matches(
+                &filter,
+                account_info(cuckoo_account, owner, data.clone(), 100, true)
+            ),
+            [
+                "account-or-cuckoo",
+                "datasize",
+                "lamports-eq",
+                "lamports-gt",
+                "lamports-lt",
+                "lamports-ne",
+                "memcmp-base58",
+                "memcmp-base64",
+                "memcmp-bytes",
+                "owner",
+                "owner-duplicate",
+                "signature-present",
+                "token-state",
+                "wildcard",
+            ]
+        );
+        assert_eq!(
+            sorted_matches(
+                &filter,
+                account_info(account, other_owner, vec![0; 3], 99, false)
+            ),
+            [
+                "account",
+                "account-duplicate",
+                "account-or-cuckoo",
+                "lamports-lt",
+                "signature-absent",
+                "wildcard",
+            ]
+        );
+        assert_eq!(
+            sorted_matches(
+                &filter,
+                account_info(other_account, other_owner, vec![0; 3], 101, false)
+            ),
+            ["lamports-gt", "lamports-ne", "signature-absent", "wildcard",]
+        );
+    }
+
+    fn aggregate_for_index(
+        index: usize,
+        account: Pubkey,
+        other_account: Pubkey,
+        owner: Pubkey,
+        other_owner: Pubkey,
+        cuckoo: &Arc<CuckooFilter<[u8; 32]>>,
+    ) -> FilterAccountAggregate {
+        let mut aggregate = FilterAccountAggregate::new(FilterName::new(format!("filter-{index}")));
+        match index % 16 {
+            0 => {}
+            1 => aggregate.accounts = Some([account].into_iter().collect()),
+            2 => aggregate.accounts = Some([other_account].into_iter().collect()),
+            3 => aggregate.owners = Some([owner].into_iter().collect()),
+            4 => aggregate.owners = Some([other_owner].into_iter().collect()),
+            5 => {
+                aggregate.accounts = Some([account].into_iter().collect());
+                aggregate.owners = Some([owner].into_iter().collect());
+            }
+            6 => {
+                aggregate.accounts = Some([account].into_iter().collect());
+                aggregate.owners = Some([other_owner].into_iter().collect());
+            }
+            7 => aggregate.accounts_cuckoo = Some(Arc::clone(cuckoo)),
+            8 => {
+                aggregate.accounts = Some([other_account].into_iter().collect());
+                aggregate.accounts_cuckoo = Some(Arc::clone(cuckoo));
+            }
+            9 => aggregate.txn_signature = Some(true),
+            10 => aggregate.txn_signature = Some(false),
+            11 => {
+                aggregate.account_state = Some(FilterAccountsState {
+                    memcmp: vec![(MEMCMP_OFFSET, MEMCMP_BYTES.to_vec())],
+                    datasize: Some(DATA_LEN),
+                    token_account_state: false,
+                    lamports: vec![],
+                });
+            }
+            12 => {
+                aggregate.account_state = Some(FilterAccountsState {
+                    memcmp: vec![],
+                    datasize: None,
+                    token_account_state: true,
+                    lamports: vec![],
+                });
+            }
+            13 => {
+                aggregate.account_state = Some(FilterAccountsState {
+                    memcmp: vec![],
+                    datasize: None,
+                    token_account_state: false,
+                    lamports: vec![
+                        FilterAccountsLamports::Eq(100),
+                        FilterAccountsLamports::Ne(99),
+                        FilterAccountsLamports::Lt(101),
+                        FilterAccountsLamports::Gt(99),
+                    ],
+                });
+            }
+            14 => {
+                aggregate.accounts = Some([account].into_iter().collect());
+                aggregate.owners = Some([owner].into_iter().collect());
+                aggregate.txn_signature = Some(true);
+                aggregate.account_state = Some(FilterAccountsState {
+                    memcmp: vec![(MEMCMP_OFFSET, MEMCMP_BYTES.to_vec())],
+                    datasize: Some(DATA_LEN),
+                    token_account_state: true,
+                    lamports: vec![FilterAccountsLamports::Eq(100)],
+                });
+            }
+            15 => {
+                aggregate.accounts = Some([other_account].into_iter().collect());
+                aggregate.accounts_cuckoo = Some(Arc::clone(cuckoo));
+                aggregate.owners = Some([owner].into_iter().collect());
+                aggregate.txn_signature = Some(true);
+                aggregate.account_state = Some(FilterAccountsState {
+                    memcmp: vec![(MEMCMP_OFFSET, MEMCMP_BYTES.to_vec())],
+                    datasize: Some(DATA_LEN),
+                    token_account_state: true,
+                    lamports: vec![FilterAccountsLamports::Eq(100)],
+                });
+            }
+            _ => unreachable!(),
+        }
+        aggregate
+    }
+
+    #[test]
+    fn account_bitset_index_matches_direct_scan_for_all_predicates_and_boundaries() {
+        let account = Pubkey::new_from_array([11; 32]);
+        let other_account = Pubkey::new_from_array([12; 32]);
+        let cuckoo_account = Pubkey::new_from_array([13; 32]);
+        let owner = Pubkey::new_from_array([14; 32]);
+        let other_owner = Pubkey::new_from_array([15; 32]);
+        let mut cuckoo = CuckooFilter::<[u8; 32]>::with_capacity(1).unwrap();
+        cuckoo.insert(&cuckoo_account.to_bytes()).unwrap();
+        let cuckoo = Arc::new(cuckoo);
+        let data = valid_token_data();
+
+        let messages = [
+            account_info(account, owner, data.clone(), 100, true),
+            account_info(account, owner, data.clone(), 100, false),
+            account_info(account, other_owner, data.clone(), 100, true),
+            account_info(other_account, owner, data.clone(), 100, true),
+            account_info(cuckoo_account, owner, data.clone(), 100, true),
+            account_info(account, owner, vec![0; DATA_LEN], 100, true),
+            account_info(account, owner, data.clone(), 99, true),
+            account_info(
+                Pubkey::new_from_array([16; 32]),
+                Pubkey::new_from_array([17; 32]),
+                vec![0; 3],
+                101,
+                false,
+            ),
+        ];
+
+        for count in [
+            0, 1, 2, 3, 15, 16, 17, 63, 64, 65, 127, 128, 129, 1023, 1024, 1025,
+        ] {
+            let aggregates = (0..count)
+                .map(|index| {
+                    aggregate_for_index(index, account, other_account, owner, other_owner, &cuckoo)
+                })
+                .collect::<Vec<_>>();
+            let index = FilterAccountsIndex::new(&aggregates);
+            assert_eq!(index.is_some(), count > 1, "filter count {count}");
+
+            for (message_index, message) in messages.iter().enumerate() {
+                let expected = aggregates
+                    .iter()
+                    .filter_map(|aggregate| aggregate.match_filter(message, None, None))
+                    .collect::<FilteredUpdateFilters>();
+                let actual = index.as_ref().map_or_else(
+                    || {
+                        aggregates
+                            .iter()
+                            .filter_map(|aggregate| aggregate.match_filter(message, None, None))
+                            .collect()
+                    },
+                    |index| index.get_filters(&aggregates, message),
+                );
+                assert_eq!(
+                    actual, expected,
+                    "filter count {count}, message {message_index}"
+                );
+            }
+        }
+    }
+
+    fn linear_scan(
+        aggregates: &[FilterAccountAggregate],
+        message: &MessageAccountInfo,
+    ) -> FilteredUpdateFilters {
+        aggregates
+            .iter()
+            .filter_map(|aggregate| aggregate.match_filter(message, None, None))
+            .collect()
+    }
+
+    fn aggregate_with_accounts(name: String, accounts: &[Pubkey]) -> FilterAccountAggregate {
+        let mut aggregate = FilterAccountAggregate::new(FilterName::new(name));
+        aggregate.accounts = Some(accounts.iter().copied().collect());
+        aggregate
+    }
+
+    #[test]
+    fn index_is_disabled_when_no_filter_constrains_a_pubkey() {
+        let cuckoo_account = Pubkey::new_from_array([21; 32]);
+        let mut cuckoo = CuckooFilter::<[u8; 32]>::with_capacity(1).unwrap();
+        cuckoo.insert(&cuckoo_account.to_bytes()).unwrap();
+        let cuckoo = Arc::new(cuckoo);
+
+        let mut aggregates = vec![
+            FilterAccountAggregate::new(FilterName::new("wildcard")),
+            FilterAccountAggregate::new(FilterName::new("signature")),
+            FilterAccountAggregate::new(FilterName::new("state")),
+            FilterAccountAggregate::new(FilterName::new("cuckoo-only")),
+        ];
+        aggregates[1].txn_signature = Some(true);
+        aggregates[2].account_state = Some(FilterAccountsState {
+            memcmp: vec![],
+            datasize: Some(DATA_LEN),
+            token_account_state: false,
+            lamports: vec![],
+        });
+        aggregates[3].accounts_cuckoo = Some(Arc::clone(&cuckoo));
+
+        assert!(FilterAccountsIndex::new(&aggregates).is_none());
+
+        let owner = Pubkey::new_from_array([22; 32]);
+        let data = valid_token_data();
+        assert_eq!(
+            linear_scan(
+                &aggregates,
+                &account_info(cuckoo_account, owner, data.clone(), 100, true),
+            )
+            .as_slice(),
+            [
+                FilterName::new("wildcard"),
+                FilterName::new("signature"),
+                FilterName::new("state"),
+                FilterName::new("cuckoo-only"),
+            ]
+        );
+        assert_eq!(
+            linear_scan(
+                &aggregates,
+                &account_info(
+                    Pubkey::new_from_array([23; 32]),
+                    owner,
+                    vec![0; 3],
+                    100,
+                    false
+                ),
+            )
+            .as_slice(),
+            [FilterName::new("wildcard")]
+        );
+
+        aggregates.push(aggregate_with_accounts(
+            "explicit".to_owned(),
+            &[Pubkey::new_from_array([24; 32])],
+        ));
+        assert!(FilterAccountsIndex::new(&aggregates).is_some());
+    }
+
+    #[test]
+    fn fully_constrained_filters_leave_both_fallbacks_empty() {
+        let accounts = fixtures_pool(30, 4);
+        let owners = fixtures_pool(31, 2);
+
+        let aggregates = (0..8)
+            .map(|i| {
+                let mut aggregate = aggregate_with_accounts(format!("both-{i}"), &accounts);
+                aggregate.owners = Some(owners.iter().copied().collect());
+                aggregate
+            })
+            .collect::<Vec<_>>();
+        let index = FilterAccountsIndex::new(&aggregates).expect("index builds");
+        assert!(
+            index.account_fallback.is_empty(),
+            "no filter is account-unconstrained, so nothing may sit in the account fallback"
+        );
+        assert!(
+            index.owner_fallback.is_empty(),
+            "no filter is owner-unconstrained, so nothing may sit in the owner fallback"
+        );
+
+        let stranger = Pubkey::new_from_array([250; 32]);
+        let miss = account_info(stranger, stranger, vec![0; 3], 100, false);
+        assert!(index.get_filters(&aggregates, &miss).is_empty());
+        assert!(linear_scan(&aggregates, &miss).is_empty());
+
+        let mut mixed = aggregates.clone();
+        mixed.push(FilterAccountAggregate::new(FilterName::new("wildcard")));
+        let mixed_index = FilterAccountsIndex::new(&mixed).expect("index builds");
+        assert!(!mixed_index.account_fallback.is_empty());
+        assert!(!mixed_index.owner_fallback.is_empty());
+        assert_eq!(
+            mixed_index.get_filters(&mixed, &miss).as_slice(),
+            [FilterName::new("wildcard")]
+        );
+    }
+
+    fn fixtures_pool(tag: u8, n: usize) -> Vec<Pubkey> {
+        crate::plugin::filter::fixtures::deterministic_pubkeys(tag, n)
+    }
+
+    #[test]
+    fn index_is_disabled_when_bitset_budget_is_exceeded() {
+        const AGGREGATES: usize = 32_768;
+        let word_bytes = AGGREGATES.div_ceil(FilterBitSet::BITS_PER_WORD) * size_of::<u64>();
+
+        let budget_memberships = FilterAccountsIndex::MAX_BITSET_BYTES / word_bytes - 2;
+        let per_filter_under = budget_memberships / AGGREGATES;
+        let per_filter_over = per_filter_under + 1;
+        assert!(
+            per_filter_under >= 1,
+            "AGGREGATES is too large for the current budget to be straddled"
+        );
+
+        let pool = fixtures_pool(101, per_filter_over);
+
+        let build = |per_filter: usize| {
+            (0..AGGREGATES)
+                .map(|i| aggregate_with_accounts(format!("filter-{i}"), &pool[..per_filter]))
+                .collect::<Vec<_>>()
+        };
+
+        let under_budget = build(per_filter_under);
+        assert!(
+            word_bytes * (AGGREGATES * per_filter_under + 2)
+                <= FilterAccountsIndex::MAX_BITSET_BYTES
+        );
+        assert!(
+            FilterAccountsIndex::new(&under_budget).is_some(),
+            "{per_filter_under} pubkeys per filter is under MAX_BITSET_BYTES and must still index"
+        );
+
+        let over_budget = build(per_filter_over);
+        assert!(
+            word_bytes * (AGGREGATES * per_filter_over + 2) > FilterAccountsIndex::MAX_BITSET_BYTES
+        );
+        assert!(
+            FilterAccountsIndex::new(&over_budget).is_none(),
+            "{per_filter_over} pubkeys per filter exceeds MAX_BITSET_BYTES and must fall back"
+        );
+
+        for (filters, per_filter, label) in [
+            (256usize, 10_000usize, "bench: 256 x 10k"),
+            (10, 100_000, "production: 10 x 100k"),
+            (20, 100_000, "production headroom: 20 x 100k"),
+        ] {
+            let bytes = filters.div_ceil(FilterBitSet::BITS_PER_WORD)
+                * size_of::<u64>()
+                * (filters * per_filter + 2);
+            assert!(
+                bytes <= FilterAccountsIndex::MAX_BITSET_BYTES,
+                "{label} estimates {bytes} bytes and would fall back to a linear scan"
+            );
+        }
+
+        let owner = Pubkey::new_from_array([200; 32]);
+        let hit = account_info(pool[0], owner, vec![0; 3], 100, false);
+        let indexed = FilterAccountsIndex::new(&under_budget).unwrap();
+        assert_eq!(
+            indexed.get_filters(&under_budget, &hit),
+            linear_scan(&under_budget, &hit)
+        );
+        assert_eq!(linear_scan(&over_budget, &hit).len(), AGGREGATES);
+
+        let miss = account_info(
+            Pubkey::new_from_array([201; 32]),
+            owner,
+            vec![0; 3],
+            100,
+            false,
+        );
+        assert!(linear_scan(&over_budget, &miss).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod parity_oracle {
+    use {
+        super::*,
+        crate::plugin::filter::fixtures,
+        yellowstone_grpc_proto::geyser::{
+            CuckooFilter as ProtoCuckooFilter, SubscribeRequestFilterAccountsFilterMemcmp,
+        },
+    };
+
+    #[derive(Debug)]
+    struct MasterAggregate {
+        filter_name: FilterName,
+        require_non_empty_txn_signature: bool,
+        require_account: bool,
+        require_cuckoo: bool,
+        require_owner: bool,
+        require_state_check: bool,
+    }
+
+    #[derive(Debug, Default)]
+    struct MasterAccountsOracle {
+        nonempty_txn_signature: Vec<(FilterName, Option<bool>)>,
+        account: FoldHashMap<Pubkey, FoldHashSet<FilterName>>,
+        account_cuckoo: FoldHashMap<FilterName, Arc<CuckooFilter<[u8; 32]>>>,
+        owner: FoldHashMap<Pubkey, FoldHashSet<FilterName>>,
+        state_check: FoldHashMap<FilterName, FilterAccountsState>,
+        aggregates: Vec<MasterAggregate>,
+    }
+
+    impl MasterAccountsOracle {
+        fn new(
+            configs: &HashMap<String, SubscribeRequestFilterAccounts>,
+            limits: &FilterLimitsAccounts,
+            names: &mut FilterNames,
+        ) -> FilterResult<Self> {
+            FilterLimits::check_max(configs.len(), limits.max)?;
+
+            let mut this = Self::default();
+            for (name, filter) in configs {
+                let has_filter_criteria = !filter.account.is_empty()
+                    || !filter.owner.is_empty()
+                    || filter.cuckoo_accounts_filter.is_some();
+
+                FilterLimits::check_any(!has_filter_criteria, limits.any)?;
+                FilterLimits::check_pubkey_max(filter.account.len(), limits.account_max)?;
+                FilterLimits::check_pubkey_max(filter.owner.len(), limits.owner_max)?;
+
+                let filter_name = names.get(name)?;
+
+                if filter.nonempty_txn_signature.is_some() {
+                    this.nonempty_txn_signature
+                        .push((filter_name.clone(), filter.nonempty_txn_signature));
+                }
+
+                Self::set(
+                    &mut this.account,
+                    filter_name.clone(),
+                    Filter::decode_pubkeys(&filter.account, &limits.account_reject),
+                )?;
+                Self::set(
+                    &mut this.owner,
+                    filter_name.clone(),
+                    Filter::decode_pubkeys(&filter.owner, &limits.owner_reject),
+                )?;
+
+                let state = FilterAccountsState::new(&filter.filters)?;
+                let require_state_check = !state.is_empty();
+                if require_state_check {
+                    this.state_check.insert(filter_name.clone(), state);
+                }
+
+                let mut require_cuckoo = false;
+                if let Some(proto_cuckoo) = &filter.cuckoo_accounts_filter {
+                    FilterLimits::check_max(proto_cuckoo.data.len(), limits.cuckoo_max_size)?;
+                    this.account_cuckoo.insert(
+                        filter_name.clone(),
+                        Arc::new(CuckooFilter::from(proto_cuckoo)),
+                    );
+                    require_cuckoo = true;
+                }
+
+                this.aggregates.push(MasterAggregate {
+                    filter_name,
+                    require_non_empty_txn_signature: filter.nonempty_txn_signature.is_some(),
+                    require_account: !filter.account.is_empty(),
+                    require_cuckoo,
+                    require_owner: !filter.owner.is_empty(),
+                    require_state_check,
+                });
+            }
+
+            Ok(this)
+        }
+
+        fn set(
+            map: &mut FoldHashMap<Pubkey, FoldHashSet<FilterName>>,
+            filter_name: FilterName,
+            keys: impl Iterator<Item = FilterResult<Pubkey>>,
+        ) -> FilterResult<()> {
+            for maybe_key in keys {
+                map.entry(maybe_key?)
+                    .or_default()
+                    .insert(filter_name.clone());
+            }
+            Ok(())
+        }
+
+        fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
+            let mut nonempty_txn_signature = FoldHashSet::default();
+            for (name, filter) in self.nonempty_txn_signature.iter() {
+                if let Some(required) = filter {
+                    if *required == account.txn_signature.is_some() {
+                        nonempty_txn_signature.insert(name.as_ref());
+                    }
+                }
+            }
+
+            let matched_account = self.account.get(&account.pubkey);
+
+            let mut cuckoo = FoldHashSet::default();
+            if !self.account_cuckoo.is_empty() {
+                let bytes = account.pubkey.to_bytes();
+                for (name, filter) in &self.account_cuckoo {
+                    if filter.contains(&bytes) {
+                        cuckoo.insert(name.as_ref());
+                    }
+                }
+            }
+
+            let matched_owner = self.owner.get(&account.owner);
+
+            let mut data = FoldHashSet::default();
+            for (name, account_state) in self.state_check.iter() {
+                if account_state.is_match(&account.data, account.lamports) {
+                    data.insert(name.as_ref());
+                }
+            }
+
+            self.aggregates
+                .iter()
+                .filter_map(|aggregate| {
+                    if aggregate.require_non_empty_txn_signature
+                        && !nonempty_txn_signature.contains(aggregate.filter_name.as_ref())
+                    {
+                        return None;
+                    }
+
+                    let needs_pubkey = aggregate.require_account || aggregate.require_cuckoo;
+                    if needs_pubkey
+                        && (!matched_account.is_some_and(|accounts| {
+                            accounts.contains(aggregate.filter_name.as_ref())
+                        }) && !cuckoo.contains(aggregate.filter_name.as_ref()))
+                    {
+                        return None;
+                    }
+
+                    if aggregate.require_owner
+                        && !matched_owner
+                            .is_some_and(|owners| owners.contains(aggregate.filter_name.as_ref()))
+                    {
+                        return None;
+                    }
+
+                    if aggregate.require_state_check
+                        && !data.contains(aggregate.filter_name.as_ref())
+                    {
+                        return None;
+                    }
+
+                    Some(aggregate.filter_name.clone())
+                })
+                .collect()
+        }
+    }
+
+    const ACCOUNT_POOL: usize = 10;
+    const OWNER_POOL: usize = 5;
+    const MAX_STATE_FILTERS: usize = 4;
+    const MEMCMP_NEEDLE: &[u8] = b"needle";
+
+    struct Scenario {
+        request: SubscribeRequest,
+        messages: Vec<Arc<MessageAccount>>,
+    }
+
+    fn pick<'a, T>(rng: &mut fastrand::Rng, items: &'a [T]) -> &'a T {
+        &items[rng.usize(..items.len())]
+    }
+
+    fn gen_state_filters(
+        rng: &mut fastrand::Rng,
+        data_len: usize,
+    ) -> Vec<SubscribeRequestFilterAccountsFilter> {
+        let mut filters = Vec::new();
+        let mut datasize_used = false;
+
+        while filters.len() < MAX_STATE_FILTERS && rng.bool() {
+            let choice = rng.u8(0..4);
+            let filter = match choice {
+                0 if !datasize_used => {
+                    datasize_used = true;
+                    AccountsFilterDataOneof::Datasize(data_len as u64)
+                }
+                0 | 1 => {
+                    let offset = rng.u64(0..8);
+                    let data = match rng.u8(0..3) {
+                        0 => AccountsFilterMemcmpOneof::Bytes(MEMCMP_NEEDLE.to_vec()),
+                        1 => AccountsFilterMemcmpOneof::Base58(
+                            bs58::encode(MEMCMP_NEEDLE).into_string(),
+                        ),
+                        _ => AccountsFilterMemcmpOneof::Base64(base64_engine.encode(MEMCMP_NEEDLE)),
+                    };
+                    AccountsFilterDataOneof::Memcmp(SubscribeRequestFilterAccountsFilterMemcmp {
+                        offset,
+                        data: Some(data),
+                    })
+                }
+                2 => AccountsFilterDataOneof::TokenAccountState(true),
+                _ => AccountsFilterDataOneof::Lamports(
+                    SubscribeRequestFilterAccountsFilterLamports {
+                        cmp: Some(match rng.u8(0..4) {
+                            0 => AccountsFilterLamports::Eq(rng.u64(98..102)),
+                            1 => AccountsFilterLamports::Ne(rng.u64(98..102)),
+                            2 => AccountsFilterLamports::Lt(rng.u64(98..102)),
+                            _ => AccountsFilterLamports::Gt(rng.u64(98..102)),
+                        }),
+                    },
+                ),
+            };
+            filters.push(SubscribeRequestFilterAccountsFilter {
+                filter: Some(filter),
+            });
+        }
+
+        filters
+    }
+
+    fn gen_scenario(rng: &mut fastrand::Rng) -> Scenario {
+        let accounts_pool = fixtures::deterministic_pubkeys(1, ACCOUNT_POOL);
+        let owners_pool = fixtures::deterministic_pubkeys(2, OWNER_POOL);
+        let strangers = fixtures::deterministic_pubkeys(3, 4);
+
+        let filter_count = match rng.u8(0..10) {
+            0 => 0,
+            1 => 1,
+            2..=7 => rng.usize(2..9),
+            8 => rng.usize(63..67),
+            _ => rng.usize(127..130),
+        };
+
+        let mut accounts = HashMap::new();
+        for i in 0..filter_count {
+            let account = (0..rng.usize(0..4))
+                .map(|_| pick(rng, &accounts_pool).to_string())
+                .collect::<Vec<_>>();
+            let owner = (0..rng.usize(0..3))
+                .map(|_| pick(rng, &owners_pool).to_string())
+                .collect::<Vec<_>>();
+
+            let cuckoo_accounts_filter = (rng.u8(0..4) == 0).then(|| {
+                let mut cuckoo = CuckooFilter::<[u8; 32]>::with_capacity(4).unwrap();
+                for _ in 0..rng.usize(1..4) {
+                    cuckoo
+                        .insert(&pick(rng, &accounts_pool).to_bytes())
+                        .unwrap();
+                }
+                ProtoCuckooFilter::from(&cuckoo)
+            });
+
+            let nonempty_txn_signature = match rng.u8(0..3) {
+                0 => None,
+                1 => Some(true),
+                _ => Some(false),
+            };
+
+            accounts.insert(
+                format!("filter-{i}"),
+                SubscribeRequestFilterAccounts {
+                    account,
+                    owner,
+                    filters: gen_state_filters(rng, fixtures::TOKEN_ACCOUNT_LEN),
+                    nonempty_txn_signature,
+                    cuckoo_accounts_filter,
+                },
+            );
+        }
+
+        let messages = (0..14)
+            .map(|_| {
+                let pubkey = if rng.bool() {
+                    *pick(rng, &accounts_pool)
+                } else {
+                    *pick(rng, &strangers)
+                };
+                let owner = match rng.u8(0..3) {
+                    0 => *pick(rng, &owners_pool),
+                    1 => *pick(rng, &accounts_pool),
+                    _ => *pick(rng, &strangers),
+                };
+                let data_len = *pick(rng, &[0usize, 4, 107, 108, 164, 165, 166, 2048]);
+                let mut data = vec![0u8; data_len];
+                if data_len > fixtures::TOKEN_ACCOUNT_STATE_OFFSET && rng.bool() {
+                    data[fixtures::TOKEN_ACCOUNT_STATE_OFFSET] = 1;
+                }
+                if data_len >= MEMCMP_NEEDLE.len() + 8 && rng.bool() {
+                    let offset = rng.usize(0..8);
+                    data[offset..offset + MEMCMP_NEEDLE.len()].copy_from_slice(MEMCMP_NEEDLE);
+                }
+                let lamports = *pick(rng, &[0u64, 98, 99, 100, 101, u64::MAX]);
+                let txn_signature = rng.bool().then(Signature::default);
+
+                fixtures::message_account(fixtures::account_info(
+                    pubkey,
+                    owner,
+                    data,
+                    lamports,
+                    txn_signature,
+                ))
+            })
+            .collect();
+
+        Scenario {
+            request: SubscribeRequest {
+                accounts,
+                ..Default::default()
+            },
+            messages,
+        }
+    }
+
+    const SEEDS: [u64; 24] = [
+        0x0000_0000_0000_0001,
+        0x0000_0000_0000_0002,
+        0x0000_0000_0000_0003,
+        0xdead_beef_cafe_f00d,
+        0x0123_4567_89ab_cdef,
+        0xfedc_ba98_7654_3210,
+        0x5555_5555_5555_5555,
+        0xaaaa_aaaa_aaaa_aaaa,
+        0x1111_2222_3333_4444,
+        0x9e37_79b9_7f4a_7c15,
+        0x6a09_e667_f3bc_c908,
+        0xbb67_ae85_84ca_a73b,
+        0x3c6e_f372_fe94_f82b,
+        0xa54f_f53a_5f1d_36f1,
+        0x510e_527f_ade6_82d1,
+        0x9b05_688c_2b3e_6c1f,
+        0x1f83_d9ab_fb41_bd6b,
+        0x5be0_cd19_137e_2179,
+        0x0000_0000_ffff_ffff,
+        0xffff_ffff_0000_0000,
+        0x7fff_ffff_ffff_ffff,
+        0x8000_0000_0000_0000,
+        0x0f0f_0f0f_0f0f_0f0f,
+        0xf0f0_f0f0_f0f0_f0f0,
+    ];
+    const SCENARIOS_PER_SEED: usize = 8;
+
+    #[test]
+    fn account_matching_is_identical_to_master_semantics() {
+        let limits = FilterLimits::default();
+        let mut checked = 0usize;
+        let mut matched = 0usize;
+
+        for seed in SEEDS {
+            let mut rng = fastrand::Rng::with_seed(seed);
+
+            for scenario_index in 0..SCENARIOS_PER_SEED {
+                let scenario = gen_scenario(&mut rng);
+                let where_ = |message_index: usize| {
+                    format!(
+                        "seed={seed:#x} scenario={scenario_index} message={message_index} \
+                         filters={}",
+                        scenario.request.accounts.len()
+                    )
+                };
+
+                let filter = Filter::new(&scenario.request, &limits, &mut fixtures::filter_names())
+                    .unwrap_or_else(|err| panic!("{}: Filter::new failed: {err}", where_(0)));
+
+                let oracle = MasterAccountsOracle::new(
+                    &scenario.request.accounts,
+                    &limits.accounts,
+                    &mut fixtures::filter_names(),
+                )
+                .unwrap_or_else(|err| panic!("{}: oracle build failed: {err}", where_(0)));
+
+                for (message_index, message) in scenario.messages.iter().enumerate() {
+                    let account = &message.account;
+                    let expected = oracle.get_filters(account);
+
+                    let updates = filter.get_updates(&Message::Account(Arc::clone(message)), None);
+                    assert!(
+                        updates.len() <= 1,
+                        "{}: account messages yield at most one update, got {}",
+                        where_(message_index),
+                        updates.len()
+                    );
+                    let actual = updates
+                        .first()
+                        .map(|update| update.filters.clone())
+                        .unwrap_or_default();
+                    assert_eq!(
+                        actual,
+                        expected,
+                        "{}: public output diverged from master semantics",
+                        where_(message_index)
+                    );
+
+                    let linear = filter
+                        .accounts
+                        .aggregates
+                        .iter()
+                        .filter_map(|aggregate| aggregate.match_filter(account, None, None))
+                        .collect::<FilteredUpdateFilters>();
+                    assert_eq!(
+                        linear,
+                        expected,
+                        "{}: linear scan diverged from master semantics",
+                        where_(message_index)
+                    );
+
+                    if let Some(index) = &filter.accounts.index {
+                        assert_eq!(
+                            index.get_filters(&filter.accounts.aggregates, account),
+                            expected,
+                            "{}: indexed lookup diverged from master semantics",
+                            where_(message_index)
+                        );
+                    }
+
+                    let mut names = actual.iter().map(|n| n.as_ref()).collect::<Vec<_>>();
+                    let before = names.len();
+                    names.sort_unstable();
+                    names.dedup();
+                    assert_eq!(
+                        names.len(),
+                        before,
+                        "{}: duplicate filter names in output",
+                        where_(message_index)
+                    );
+
+                    if !updates.is_empty() {
+                        assert_eq!(
+                            updates[0].created_at,
+                            message.created_at,
+                            "{}: created_at not propagated",
+                            where_(message_index)
+                        );
+                        matched += 1;
+                    }
+                    checked += 1;
+                }
+            }
+        }
+
+        assert!(
+            matched * 5 > checked,
+            "generator produced too few matches to be meaningful: {matched}/{checked}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod filter_kind_coverage {
+    use {
+        super::*,
+        crate::plugin::filter::fixtures,
+        yellowstone_grpc_proto::geyser::{
+            CuckooFilter as ProtoCuckooFilter, SubscribeRequestFilterEntry,
+        },
+    };
+
+    fn matched_names(updates: &FilteredUpdates) -> Vec<String> {
+        let mut names = updates
+            .iter()
+            .flat_map(|update| update.filters.iter())
+            .map(|name| name.as_ref().to_owned())
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        names
+    }
+
+    fn build(request: SubscribeRequest) -> Filter {
+        Filter::new(
+            &request,
+            &FilterLimits::default(),
+            &mut fixtures::filter_names(),
+        )
+        .expect("filter builds")
+    }
+
+    const ALL_SLOT_STATUSES: [SlotStatus; 7] = [
+        SlotStatus::Processed,
+        SlotStatus::Confirmed,
+        SlotStatus::Finalized,
+        SlotStatus::FirstShredReceived,
+        SlotStatus::Completed,
+        SlotStatus::CreatedBank,
+        SlotStatus::Dead,
+    ];
+
+    fn slots_request(
+        filter_by_commitment: Option<bool>,
+        interslot_updates: Option<bool>,
+    ) -> SubscribeRequest {
+        SubscribeRequest {
+            slots: HashMap::from([(
+                "s".to_owned(),
+                SubscribeRequestFilterSlots {
+                    filter_by_commitment,
+                    interslot_updates,
+                },
+            )]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn slot_status_and_interslot_updates_gate_delivery() {
+        for interslot in [None, Some(false), Some(true)] {
+            let filter = build(slots_request(None, interslot));
+            let wants_all = interslot == Some(true);
+
+            for status in ALL_SLOT_STATUSES {
+                let updates = filter.get_updates(
+                    &Message::Slot(Arc::new(fixtures::message_slot(42, status))),
+                    None,
+                );
+                let commitment_bearing = matches!(
+                    status,
+                    SlotStatus::Processed | SlotStatus::Confirmed | SlotStatus::Finalized
+                );
+                assert_eq!(
+                    !updates.is_empty(),
+                    wants_all || commitment_bearing,
+                    "interslot={interslot:?} status={status:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn slot_filter_by_commitment_requires_matching_commitment() {
+        let filter = build(slots_request(Some(true), Some(true)));
+
+        for status in ALL_SLOT_STATUSES {
+            let message = Message::Slot(Arc::new(fixtures::message_slot(42, status)));
+
+            assert!(
+                filter.get_updates(&message, None).is_empty(),
+                "status={status:?} with no commitment"
+            );
+
+            for commitment in [
+                CommitmentLevel::Processed,
+                CommitmentLevel::Confirmed,
+                CommitmentLevel::Finalized,
+            ] {
+                let updates = filter.get_updates(&message, Some(commitment));
+                assert_eq!(
+                    !updates.is_empty(),
+                    commitment == status,
+                    "status={status:?} commitment={commitment:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn entry_filter_matches_every_entry_and_absence_yields_nothing() {
+        let filter = build(SubscribeRequest {
+            entry: HashMap::from([("e".to_owned(), SubscribeRequestFilterEntry {})]),
+            ..Default::default()
+        });
+        let updates = filter.get_updates(&Message::Entry(fixtures::message_entry(42, 3)), None);
+        assert_eq!(matched_names(&updates), ["e"]);
+
+        let empty = build(SubscribeRequest::default());
+        assert!(empty
+            .get_updates(&Message::Entry(fixtures::message_entry(42, 3)), None)
+            .is_empty());
+    }
+
+    #[test]
+    fn blocks_meta_filter_matches_and_reports_every_subscribed_name() {
+        let filter = build(SubscribeRequest {
+            blocks_meta: HashMap::from([
+                ("a".to_owned(), SubscribeRequestFilterBlocksMeta {}),
+                ("b".to_owned(), SubscribeRequestFilterBlocksMeta {}),
+            ]),
+            ..Default::default()
+        });
+
+        let updates =
+            filter.get_updates(&Message::BlockMeta(fixtures::message_block_meta(42)), None);
+        assert_eq!(updates.len(), 1, "one update carrying both filter names");
+        assert_eq!(matched_names(&updates), ["a", "b"]);
+
+        let empty = build(SubscribeRequest::default());
+        assert!(empty
+            .get_updates(&Message::BlockMeta(fixtures::message_block_meta(42)), None)
+            .is_empty());
+    }
+
+    fn blocks_request(
+        include_transactions: Option<bool>,
+        include_accounts: Option<bool>,
+        include_entries: Option<bool>,
+        account_include: Vec<String>,
+        cuckoo_account_include: Option<ProtoCuckooFilter>,
+    ) -> SubscribeRequest {
+        SubscribeRequest {
+            blocks: HashMap::from([(
+                "b".to_owned(),
+                SubscribeRequestFilterBlocks {
+                    account_include,
+                    include_transactions,
+                    include_accounts,
+                    include_entries,
+                    cuckoo_account_include,
+                },
+            )]),
+            ..Default::default()
+        }
+    }
+
+    fn block_payload(update: &FilteredUpdate) -> &FilteredUpdateBlock {
+        match &update.message {
+            FilteredUpdateOneof::Block(block) => block,
+            other => panic!("expected a block payload, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_include_toggles_control_which_children_are_carried() {
+        let keys = fixtures::deterministic_pubkeys(4, 3);
+        let transactions = vec![fixtures::message_transaction(
+            Signature::default(),
+            keys.clone(),
+            false,
+            Default::default(),
+        )];
+        let accounts = vec![fixtures::simple_message_account(keys[0], keys[1])];
+        let entries = vec![fixtures::message_entry(42, 0)];
+
+        for (include_transactions, include_accounts, include_entries) in [
+            (None, None, None),
+            (Some(true), Some(true), Some(true)),
+            (Some(false), Some(false), Some(false)),
+            (Some(false), Some(true), None),
+        ] {
+            let filter = build(blocks_request(
+                include_transactions,
+                include_accounts,
+                include_entries,
+                vec![],
+                None,
+            ));
+            let block = fixtures::message_block(
+                42,
+                transactions.clone(),
+                accounts.clone(),
+                entries.clone(),
+            );
+            let updates = filter.get_updates(&Message::Block(block), None);
+            assert_eq!(updates.len(), 1);
+            let payload = block_payload(&updates[0]);
+
+            let label =
+                format!("txs={include_transactions:?} accts={include_accounts:?} entries={include_entries:?}");
+            assert_eq!(
+                payload.transactions.len(),
+                usize::from(matches!(include_transactions, None | Some(true))),
+                "{label}: transactions"
+            );
+            assert_eq!(
+                payload.accounts.len(),
+                usize::from(include_accounts == Some(true)),
+                "{label}: accounts"
+            );
+            assert_eq!(
+                payload.entries.len(),
+                usize::from(include_entries == Some(true)),
+                "{label}: entries"
+            );
+            assert_eq!(payload.updated_account_count, 1, "{label}: account count");
+        }
+    }
+
+    #[test]
+    fn block_account_include_selects_children_without_suppressing_the_update() {
+        let keys = fixtures::deterministic_pubkeys(5, 4);
+        let wanted = keys[1];
+        let transactions = vec![
+            fixtures::message_transaction(
+                Signature::default(),
+                vec![wanted, keys[2]],
+                false,
+                Default::default(),
+            ),
+            fixtures::message_transaction(
+                Signature::default(),
+                vec![keys[2], keys[3]],
+                false,
+                Default::default(),
+            ),
+        ];
+        let accounts = vec![
+            fixtures::simple_message_account(wanted, keys[0]),
+            fixtures::simple_message_account(keys[3], keys[0]),
+        ];
+
+        let filter = build(blocks_request(
+            Some(true),
+            Some(true),
+            None,
+            vec![wanted.to_string()],
+            None,
+        ));
+        let updates = filter.get_updates(
+            &Message::Block(fixtures::message_block(42, transactions, accounts, vec![])),
+            None,
+        );
+
+        assert_eq!(matched_names(&updates), ["b"]);
+        let payload = block_payload(&updates[0]);
+        assert_eq!(payload.transactions.len(), 1, "only the matching tx");
+        assert_eq!(payload.accounts.len(), 1, "only the matching account");
+        assert_eq!(payload.accounts[0].account.pubkey, wanted);
+    }
+
+    #[test]
+    fn block_explicit_and_cuckoo_account_lists_are_ored() {
+        let keys = fixtures::deterministic_pubkeys(6, 4);
+        let explicit = keys[0];
+        let via_cuckoo = keys[1];
+        let unrelated = keys[2];
+
+        let mut cuckoo = CuckooFilter::<[u8; 32]>::with_capacity(4).unwrap();
+        cuckoo.insert(&via_cuckoo.to_bytes()).unwrap();
+        assert!(
+            !cuckoo.contains(&unrelated.to_bytes()),
+            "precondition: the unrelated key must not be a cuckoo false positive"
+        );
+        let proto_cuckoo = ProtoCuckooFilter::from(&cuckoo);
+
+        let filter = build(blocks_request(
+            Some(true),
+            None,
+            None,
+            vec![explicit.to_string()],
+            Some(proto_cuckoo),
+        ));
+
+        let transactions = vec![
+            fixtures::message_transaction(
+                Signature::default(),
+                vec![explicit],
+                false,
+                Default::default(),
+            ),
+            fixtures::message_transaction(
+                Signature::default(),
+                vec![via_cuckoo],
+                false,
+                Default::default(),
+            ),
+            fixtures::message_transaction(
+                Signature::default(),
+                vec![unrelated],
+                false,
+                Default::default(),
+            ),
+        ];
+
+        let updates = filter.get_updates(
+            &Message::Block(fixtures::message_block(42, transactions, vec![], vec![])),
+            None,
+        );
+        let payload = block_payload(&updates[0]);
+        assert_eq!(
+            payload.transactions.len(),
+            2,
+            "the explicit list and the cuckoo each contribute one transaction"
+        );
+    }
+
+    #[test]
+    fn account_data_slice_validation_rejects_disorder_and_overlap() {
+        let slice = |offset: u64, length: u64| SubscribeRequestAccountsDataSlice { offset, length };
+
+        assert!(FilterAccountsDataSlice::new(&[], usize::MAX).is_ok());
+        assert!(FilterAccountsDataSlice::new(&[slice(0, 4), slice(8, 4)], usize::MAX).is_ok());
+        assert!(matches!(
+            FilterAccountsDataSlice::new(&[slice(8, 4), slice(0, 4)], usize::MAX),
+            Err(FilterError::CreateDataSliceOutOfOrder)
+        ));
+        assert!(matches!(
+            FilterAccountsDataSlice::new(&[slice(0, 8), slice(4, 4)], usize::MAX),
+            Err(FilterError::CreateDataSliceOverlap)
+        ));
+        assert!(matches!(
+            FilterAccountsDataSlice::new(&[slice(0, 4), slice(4, 4), slice(2, 2)], usize::MAX),
+            Err(FilterError::CreateDataSliceOutOfOrder)
+        ));
+        assert!(matches!(
+            FilterAccountsDataSlice::new(&[slice(0, 4)], 0),
+            Err(FilterError::LimitsCheck(_))
+        ));
+    }
+
+    #[test]
+    fn account_data_slice_extraction_and_length_agree() {
+        let source = (0..16u8).collect::<Vec<_>>();
+
+        for slices in [
+            vec![],
+            vec![(0u64, 4u64)],
+            vec![(4, 4)],
+            vec![(0, 4), (8, 4)],
+            vec![(12, 4)],
+            vec![(13, 4)],
+            vec![(0, 4), (100, 4)],
+        ] {
+            let protos = slices
+                .iter()
+                .map(|&(offset, length)| SubscribeRequestAccountsDataSlice { offset, length })
+                .collect::<Vec<_>>();
+            let data_slice = FilterAccountsDataSlice::new(&protos, usize::MAX).unwrap();
+
+            let extracted = data_slice.get_slice(&source);
+            assert_eq!(
+                extracted.len(),
+                data_slice.get_slice_len(&source),
+                "slices {slices:?}: get_slice_len disagrees with get_slice"
+            );
+
+            let expected = if slices.is_empty() {
+                source.clone()
+            } else {
+                slices
+                    .iter()
+                    .filter(|&&(offset, length)| source.len() as u64 >= offset + length)
+                    .flat_map(|&(offset, length)| {
+                        source[offset as usize..(offset + length) as usize].to_vec()
+                    })
+                    .collect()
+            };
+            assert_eq!(extracted, expected, "slices {slices:?}");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2799,8 +4823,20 @@ mod cuckoo_tests {
 
     #[test]
     fn test_cuckoo_filter_no_match() {
-        let in_filter = Pubkey::new_unique();
-        let not_in_filter = Pubkey::new_unique();
+        let in_filter = Pubkey::new_from_array([0x11; 32]);
+        let not_in_filter = Pubkey::new_from_array([0x22; 32]);
+
+        let mut probe = CuckooFilter::<[u8; 32]>::with_capacity(1).unwrap();
+        probe.insert(&in_filter.to_bytes()).unwrap();
+        assert!(
+            probe.contains(&in_filter.to_bytes()),
+            "cuckoo filters have no false negatives"
+        );
+        assert!(
+            !probe.contains(&not_in_filter.to_bytes()),
+            "precondition: the chosen absent key must not be a false positive of this filter"
+        );
+
         let cuckoo = create_cuckoo_with_pubkeys(&[in_filter]);
 
         let mut accounts = HashMap::new();
@@ -2835,7 +4871,7 @@ mod cuckoo_tests {
             &mut create_filter_names(),
         )
         .unwrap();
-        let message = create_message_account(not_in_filter, Pubkey::new_unique());
+        let message = create_message_account(not_in_filter, Pubkey::new_from_array([0x33; 32]));
         let updates = filter.get_updates(&Message::Account(message), None);
 
         assert!(updates.is_empty());
@@ -2845,6 +4881,7 @@ mod cuckoo_tests {
     fn test_cuckoo_or_explicit_account() {
         let pk_in_cuckoo = Pubkey::new_unique();
         let pk_in_list = Pubkey::new_unique();
+        let pk_in_other_filter = Pubkey::new_unique();
         let cuckoo = create_cuckoo_with_pubkeys(&[pk_in_cuckoo]);
 
         let mut accounts = HashMap::new();
@@ -2856,6 +4893,13 @@ mod cuckoo_tests {
                 filters: vec![],
                 nonempty_txn_signature: None,
                 cuckoo_accounts_filter: Some(cuckoo),
+            },
+        );
+        accounts.insert(
+            "other".to_string(),
+            SubscribeRequestFilterAccounts {
+                account: vec![pk_in_other_filter.to_string()],
+                ..Default::default()
             },
         );
 

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -274,7 +274,7 @@ impl Filter {
         // filters would be missing if we iterated only account/owner maps.
         let accounts = self
             .accounts
-            .aggregates
+            .aggregates()
             .iter()
             .map(|aggregate| AccountFilterStats {
                 // `accounts.account` is indexed by pubkey -> set(filter_name).
@@ -381,7 +381,7 @@ impl Filter {
 
     pub fn get_metrics(&self) -> [(&'static str, usize); 8] {
         [
-            ("accounts", self.accounts.aggregates.len()),
+            ("accounts", self.accounts.aggregates().len()),
             ("slots", self.slots.filters.len()),
             ("transactions", self.transactions.filters.len()),
             (
@@ -393,7 +393,7 @@ impl Filter {
             ("blocks_meta", self.blocks_meta.filters.len()),
             (
                 "all",
-                self.accounts.aggregates.len()
+                self.accounts.aggregates().len()
                     + self.slots.filters.len()
                     + self.transactions.filters.len()
                     + self.transactions_status.filters.len()
@@ -574,8 +574,48 @@ impl FilterBitSet {
     }
 }
 
+/// Bitset-indexed matching: precomputes, per pubkey and per owner, which
+/// aggregate indices are candidates, so one incoming account update is
+/// checked in roughly O(aggregates / 64) instead of O(aggregates).
+///
+/// Every aggregate owns one bit. Two bitsets record exact hits (`accounts`,
+/// `owners`, keyed by pubkey), and two more (`account_fallback`,
+/// `owner_fallback`) record aggregates that are unconstrained on that axis —
+/// always a candidate, whatever pubkey/owner shows up. A lookup is then two
+/// ORs and an AND, done 64 aggregates at a time:
+///
+/// ```text
+///   account_candidates = accounts[pubkey]  (or all-zero if no exact hit)
+///                      | account_fallback
+///   owner_candidates   = owners[owner]     (or all-zero if no exact hit)
+///                      | owner_fallback
+///   candidates         = account_candidates & owner_candidates
+/// ```
+///
+/// Example: 5 aggregates, update arrives for `(pubkey=A, owner=X)`:
+///
+/// ```text
+///  idx  accounts wants   owners wants   account_fallback?  owner_fallback?
+///   0        {A}             --               no               yes
+///   1        {B}             {X}              no                no
+///   2        --              {X}              yes               no
+///   3      {A, B}            --               no               yes
+///   4        --              --               yes               yes
+///
+///  accounts[A] = {0,3}   account_fallback = {2,4}    -> account_candidates = {0,2,3,4}
+///  owners[X]   = {1,2}   owner_fallback   = {0,3,4}  -> owner_candidates   = {0,1,2,3,4}
+///  candidates  = {0,2,3,4} & {0,1,2,3,4} = {0,2,3,4}   (aggregate 1 excluded: wanted B, not A)
+/// ```
+///
+/// Only the surviving candidates go through the full per-aggregate
+/// `match_filter` check (cuckoo filter, txn signature, data/lamports state).
 #[derive(Debug, Clone)]
 struct FilterAccountsIndex {
+    // Owned so the index is self-sufficient: `get_filters` never needs a caller
+    // to hand back the exact slice it was built from (which risked mismatched
+    // aggregates/index pairs). Cloned once at construction, off the hot path.
+    aggregates: Vec<FilterAccountAggregate>,
+
     accounts: FoldHashMap<Pubkey, FilterBitSet>,
     owners: FoldHashMap<Pubkey, FilterBitSet>,
 
@@ -613,6 +653,8 @@ impl FilterAccountsIndex {
         }
 
         let mut this = Self {
+            aggregates: aggregates.to_vec(),
+
             accounts: FoldHashMap::default(),
             owners: FoldHashMap::default(),
 
@@ -658,11 +700,11 @@ impl FilterAccountsIndex {
         }
     }
 
-    fn get_filters(
-        &self,
-        aggregates: &[FilterAccountAggregate],
-        account: &MessageAccountInfo,
-    ) -> FilteredUpdateFilters {
+    fn aggregates(&self) -> &[FilterAccountAggregate] {
+        &self.aggregates
+    }
+
+    fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
         let matched_accounts = self.accounts.get(&account.pubkey);
         if matched_accounts.is_none() && self.account_fallback_empty {
             return FilteredUpdateFilters::new();
@@ -689,7 +731,7 @@ impl FilterAccountsIndex {
                 let aggregate_index = word_index * FilterBitSet::BITS_PER_WORD + bit_index;
                 let bit = 1 << bit_index;
 
-                if let Some(filter) = aggregates[aggregate_index].match_filter(
+                if let Some(filter) = self.aggregates[aggregate_index].match_filter(
                     account,
                     Some(matched_accounts_word & bit != 0),
                     Some(matched_owners_word & bit != 0),
@@ -703,26 +745,6 @@ impl FilterAccountsIndex {
 
         filters
     }
-}
-
-#[derive(Debug, Default, Clone)]
-struct FilterAccounts {
-    aggregates: Vec<FilterAccountAggregate>,
-
-    // bitset matching algorithm, capped at 512MB of usage. if the requested filter goes above this, it will fall back to non indexed algo.
-    index: Option<Arc<FilterAccountsIndex>>,
-
-    // non indexed (slightly slower) algorithm, used when the index is not available or when the filter is too large to be indexed.
-    // query multiple filters by account, each usize inside of the Vec represents an 'aggregate' index in the FilterAccounts::aggregates Vec.
-    accounts: FoldHashMap<Pubkey, Vec<usize>>,
-    owners: FoldHashMap<Pubkey, Vec<usize>>,
-
-    // aggregates unconstrained on each axis, which therefore stay candidates for every
-    // message. one carrying a cuckoo belongs in account_any even when it also has an
-    // explicit account list, because match_account still probes the cuckoo after the
-    // explicit set misses.
-    account_any: Vec<usize>,
-    owner_any: Vec<usize>,
 }
 
 #[inline]
@@ -761,13 +783,434 @@ fn next_union(
     }
 }
 
-impl FilterAccounts {
+/// Linear scan over every aggregate — no lookup structure at all. Used when
+/// there are too few aggregates (`<= DIRECT_SCAN_LIMIT`) for a hashmap lookup
+/// to pay for itself, or when indexing wasn't possible/worth it.
+///
+/// ```text
+///  for aggregate in aggregates { aggregate.match_filter(account, None, None) }
+/// ```
+#[derive(Debug, Clone)]
+struct LinearScanFilter {
+    aggregates: Vec<FilterAccountAggregate>,
+}
+
+impl LinearScanFilter {
+    fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
+        self.aggregates
+            .iter()
+            .filter_map(|aggregate| aggregate.match_filter(account, None, None))
+            .collect()
+    }
+}
+
+/// Every aggregate is a candidate on both axes regardless of the incoming
+/// message: each one is unconstrained (or carries a cuckoo filter alongside
+/// an explicit list) on both the account axis and the owner axis, so there's
+/// nothing to rule out — only annotating to do.
+///
+/// ```text
+///  for every aggregate: accounts == None  (or cuckoo-paired)  AND  owners == None
+///  => account_any.len() == owner_any.len() == aggregates.len()
+///  => walk 0..aggregates.len() directly; no merge, nothing can be excluded
+/// ```
+///
+/// Still worth keeping the `accounts`/`owners` maps: an aggregate can be
+/// "unconstrained" while also carrying an explicit account/owner list
+/// alongside a cuckoo filter, so exact hits are looked up anyway and passed
+/// to `match_filter` as `Some(bool)` so it can skip re-checking its own sets.
+#[derive(Debug, Clone)]
+struct AllUnconstrainedFilter {
+    aggregates: Vec<FilterAccountAggregate>,
+    accounts: FoldHashMap<Pubkey, Vec<usize>>,
+    owners: FoldHashMap<Pubkey, Vec<usize>>,
+}
+
+impl AllUnconstrainedFilter {
+    fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
+        let account_hits = if self.accounts.is_empty() {
+            &[][..]
+        } else {
+            self.accounts
+                .get(&account.pubkey)
+                .map_or(&[][..], |v| v.as_slice())
+        };
+        let owner_hits = if self.owners.is_empty() {
+            &[][..]
+        } else {
+            self.owners
+                .get(&account.owner)
+                .map_or(&[][..], |v| v.as_slice())
+        };
+
+        let (mut account_hits_cursor, mut owner_hits_cursor) = (0usize, 0usize);
+        self.aggregates
+            .iter()
+            .enumerate()
+            .filter_map(|(index, aggregate)| {
+                let matched_account = if account_hits_cursor < account_hits.len()
+                    && account_hits[account_hits_cursor] == index
+                {
+                    account_hits_cursor += 1;
+                    true
+                } else {
+                    false
+                };
+                let matched_owner = if owner_hits_cursor < owner_hits.len()
+                    && owner_hits[owner_hits_cursor] == index
+                {
+                    owner_hits_cursor += 1;
+                    true
+                } else {
+                    false
+                };
+                aggregate.match_filter(account, Some(matched_account), Some(matched_owner))
+            })
+            .collect()
+    }
+}
+
+/// Exactly one axis is unconstrained for every aggregate (say, owner — no
+/// aggregate restricts by owner at all), so that axis can never rule
+/// anything out. Only the bounded axis (account) needs a real
+/// hits-vs-unconstrained merge walk.
+///
+/// ```text
+///  bounded axis hits:      [2, 7, 9]     aggregates with an exact pubkey/owner match
+///  bounded axis "any":     [0, 4]        aggregates unconstrained on THIS axis too
+///  next_union walks both sorted lists together, in index order:
+///                          0, 2, 4, 7, 9
+/// ```
+///
+/// `unbounded_is_owner` records which axis was dropped, so the surviving
+/// axis's match result is passed to `match_filter` as the right one of
+/// `matched_account`/`matched_owner` — the other is hardcoded `false`, which
+/// `match_filter` ignores since that axis has no constraint to check anyway.
+#[derive(Debug, Clone)]
+struct SingleAxisMergeFilter {
+    aggregates: Vec<FilterAccountAggregate>,
+    unbounded_is_owner: bool,
+    bounded_hits: FoldHashMap<Pubkey, Vec<usize>>,
+    bounded_any: Vec<usize>,
+}
+
+impl SingleAxisMergeFilter {
+    fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
+        let bounded_pubkey = if self.unbounded_is_owner {
+            &account.pubkey
+        } else {
+            &account.owner
+        };
+        let hits = if self.bounded_hits.is_empty() {
+            &[][..]
+        } else {
+            self.bounded_hits
+                .get(bounded_pubkey)
+                .map_or(&[][..], |v| v.as_slice())
+        };
+
+        if hits.is_empty() && self.bounded_any.is_empty() {
+            return FilteredUpdateFilters::new();
+        }
+
+        let (mut hits_cursor, mut any_cursor) = (0usize, 0usize);
+        let mut filters = FilteredUpdateFilters::new();
+        while let Some((index, matched)) =
+            next_union(hits, &self.bounded_any, &mut hits_cursor, &mut any_cursor)
+        {
+            let (matched_account, matched_owner) = if self.unbounded_is_owner {
+                (matched, false)
+            } else {
+                (false, matched)
+            };
+            if let Some(name) = self.aggregates[index].match_filter(
+                account,
+                Some(matched_account),
+                Some(matched_owner),
+            ) {
+                filters.push(name);
+            }
+        }
+        filters
+    }
+}
+
+/// Fully general case: neither axis is unconstrained for every aggregate —
+/// both the account axis and the owner axis can rule candidates out, so both
+/// need a hits-vs-unconstrained merge walk, advanced in lockstep. An
+/// aggregate is only checked when both cursors land on the same index.
+///
+/// ```text
+///  account_pos walks account_hits ∪ account_any:  0, 3, 5, 8, ...
+///  owner_pos   walks owner_hits   ∪ owner_any:    0, 2, 5, 9, ...
+///
+///  index 0:      both agree      -> match_filter(aggregates[0])
+///  3 vs 2:       owner is behind -> advance owner_pos only
+///  index 5:      both agree      -> match_filter(aggregates[5])
+///  8 vs 9:       account is behind -> advance account_pos only
+///  ...
+/// ```
+///
+/// Whichever cursor points at the smaller index advances alone — it can't be
+/// a candidate without the other axis agreeing on the same aggregate.
+#[derive(Debug, Clone)]
+struct DualAxisMergeFilter {
+    aggregates: Vec<FilterAccountAggregate>,
+    accounts: FoldHashMap<Pubkey, Vec<usize>>,
+    owners: FoldHashMap<Pubkey, Vec<usize>>,
+    account_any: Vec<usize>,
+    owner_any: Vec<usize>,
+}
+
+impl DualAxisMergeFilter {
+    fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
+        let account_hits = if self.accounts.is_empty() {
+            &[][..]
+        } else {
+            self.accounts
+                .get(&account.pubkey)
+                .map_or(&[][..], |v| v.as_slice())
+        };
+        let owner_hits = if self.owners.is_empty() {
+            &[][..]
+        } else {
+            self.owners
+                .get(&account.owner)
+                .map_or(&[][..], |v| v.as_slice())
+        };
+
+        if (account_hits.is_empty() && self.account_any.is_empty())
+            || (owner_hits.is_empty() && self.owner_any.is_empty())
+        {
+            return FilteredUpdateFilters::new();
+        }
+
+        let mut account_hits_cursor = 0;
+        let mut account_any_cursor = 0;
+        let mut owner_hits_cursor = 0;
+        let mut owner_any_cursor = 0;
+        let mut account_pos = next_union(
+            account_hits,
+            &self.account_any,
+            &mut account_hits_cursor,
+            &mut account_any_cursor,
+        );
+        let mut owner_pos = next_union(
+            owner_hits,
+            &self.owner_any,
+            &mut owner_hits_cursor,
+            &mut owner_any_cursor,
+        );
+
+        let mut filters = FilteredUpdateFilters::new();
+        while let (Some((account_index, matched_account)), Some((owner_index, matched_owner))) =
+            (account_pos, owner_pos)
+        {
+            if account_index < owner_index {
+                account_pos = next_union(
+                    account_hits,
+                    &self.account_any,
+                    &mut account_hits_cursor,
+                    &mut account_any_cursor,
+                );
+            } else if owner_index < account_index {
+                owner_pos = next_union(
+                    owner_hits,
+                    &self.owner_any,
+                    &mut owner_hits_cursor,
+                    &mut owner_any_cursor,
+                );
+            } else {
+                if let Some(name) = self.aggregates[account_index].match_filter(
+                    account,
+                    Some(matched_account),
+                    Some(matched_owner),
+                ) {
+                    filters.push(name);
+                }
+                account_pos = next_union(
+                    account_hits,
+                    &self.account_any,
+                    &mut account_hits_cursor,
+                    &mut account_any_cursor,
+                );
+                owner_pos = next_union(
+                    owner_hits,
+                    &self.owner_any,
+                    &mut owner_hits_cursor,
+                    &mut owner_any_cursor,
+                );
+            }
+        }
+        filters
+    }
+}
+
+/// Which matching strategy an `accounts` filter set uses, decided once at
+/// construction from the shape of the parsed aggregates (never re-derived
+/// per message). Dispatch is a plain `match` (no trait object) so each arm
+/// stays a concrete, independently readable and testable type.
+///
+/// Chosen in this order:
+///
+/// ```text
+///  aggregates.is_empty()?
+///        |
+///  yes --+-- no
+///   |          |
+/// Empty   FilterAccountsIndex::new(&aggregates)
+///                |
+///        succeeds -+- fails
+///           |            |
+///        Indexed   aggregates.len() <= DIRECT_SCAN_LIMIT?
+///                        |
+///                yes ----+---- no
+///                 |             |
+///           LinearScan   build accounts/owners maps +
+///                        account_any/owner_any lists,
+///                        then pick by axis shape below
+/// ```
+///
+/// The final pick, once the maps above are built, depends on how many
+/// aggregates are unconstrained ("don't care") on each axis:
+///
+/// Both questions below mean "unconstrained for every aggregate in this
+/// filter set" (i.e. no aggregate restricts by that axis at all):
+///
+/// ```text
+///                    OWNER: yes           OWNER: no
+///              +--------------------+--------------------+
+/// ACCOUNT: yes |  AllUnconstrained  |  SingleAxisMerge   |
+///              +--------------------+--------------------+
+/// ACCOUNT: no  |  SingleAxisMerge   |   DualAxisMerge    |
+///              +--------------------+--------------------+
+/// ```
+#[derive(Debug, Clone, Default)]
+enum FilterAccountsStrategy {
+    #[default]
+    Empty,
+    LinearScan(LinearScanFilter),
+    Indexed(Arc<FilterAccountsIndex>),
+    AllUnconstrained(AllUnconstrainedFilter),
+    SingleAxisMerge(SingleAxisMergeFilter),
+    DualAxisMerge(DualAxisMergeFilter),
+}
+
+impl FilterAccountsStrategy {
     // Below this many aggregates the two hash lookups cost more than asking each
-    // aggregate directly. Construction and get_updates MUST test the same constant: if
-    // the lists are absent the candidate walk would see two empty unions and wrongly
-    // conclude that nothing can match.
+    // aggregate directly.
     const DIRECT_SCAN_LIMIT: usize = 4;
 
+    fn build(aggregates: Vec<FilterAccountAggregate>) -> Self {
+        if aggregates.is_empty() {
+            return Self::Empty;
+        }
+
+        // bitset matching algorithm, capped at 512MB of usage. if the requested
+        // filter goes above this, it falls back to one of the non-indexed
+        // strategies below.
+        if let Some(index) = FilterAccountsIndex::new(&aggregates) {
+            return Self::Indexed(Arc::new(index));
+        }
+
+        if aggregates.len() <= Self::DIRECT_SCAN_LIMIT {
+            return Self::LinearScan(LinearScanFilter { aggregates });
+        }
+
+        // non indexed (slightly slower) algorithm, used when the index is not
+        // available or when the filter is too large to be indexed. each usize
+        // inside of the maps/lists below represents an index into `aggregates`.
+        let mut accounts: FoldHashMap<Pubkey, Vec<usize>> = FoldHashMap::default();
+        let mut owners: FoldHashMap<Pubkey, Vec<usize>> = FoldHashMap::default();
+        // aggregates unconstrained on each axis, which therefore stay candidates
+        // for every message. one carrying a cuckoo belongs in account_any even
+        // when it also has an explicit account list, because match_account
+        // still probes the cuckoo after the explicit set misses.
+        let mut account_any = Vec::new();
+        let mut owner_any = Vec::new();
+
+        for (index, aggregate) in aggregates.iter().enumerate() {
+            if let Some(accs) = &aggregate.accounts {
+                for account in accs {
+                    accounts.entry(*account).or_default().push(index);
+                }
+            }
+
+            if aggregate.accounts.is_none() || aggregate.accounts_cuckoo.is_some() {
+                account_any.push(index);
+            }
+
+            if let Some(owns) = &aggregate.owners {
+                for owner in owns {
+                    owners.entry(*owner).or_default().push(index);
+                }
+            } else {
+                owner_any.push(index);
+            }
+        }
+
+        if account_any.len() == aggregates.len() && owner_any.len() == aggregates.len() {
+            return Self::AllUnconstrained(AllUnconstrainedFilter {
+                aggregates,
+                accounts,
+                owners,
+            });
+        }
+
+        let account_unbounded = account_any.len() == aggregates.len();
+        let owner_unbounded = owner_any.len() == aggregates.len();
+        if account_unbounded != owner_unbounded {
+            let (unbounded_is_owner, bounded_hits, bounded_any) = if owner_unbounded {
+                (true, accounts, account_any)
+            } else {
+                (false, owners, owner_any)
+            };
+            return Self::SingleAxisMerge(SingleAxisMergeFilter {
+                aggregates,
+                unbounded_is_owner,
+                bounded_hits,
+                bounded_any,
+            });
+        }
+
+        Self::DualAxisMerge(DualAxisMergeFilter {
+            aggregates,
+            accounts,
+            owners,
+            account_any,
+            owner_any,
+        })
+    }
+
+    fn get_filters(&self, account: &MessageAccountInfo) -> FilteredUpdateFilters {
+        match self {
+            Self::Empty => FilteredUpdateFilters::new(),
+            Self::LinearScan(strategy) => strategy.get_filters(account),
+            Self::Indexed(index) => index.get_filters(account),
+            Self::AllUnconstrained(strategy) => strategy.get_filters(account),
+            Self::SingleAxisMerge(strategy) => strategy.get_filters(account),
+            Self::DualAxisMerge(strategy) => strategy.get_filters(account),
+        }
+    }
+
+    fn aggregates(&self) -> &[FilterAccountAggregate] {
+        match self {
+            Self::Empty => &[],
+            Self::LinearScan(strategy) => &strategy.aggregates,
+            Self::Indexed(index) => index.aggregates(),
+            Self::AllUnconstrained(strategy) => &strategy.aggregates,
+            Self::SingleAxisMerge(strategy) => &strategy.aggregates,
+            Self::DualAxisMerge(strategy) => &strategy.aggregates,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct FilterAccounts {
+    strategy: FilterAccountsStrategy,
+}
+
+impl FilterAccounts {
     fn new(
         configs: &HashMap<String, SubscribeRequestFilterAccounts>,
         limits: &FilterLimitsAccounts,
@@ -775,7 +1218,7 @@ impl FilterAccounts {
     ) -> FilterResult<Self> {
         FilterLimits::check_max(configs.len(), limits.max)?;
 
-        let mut filter_accounts_result = Self::default();
+        let mut aggregates = Vec::new();
 
         for (name, filter) in configs {
             let has_filter_criteria = !filter.account.is_empty()
@@ -820,45 +1263,16 @@ impl FilterAccounts {
                 filter_aggregate.accounts_cuckoo = Some(Arc::new(CuckooFilter::from(proto_cuckoo)));
             }
 
-            filter_accounts_result.aggregates.push(filter_aggregate);
+            aggregates.push(filter_aggregate);
         }
 
-        filter_accounts_result.index =
-            FilterAccountsIndex::new(&filter_accounts_result.aggregates).map(Arc::new);
+        Ok(Self {
+            strategy: FilterAccountsStrategy::build(aggregates),
+        })
+    }
 
-        if filter_accounts_result.index.is_none()
-            && filter_accounts_result.aggregates.len() > Self::DIRECT_SCAN_LIMIT
-        {
-            for (index, aggregate) in filter_accounts_result.aggregates.iter().enumerate() {
-                if let Some(accounts) = &aggregate.accounts {
-                    for account in accounts {
-                        filter_accounts_result
-                            .accounts
-                            .entry(*account)
-                            .or_insert_with(Vec::new)
-                            .push(index);
-                    }
-                }
-
-                if aggregate.accounts.is_none() || aggregate.accounts_cuckoo.is_some() {
-                    filter_accounts_result.account_any.push(index);
-                }
-
-                if let Some(owners) = &aggregate.owners {
-                    for owner in owners {
-                        filter_accounts_result
-                            .owners
-                            .entry(*owner)
-                            .or_insert_with(Vec::new)
-                            .push(index);
-                    }
-                } else {
-                    filter_accounts_result.owner_any.push(index);
-                }
-            }
-        }
-
-        Ok(filter_accounts_result)
+    fn aggregates(&self) -> &[FilterAccountAggregate] {
+        self.strategy.aggregates()
     }
 
     fn get_updates(
@@ -866,177 +1280,7 @@ impl FilterAccounts {
         message: &Arc<MessageAccount>,
         accounts_data_slice: &FilterAccountsDataSlice,
     ) -> FilteredUpdates {
-        if self.aggregates.is_empty() {
-            return FilteredUpdates::new();
-        }
-
-        let filters = if let Some(index) = &self.index {
-            index.get_filters(&self.aggregates, &message.account)
-        } else if self.aggregates.len() <= Self::DIRECT_SCAN_LIMIT {
-            self.aggregates
-                .iter()
-                .filter_map(|aggregate| aggregate.match_filter(&message.account, None, None))
-                .collect()
-        } else if self.account_any.len() == self.aggregates.len()
-            && self.owner_any.len() == self.aggregates.len()
-        {
-            let account_hits = if self.accounts.is_empty() {
-                &[][..]
-            } else {
-                self.accounts
-                    .get(&message.account.pubkey)
-                    .map_or(&[][..], |v| v.as_slice())
-            };
-            let owner_hits = if self.owners.is_empty() {
-                &[][..]
-            } else {
-                self.owners
-                    .get(&message.account.owner)
-                    .map_or(&[][..], |v| v.as_slice())
-            };
-
-            let (mut account_hits_cursor, mut owner_hits_cursor) = (0usize, 0usize);
-            self.aggregates
-                .iter()
-                .enumerate()
-                .filter_map(|(index, aggregate)| {
-                    let matched_account = if account_hits_cursor < account_hits.len()
-                        && account_hits[account_hits_cursor] == index
-                    {
-                        account_hits_cursor += 1;
-                        true
-                    } else {
-                        false
-                    };
-                    let matched_owner = if owner_hits_cursor < owner_hits.len()
-                        && owner_hits[owner_hits_cursor] == index
-                    {
-                        owner_hits_cursor += 1;
-                        true
-                    } else {
-                        false
-                    };
-                    aggregate.match_filter(
-                        &message.account,
-                        Some(matched_account),
-                        Some(matched_owner),
-                    )
-                })
-                .collect()
-        } else {
-            let account_hits = if self.accounts.is_empty() {
-                &[][..]
-            } else {
-                self.accounts
-                    .get(&message.account.pubkey)
-                    .map_or(&[][..], |v| v.as_slice())
-            };
-            let owner_hits = if self.owners.is_empty() {
-                &[][..]
-            } else {
-                self.owners
-                    .get(&message.account.owner)
-                    .map_or(&[][..], |v| v.as_slice())
-            };
-
-            if (account_hits.is_empty() && self.account_any.is_empty())
-                || (owner_hits.is_empty() && self.owner_any.is_empty())
-            {
-                return FilteredUpdates::new();
-            }
-
-            let account_unbounded = self.account_any.len() == self.aggregates.len();
-            let owner_unbounded = self.owner_any.len() == self.aggregates.len();
-            if account_unbounded != owner_unbounded {
-                let (hits, any, matched_is_account) = if owner_unbounded {
-                    (account_hits, self.account_any.as_slice(), true)
-                } else {
-                    (owner_hits, self.owner_any.as_slice(), false)
-                };
-                let (mut hits_cursor, mut any_cursor) = (0usize, 0usize);
-                let mut filters = FilteredUpdateFilters::new();
-                while let Some((index, matched)) =
-                    next_union(hits, any, &mut hits_cursor, &mut any_cursor)
-                {
-                    let (matched_account, matched_owner) = if matched_is_account {
-                        (matched, false)
-                    } else {
-                        (false, matched)
-                    };
-                    if let Some(name) = self.aggregates[index].match_filter(
-                        &message.account,
-                        Some(matched_account),
-                        Some(matched_owner),
-                    ) {
-                        filters.push(name);
-                    }
-                }
-                return filtered_updates_once_owned!(
-                    filters,
-                    FilteredUpdateOneof::account(Arc::clone(message), accounts_data_slice.clone()),
-                    message.created_at
-                );
-            }
-
-            let mut account_hits_cursor = 0;
-            let mut account_any_cursor = 0;
-            let mut owner_hits_cursor = 0;
-            let mut owner_any_cursor = 0;
-            let mut account = next_union(
-                account_hits,
-                &self.account_any,
-                &mut account_hits_cursor,
-                &mut account_any_cursor,
-            );
-            let mut owner = next_union(
-                owner_hits,
-                &self.owner_any,
-                &mut owner_hits_cursor,
-                &mut owner_any_cursor,
-            );
-
-            let mut filters = FilteredUpdateFilters::new();
-            while let (Some((account_index, matched_account)), Some((owner_index, matched_owner))) =
-                (account, owner)
-            {
-                if account_index < owner_index {
-                    account = next_union(
-                        account_hits,
-                        &self.account_any,
-                        &mut account_hits_cursor,
-                        &mut account_any_cursor,
-                    );
-                } else if owner_index < account_index {
-                    owner = next_union(
-                        owner_hits,
-                        &self.owner_any,
-                        &mut owner_hits_cursor,
-                        &mut owner_any_cursor,
-                    );
-                } else {
-                    if let Some(name) = self.aggregates[account_index].match_filter(
-                        &message.account,
-                        Some(matched_account),
-                        Some(matched_owner),
-                    ) {
-                        filters.push(name);
-                    }
-                    account = next_union(
-                        account_hits,
-                        &self.account_any,
-                        &mut account_hits_cursor,
-                        &mut account_any_cursor,
-                    );
-                    owner = next_union(
-                        owner_hits,
-                        &self.owner_any,
-                        &mut owner_hits_cursor,
-                        &mut owner_any_cursor,
-                    );
-                }
-            }
-            filters
-        };
+        let filters = self.strategy.get_filters(&message.account);
 
         filtered_updates_once_owned!(
             filters,
@@ -2152,7 +2396,7 @@ impl FilterAccountsDataSlice {
 #[cfg(test)]
 mod tests {
     use {
-        super::{DeshredFilter, Filter, FilterBitSet, FilterBlocksInner},
+        super::{DeshredFilter, Filter, FilterAccountsStrategy, FilterBitSet, FilterBlocksInner},
         crate::plugin::{
             convert_to,
             filter::{
@@ -3165,7 +3409,9 @@ mod tests {
         )
         .unwrap();
 
-        let index = filter.accounts.index.as_ref().unwrap();
+        let FilterAccountsStrategy::Indexed(index) = &filter.accounts.strategy else {
+            panic!("expected indexed strategy");
+        };
         let account_matches = index.accounts.get(&account).unwrap();
         let owner_matches = index.owners.get(&owner).unwrap();
         assert_eq!(
@@ -3185,7 +3431,7 @@ mod tests {
             2
         );
 
-        for (aggregate_index, aggregate) in filter.accounts.aggregates.iter().enumerate() {
+        for (aggregate_index, aggregate) in filter.accounts.aggregates().iter().enumerate() {
             assert_eq!(
                 index.account_fallback.contains(aggregate_index),
                 aggregate.accounts.is_none() || aggregate.accounts_cuckoo.is_some()
@@ -3246,7 +3492,10 @@ mod tests {
             &mut create_filter_names(),
         )
         .unwrap();
-        assert!(single_filter.accounts.index.is_none());
+        assert!(!matches!(
+            single_filter.accounts.strategy,
+            FilterAccountsStrategy::Indexed(_)
+        ));
     }
 }
 
@@ -3698,7 +3947,7 @@ mod account_filter_regression_tests {
                             .filter_map(|aggregate| aggregate.match_filter(message, None, None))
                             .collect()
                     },
-                    |index| index.get_filters(&aggregates, message),
+                    |index| index.get_filters(message),
                 );
                 assert_eq!(
                     actual, expected,
@@ -3809,7 +4058,7 @@ mod account_filter_regression_tests {
 
         let stranger = Pubkey::new_from_array([250; 32]);
         let miss = account_info(stranger, stranger, vec![0; 3], 100, false);
-        assert!(index.get_filters(&aggregates, &miss).is_empty());
+        assert!(index.get_filters(&miss).is_empty());
         assert!(linear_scan(&aggregates, &miss).is_empty());
 
         let mut mixed = aggregates.clone();
@@ -3818,7 +4067,7 @@ mod account_filter_regression_tests {
         assert!(!mixed_index.account_fallback.is_empty());
         assert!(!mixed_index.owner_fallback.is_empty());
         assert_eq!(
-            mixed_index.get_filters(&mixed, &miss).as_slice(),
+            mixed_index.get_filters(&miss).as_slice(),
             [FilterName::new("wildcard")]
         );
     }
@@ -3884,10 +4133,7 @@ mod account_filter_regression_tests {
         let owner = Pubkey::new_from_array([200; 32]);
         let hit = account_info(pool[0], owner, vec![0; 3], 100, false);
         let indexed = FilterAccountsIndex::new(&under_budget).unwrap();
-        assert_eq!(
-            indexed.get_filters(&under_budget, &hit),
-            linear_scan(&under_budget, &hit)
-        );
+        assert_eq!(indexed.get_filters(&hit), linear_scan(&under_budget, &hit));
         assert_eq!(linear_scan(&over_budget, &hit).len(), AGGREGATES);
 
         let miss = account_info(
@@ -4313,7 +4559,7 @@ mod parity_oracle {
 
                     let linear = filter
                         .accounts
-                        .aggregates
+                        .aggregates()
                         .iter()
                         .filter_map(|aggregate| aggregate.match_filter(account, None, None))
                         .collect::<FilteredUpdateFilters>();
@@ -4324,9 +4570,9 @@ mod parity_oracle {
                         where_(message_index)
                     );
 
-                    if let Some(index) = &filter.accounts.index {
+                    if let FilterAccountsStrategy::Indexed(index) = &filter.accounts.strategy {
                         assert_eq!(
-                            index.get_filters(&filter.accounts.aggregates, account),
+                            index.get_filters(account),
                             expected,
                             "{}: indexed lookup diverged from master semantics",
                             where_(message_index)

--- a/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/filter.rs
@@ -557,7 +557,15 @@ impl FilterBitSet {
     }
 
     fn insert(&mut self, index: usize) {
-        self.0[index / Self::BITS_PER_WORD] |= 1 << (index % Self::BITS_PER_WORD);
+        if let Some(word) = self.0.get_mut(index / Self::BITS_PER_WORD) {
+            *word |= 1 << (index % Self::BITS_PER_WORD);
+        } else {
+            panic!(
+                "Index {} out of bounds for FilterBitSet with {} bits",
+                index,
+                self.0.len() * Self::BITS_PER_WORD
+            );
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -629,7 +637,7 @@ struct FilterAccountsIndex {
 impl FilterAccountsIndex {
     const MAX_BITSET_BYTES: usize = 512 * 1024 * 1024;
 
-    fn new(aggregates: &[FilterAccountAggregate]) -> Option<Self> {
+    fn try_init(aggregates: &[FilterAccountAggregate]) -> Option<Self> {
         if aggregates.len() <= 1 {
             return None;
         }
@@ -1109,7 +1117,7 @@ impl FilterAccountsStrategy {
         // bitset matching algorithm, capped at 512MB of usage. if the requested
         // filter goes above this, it falls back to one of the non-indexed
         // strategies below.
-        if let Some(index) = FilterAccountsIndex::new(&aggregates) {
+        if let Some(index) = FilterAccountsIndex::try_init(&aggregates) {
             return Self::Indexed(Arc::new(index));
         }
 
@@ -3932,7 +3940,7 @@ mod account_filter_regression_tests {
                     aggregate_for_index(index, account, other_account, owner, other_owner, &cuckoo)
                 })
                 .collect::<Vec<_>>();
-            let index = FilterAccountsIndex::new(&aggregates);
+            let index = FilterAccountsIndex::try_init(&aggregates);
             assert_eq!(index.is_some(), count > 1, "filter count {count}");
 
             for (message_index, message) in messages.iter().enumerate() {
@@ -3995,7 +4003,7 @@ mod account_filter_regression_tests {
         });
         aggregates[3].accounts_cuckoo = Some(Arc::clone(&cuckoo));
 
-        assert!(FilterAccountsIndex::new(&aggregates).is_none());
+        assert!(FilterAccountsIndex::try_init(&aggregates).is_none());
 
         let owner = Pubkey::new_from_array([22; 32]);
         let data = valid_token_data();
@@ -4031,7 +4039,7 @@ mod account_filter_regression_tests {
             "explicit".to_owned(),
             &[Pubkey::new_from_array([24; 32])],
         ));
-        assert!(FilterAccountsIndex::new(&aggregates).is_some());
+        assert!(FilterAccountsIndex::try_init(&aggregates).is_some());
     }
 
     #[test]
@@ -4046,7 +4054,7 @@ mod account_filter_regression_tests {
                 aggregate
             })
             .collect::<Vec<_>>();
-        let index = FilterAccountsIndex::new(&aggregates).expect("index builds");
+        let index = FilterAccountsIndex::try_init(&aggregates).expect("index builds");
         assert!(
             index.account_fallback.is_empty(),
             "no filter is account-unconstrained, so nothing may sit in the account fallback"
@@ -4063,7 +4071,7 @@ mod account_filter_regression_tests {
 
         let mut mixed = aggregates.clone();
         mixed.push(FilterAccountAggregate::new(FilterName::new("wildcard")));
-        let mixed_index = FilterAccountsIndex::new(&mixed).expect("index builds");
+        let mixed_index = FilterAccountsIndex::try_init(&mixed).expect("index builds");
         assert!(!mixed_index.account_fallback.is_empty());
         assert!(!mixed_index.owner_fallback.is_empty());
         assert_eq!(
@@ -4103,7 +4111,7 @@ mod account_filter_regression_tests {
                 <= FilterAccountsIndex::MAX_BITSET_BYTES
         );
         assert!(
-            FilterAccountsIndex::new(&under_budget).is_some(),
+            FilterAccountsIndex::try_init(&under_budget).is_some(),
             "{per_filter_under} pubkeys per filter is under MAX_BITSET_BYTES and must still index"
         );
 
@@ -4112,7 +4120,7 @@ mod account_filter_regression_tests {
             word_bytes * (AGGREGATES * per_filter_over + 2) > FilterAccountsIndex::MAX_BITSET_BYTES
         );
         assert!(
-            FilterAccountsIndex::new(&over_budget).is_none(),
+            FilterAccountsIndex::try_init(&over_budget).is_none(),
             "{per_filter_over} pubkeys per filter exceeds MAX_BITSET_BYTES and must fall back"
         );
 
@@ -4132,7 +4140,7 @@ mod account_filter_regression_tests {
 
         let owner = Pubkey::new_from_array([200; 32]);
         let hit = account_info(pool[0], owner, vec![0; 3], 100, false);
-        let indexed = FilterAccountsIndex::new(&under_budget).unwrap();
+        let indexed = FilterAccountsIndex::try_init(&under_budget).unwrap();
         assert_eq!(indexed.get_filters(&hit), linear_scan(&under_budget, &hit));
         assert_eq!(linear_scan(&over_budget, &hit).len(), AGGREGATES);
 

--- a/yellowstone-grpc-geyser/src/plugin/filter/fixtures.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/fixtures.rs
@@ -1,0 +1,175 @@
+use {
+    crate::plugin::{
+        convert_to,
+        filter::name::FilterNames,
+        message::{
+            MessageAccount, MessageAccountInfo, MessageBlock, MessageBlockMeta, MessageEntry,
+            MessageSlot, MessageTransaction, MessageTransactionInfo, SlotStatus,
+        },
+    },
+    bytes::Bytes,
+    prost_types::Timestamp,
+    solana_hash::Hash,
+    solana_message::{legacy::Message as LegacyMessage, MessageHeader, VersionedMessage},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_transaction::versioned::VersionedTransaction,
+    std::{
+        sync::{Arc, OnceLock},
+        time::Duration,
+    },
+    yellowstone_grpc_proto::{geyser::SubscribeUpdateBlockMeta, solana::storage::confirmed_block},
+};
+
+pub const TOKEN_ACCOUNT_LEN: usize = 165;
+pub const TOKEN_ACCOUNT_STATE_OFFSET: usize = 108;
+
+pub fn filter_names() -> FilterNames {
+    FilterNames::new(64, 1024, Duration::from_secs(1))
+}
+
+pub fn deterministic_pubkeys(tag: u8, n: usize) -> Vec<Pubkey> {
+    (0..n)
+        .map(|i| {
+            let mut bytes = [0u8; 32];
+            bytes[0] = tag;
+            bytes[1..9].copy_from_slice(&(i as u64).to_le_bytes());
+            for (slot, byte) in bytes.iter_mut().enumerate().skip(9) {
+                *byte = (slot as u8).wrapping_mul(31).wrapping_add(i as u8);
+            }
+            Pubkey::new_from_array(bytes)
+        })
+        .collect()
+}
+
+pub fn token_account_data(needle: Option<(usize, &[u8])>) -> Vec<u8> {
+    let mut data = vec![0; TOKEN_ACCOUNT_LEN];
+    data[TOKEN_ACCOUNT_STATE_OFFSET] = 1;
+    if let Some((offset, bytes)) = needle {
+        data[offset..offset + bytes.len()].copy_from_slice(bytes);
+    }
+    data
+}
+
+pub fn account_info(
+    pubkey: Pubkey,
+    owner: Pubkey,
+    data: Vec<u8>,
+    lamports: u64,
+    txn_signature: Option<Signature>,
+) -> MessageAccountInfo {
+    MessageAccountInfo {
+        pubkey,
+        lamports,
+        owner,
+        executable: false,
+        rent_epoch: 0,
+        data: Bytes::from(data),
+        write_version: 7,
+        txn_signature,
+        pre_encoded: OnceLock::new(),
+    }
+}
+
+pub fn message_account(account: MessageAccountInfo) -> Arc<MessageAccount> {
+    Arc::new(MessageAccount {
+        account,
+        slot: 100,
+        is_startup: false,
+        created_at: Timestamp::default(),
+    })
+}
+
+pub fn simple_message_account(pubkey: Pubkey, owner: Pubkey) -> Arc<MessageAccount> {
+    message_account(account_info(pubkey, owner, Vec::new(), 1000, None))
+}
+
+pub fn message_slot(slot: u64, status: SlotStatus) -> MessageSlot {
+    MessageSlot {
+        slot,
+        parent: Some(slot.saturating_sub(1)),
+        status,
+        dead_error: None,
+        created_at: Timestamp::default(),
+    }
+}
+
+pub fn message_entry(slot: u64, index: usize) -> Arc<MessageEntry> {
+    Arc::new(MessageEntry {
+        slot,
+        index,
+        num_hashes: 128,
+        hash: Hash::default(),
+        executed_transaction_count: 4,
+        starting_transaction_index: 0,
+        created_at: Timestamp::default(),
+    })
+}
+
+pub fn message_block_meta(slot: u64) -> Arc<MessageBlockMeta> {
+    Arc::new(MessageBlockMeta {
+        block_meta: SubscribeUpdateBlockMeta {
+            slot,
+            blockhash: Hash::default().to_string(),
+            parent_slot: slot.saturating_sub(1),
+            parent_blockhash: Hash::default().to_string(),
+            executed_transaction_count: 0,
+            entries_count: 0,
+            ..Default::default()
+        },
+        created_at: Timestamp::default(),
+    })
+}
+
+pub fn message_block(
+    slot: u64,
+    transactions: Vec<Arc<MessageTransaction>>,
+    accounts: Vec<Arc<MessageAccount>>,
+    entries: Vec<Arc<MessageEntry>>,
+) -> Arc<MessageBlock> {
+    Arc::new(MessageBlock {
+        meta: message_block_meta(slot),
+        updated_account_count: accounts.len() as u64,
+        transactions,
+        accounts,
+        entries,
+        created_at: Timestamp::default(),
+    })
+}
+
+pub fn message_transaction(
+    signature: Signature,
+    account_keys: Vec<Pubkey>,
+    is_vote: bool,
+    meta: confirmed_block::TransactionStatusMeta,
+) -> Arc<MessageTransaction> {
+    let message = VersionedMessage::Legacy(LegacyMessage {
+        header: MessageHeader {
+            num_required_signatures: 1,
+            ..MessageHeader::default()
+        },
+        account_keys: account_keys.clone(),
+        recent_blockhash: Hash::default(),
+        instructions: Vec::new(),
+    });
+    let versioned = VersionedTransaction {
+        signatures: vec![signature],
+        message,
+    };
+
+    Arc::new(MessageTransaction {
+        transaction: MessageTransactionInfo {
+            signature,
+            is_vote,
+            transaction: convert_to::create_transaction(&versioned),
+            meta,
+            index: 1,
+            account_keys: account_keys.into_iter().collect(),
+            pre_encoded: OnceLock::new(),
+            token_owners_all: OnceLock::new(),
+            token_owners_changed: OnceLock::new(),
+        },
+        slot: 100,
+        created_at: Timestamp::default(),
+    })
+}

--- a/yellowstone-grpc-geyser/src/plugin/filter/mod.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/mod.rs
@@ -1,6 +1,8 @@
 pub mod encoder;
 #[allow(clippy::module_inception)]
 mod filter;
+#[cfg(any(test, feature = "bench"))]
+pub mod fixtures;
 pub mod limits;
 pub mod message;
 pub mod name;

--- a/yellowstone-grpc-proto/src/cuckoo/filter.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/filter.rs
@@ -231,8 +231,8 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
     ///
     /// [`MAX_KICKS`]: crate::cuckoo
     pub fn insert(&mut self, item: &T) -> Result<(), TableFullError> {
-        let fp = self.fingerprint(item);
         let h = self.hash(item);
+        let fp = Self::fingerprint_from_hash(h);
         let i1 = self.index(h);
         let i2 = i1 ^ self.index(self.hash(&fp));
 
@@ -272,8 +272,8 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
     /// [`HashSet`]: std::collections::HashSet
     /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
     pub fn contains(&self, item: &T) -> bool {
-        let fp = self.fingerprint(item);
         let h = self.hash(item);
+        let fp = Self::fingerprint_from_hash(h);
         let i1 = self.index(h);
         let i2 = i1 ^ self.index(self.hash(&fp));
 
@@ -294,8 +294,8 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
     ///
     /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
     pub fn remove(&mut self, item: &T) -> bool {
-        let fp = self.fingerprint(item);
         let h = self.hash(item);
+        let fp = Self::fingerprint_from_hash(h);
         let i1 = self.index(h);
         let i2 = i1 ^ self.index(self.hash(&fp));
 
@@ -304,9 +304,8 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
 
     /// Extracts a fingerprint from an item's hash.
     /// Returns upper 16 bits, ensuring non-zero (0 = empty slot).
-    fn fingerprint(&self, item: &T) -> Fingerprint {
-        let h = self.hash(item);
-        let fp = (h >> 32) as u16;
+    const fn fingerprint_from_hash(hash: u64) -> Fingerprint {
+        let fp = (hash >> 32) as u16;
         if fp == 0 {
             1
         } else {
@@ -389,7 +388,26 @@ impl<T> From<&CuckooFilter<T, YellowstoneHasherBuilder>> for ProtoCuckooFilter {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, rand::RngExt};
+    use {
+        super::*,
+        rand::RngExt,
+        std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    struct CountedHash {
+        value: u64,
+        hash_calls: Arc<AtomicUsize>,
+    }
+
+    impl Hash for CountedHash {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.hash_calls.fetch_add(1, Ordering::Relaxed);
+            self.value.hash(state);
+        }
+    }
 
     #[test]
     fn empty_filter_contains_nothing() {
@@ -406,6 +424,31 @@ mod tests {
         assert!(filter.insert(&"hello").is_ok());
         assert!(filter.contains(&"hello"));
         assert!(!filter.contains(&"world"));
+    }
+
+    #[test]
+    fn operations_hash_item_once() {
+        let hash_calls = Arc::new(AtomicUsize::new(0));
+        let item = CountedHash {
+            value: 42,
+            hash_calls: Arc::clone(&hash_calls),
+        };
+        let mut filter = CuckooFilter::<CountedHash>::with_capacity(100).unwrap();
+
+        filter.insert(&item).unwrap();
+        assert_eq!(hash_calls.swap(0, Ordering::Relaxed), 1);
+
+        assert!(filter.contains(&item));
+        assert_eq!(hash_calls.swap(0, Ordering::Relaxed), 1);
+
+        assert!(filter.remove(&item));
+        assert_eq!(hash_calls.swap(0, Ordering::Relaxed), 1);
+
+        assert!(!filter.contains(&item));
+        assert_eq!(hash_calls.swap(0, Ordering::Relaxed), 1);
+
+        assert!(!filter.remove(&item));
+        assert_eq!(hash_calls.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -1001,5 +1044,83 @@ mod tests {
         filter.insert(&"hello").unwrap();
         assert!(filter.contains(&"hello"));
         assert!(!filter.contains(&"world"));
+    }
+
+    #[test]
+    fn hash_reuse_preserves_golden_wire_fixture() {
+        const SEED: u64 = 0x0123_4567_89ab_cdef;
+        const CAPACITY: usize = 32;
+        const KEY_COUNT: u8 = 47;
+        const ALTERNATE_PLACEMENT_KEY: u8 = 31;
+        const RELOCATION_KEY: u8 = 46;
+        const GOLDEN_DATA: [u8; 128] = [
+            98, 225, 76, 119, 190, 148, 14, 101, 11, 41, 217, 3, 119, 174, 0, 0, 66, 89, 195, 68,
+            95, 234, 230, 233, 20, 49, 10, 177, 0, 0, 0, 0, 219, 56, 38, 161, 53, 30, 11, 123, 215,
+            189, 20, 44, 123, 34, 176, 131, 12, 189, 134, 227, 205, 228, 142, 117, 68, 108, 97,
+            147, 203, 29, 222, 218, 104, 255, 204, 10, 145, 239, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41,
+            254, 16, 199, 37, 77, 0, 0, 170, 17, 23, 225, 34, 7, 180, 119, 125, 61, 0, 0, 0, 0, 0,
+            0, 199, 228, 152, 62, 183, 114, 0, 0, 209, 244, 248, 9, 104, 65, 230, 66, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ];
+
+        let builder = YellowstoneHasherBuilder::new(SEED);
+        let mut filter = CuckooFilter::<[u8; 32]>::with_capacity_and_hasher(
+            CAPACITY,
+            YellowstoneHasherBuilder::new(SEED),
+        )
+        .unwrap();
+
+        for byte in 0..KEY_COUNT {
+            let key = [byte; 32];
+            let hash = builder.hash_one(key);
+            let fp = fingerprint_for_test(hash);
+            let mask = filter.buckets.len() - 1;
+            let i1 = filter.index(hash);
+            let i2 = i1 ^ (builder.hash_one(fp) as usize & mask);
+            let primary_full = filter.buckets[i1].iter().all(|slot| *slot != 0);
+            let alternate_full = filter.buckets[i2].iter().all(|slot| *slot != 0);
+
+            if byte == ALTERNATE_PLACEMENT_KEY {
+                assert_ne!(i1, i2);
+                assert!(primary_full);
+                assert!(!alternate_full);
+            }
+            if byte == RELOCATION_KEY {
+                assert_ne!(i1, i2);
+                assert!(primary_full);
+                assert!(alternate_full);
+            }
+
+            filter.insert(&key).unwrap();
+
+            if byte == ALTERNATE_PLACEMENT_KEY {
+                assert!(filter.buckets[i2].contains(&fp));
+            }
+        }
+
+        let proto = ProtoCuckooFilter::from(&filter);
+        let golden_proto = ProtoCuckooFilter {
+            data: GOLDEN_DATA.to_vec(),
+            bucket_count: 16,
+            entries_per_bucket: 4,
+            fingerprint_bits: 16,
+            hash_seed: SEED,
+            hash_algorithm: CuckooHashAlgorithm::SipHash as i32,
+        };
+        assert_eq!(proto, golden_proto);
+
+        // This literal models a filter serialized by the pre-optimization
+        // implementation, so reconstruction also covers old producer -> new
+        // consumer compatibility.
+        let mut restored = CuckooFilter::<[u8; 32]>::from(&golden_proto);
+        for byte in 0..KEY_COUNT {
+            assert!(restored.contains(&[byte; 32]), "missing key {byte}");
+        }
+        assert!(!restored.contains(&[u8::MAX; 32]));
+        assert!(restored.remove(&[RELOCATION_KEY; 32]));
+        assert!(!restored.contains(&[RELOCATION_KEY; 32]));
+        for byte in 0..RELOCATION_KEY {
+            assert!(restored.contains(&[byte; 32]), "remove damaged key {byte}");
+        }
     }
 }


### PR DESCRIPTION
Introduced performance increases on account filtering, tested thoroughly for both compatibility and performance across hundreds of different variations of account filter types.

In the end, benched performance improvement is anywhere between 1.5x to 723x (large amount of filters are negated almost entirely).