### PR TITLE
removed useless code

### DIFF
--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -17,12 +17,12 @@ use {
         path::PathBuf,
         str::FromStr,
         sync::Arc,
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+        time::{Duration, SystemTime, UNIX_EPOCH},
     },
     tokio::{fs, sync::Mutex},
     tonic::transport::{channel::ClientTlsConfig, Certificate},
     yellowstone_grpc_client::{GeyserGrpcBuilder, GeyserGrpcClient},
-    yellowstone_grpc_geyser::plugin::{convert_from, filter::message::FilteredUpdate},
+    yellowstone_grpc_geyser::plugin::convert_from,
     yellowstone_grpc_proto::{
         geyser::SlotStatus,
         prelude::{
@@ -405,10 +405,6 @@ struct ActionSubscribe {
     /// Show total stat instead of messages
     #[clap(long, default_value_t = false)]
     stats: bool,
-
-    /// Verify manually implemented encoding against prost
-    #[clap(long, default_value_t = false)]
-    verify_encoding: bool,
 }
 
 /// Subscribe on deshred transactions (pre-execution)
@@ -447,7 +443,7 @@ impl Action {
     async fn get_subscribe_request(
         &self,
         commitment: Option<CommitmentLevel>,
-    ) -> anyhow::Result<Option<(SubscribeRequest, usize, bool, bool)>> {
+    ) -> anyhow::Result<Option<(SubscribeRequest, usize, bool)>> {
         Ok(match self {
             Self::Subscribe(args) => {
                 let mut accounts: AccountFilterMap = HashMap::new();
@@ -630,7 +626,6 @@ impl Action {
                     },
                     args.resub.unwrap_or(0),
                     args.stats,
-                    args.verify_encoding,
                 ))
             }
             _ => None,
@@ -691,12 +686,12 @@ async fn run_action(
             .map(|response| info!("response: {response:?}")),
         Action::HealthWatch => geyser_health_watch(client).await,
         Action::Subscribe(_) => {
-            let (request, resub, stats, verify_encoding) = action
+            let (request, resub, stats) = action
                 .get_subscribe_request(commitment)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("expect subscribe action"))?;
 
-            geyser_subscribe(client, request, resub, stats, verify_encoding).await
+            geyser_subscribe(client, request, resub, stats).await
         }
         Action::SubscribeDeshred(_) => {
             let (request, stats) = action
@@ -817,7 +812,6 @@ async fn geyser_subscribe(
     request: SubscribeRequest,
     resub: usize,
     stats: bool,
-    verify_encoding: bool,
 ) -> anyhow::Result<()> {
     let pb_multi = MultiProgress::new();
     let mut pb_accounts_c = 0;
@@ -838,8 +832,6 @@ async fn geyser_subscribe(
     let pb_pp = crate_progress_bar(&pb_multi, ProgressBarTpl::Msg("ping/pong"))?;
     let mut pb_total_c = 0;
     let pb_total = crate_progress_bar(&pb_multi, ProgressBarTpl::Total)?;
-    let mut pb_verify_c = verify_encoding.then_some((0, 0));
-    let pb_verify = crate_progress_bar(&pb_multi, ProgressBarTpl::Verify)?;
 
     let (mut subscribe_tx, mut stream) = client.subscribe_with_request(Some(request)).await?;
 
@@ -871,50 +863,6 @@ async fn geyser_subscribe(
                     pb_total_c += 1;
                     pb_total.set_message(format_thousands(pb_total_c));
                     pb_total.inc(encoded_len);
-
-                    if let Some((prost_c, ref_c)) = &mut pb_verify_c {
-                        let encoded_len_prost0 = msg.encoded_len();
-                        let encoded_prost0 = msg.encode_to_vec();
-
-                        let update = FilteredUpdate::from_subscribe_update(msg)
-                            .map_err(|error| anyhow::anyhow!(error))
-                            .context("failed to convert update message to filtered update")?;
-
-                        let ts = Instant::now();
-                        let msg2 = update.as_subscribe_update();
-                        let encoded_len_prost = msg2.encoded_len();
-                        let encoded_prost = msg2.encode_to_vec();
-                        *prost_c += ts.elapsed().as_nanos();
-
-                        let ts = Instant::now();
-                        let encoded_len_ref = update.encoded_len();
-                        let encoded_ref = update.encode_to_vec();
-                        *ref_c += ts.elapsed().as_nanos();
-
-                        pb_verify.set_message(format!(
-                            "{:.2?}%",
-                            100f64 * (*ref_c as f64) / (*prost_c as f64)
-                        ));
-
-                        if encoded_len_prost0 != encoded_len_prost
-                            || encoded_len_prost != encoded_len_ref
-                            || encoded_prost0 != encoded_prost
-                            || encoded_prost != encoded_ref
-                        {
-                            let dir = "grpc-client-verify";
-                            let name = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-                            let path = format!("{dir}/{name}");
-                            pb_multi
-                                .println(format!("found unmached message, save to `{path}`"))?;
-                            fs::create_dir_all(dir)
-                                .await
-                                .context("failed to create dir for unmached")?;
-                            fs::write(path, encoded_prost)
-                                .await
-                                .context("failed to save unmached")?;
-                        }
-                    }
-
                     continue;
                 }
 
@@ -1196,7 +1144,6 @@ async fn geyser_subscribe_deshred(
 enum ProgressBarTpl {
     Msg(&'static str),
     Total,
-    Verify,
 }
 
 fn crate_progress_bar(
@@ -1210,9 +1157,6 @@ fn crate_progress_bar(
         }
         ProgressBarTpl::Total => {
             "{spinner} total: {msg} / ~{bytes} (~{bytes_per_sec}) in {elapsed_precise}".to_owned()
-        }
-        ProgressBarTpl::Verify => {
-            "{spinner} verify: {msg} (elapsed time, compare to prost)".to_owned()
         }
     };
     pb.set_style(ProgressStyle::with_template(&tpl)?);

--- a/yellowstone-grpc-geyser/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/filter/message.rs
@@ -8,9 +8,9 @@ use {
                 FilterAccountsDataSlice,
             },
             message::{
-                MessageAccount, MessageAccountInfo, MessageBlock, MessageBlockMeta,
-                MessageDeshredTransaction, MessageDeshredTransactionInfo, MessageEntry,
-                MessageSlot, MessageTransaction, MessageTransactionInfo,
+                MessageAccount, MessageAccountInfo, MessageBlockMeta, MessageDeshredTransaction,
+                MessageDeshredTransactionInfo, MessageEntry, MessageSlot, MessageTransaction,
+                MessageTransactionInfo,
             },
         },
     },
@@ -18,7 +18,6 @@ use {
         buf::{Buf, BufMut},
         Bytes,
     },
-    foldhash::{HashSet as FoldHashSet, HashSetExt},
     prost::{
         encoding::{
             encode_key, encode_varint, encoded_len_varint, key_len, message, DecodeContext,
@@ -32,18 +31,15 @@ use {
     solana_signature::Signature,
     std::{
         ops::{Deref, DerefMut},
-        sync::{Arc, OnceLock},
+        sync::Arc,
         time::SystemTime,
     },
-    yellowstone_grpc_proto::{
-        geyser::{
-            subscribe_update::UpdateOneof, SlotStatus as SlotStatusProto, SubscribeUpdate,
-            SubscribeUpdateAccount, SubscribeUpdateAccountInfo, SubscribeUpdateBlock,
-            SubscribeUpdateEntry, SubscribeUpdatePing, SubscribeUpdatePong, SubscribeUpdateSlot,
-            SubscribeUpdateTransaction, SubscribeUpdateTransactionInfo,
-            SubscribeUpdateTransactionStatus,
-        },
-        solana::storage::confirmed_block,
+    yellowstone_grpc_proto::geyser::{
+        subscribe_update::UpdateOneof, SlotStatus as SlotStatusProto, SubscribeUpdate,
+        SubscribeUpdateAccount, SubscribeUpdateAccountInfo, SubscribeUpdateBlock,
+        SubscribeUpdateEntry, SubscribeUpdatePing, SubscribeUpdatePong, SubscribeUpdateSlot,
+        SubscribeUpdateTransaction, SubscribeUpdateTransactionInfo,
+        SubscribeUpdateTransactionStatus,
     },
 };
 
@@ -257,81 +253,6 @@ impl FilteredUpdate {
             update_oneof: Some(message),
             created_at: Some(self.created_at),
         }
-    }
-
-    pub fn from_subscribe_update(update: SubscribeUpdate) -> Result<Self, &'static str> {
-        let created_at = update.created_at.ok_or("create_at should be defined")?;
-
-        let message = match update.update_oneof.ok_or("update should be defined")? {
-            UpdateOneof::Account(msg) => {
-                let account = MessageAccount::from_update_oneof(msg, created_at)?;
-                FilteredUpdateOneof::Account(FilteredUpdateAccount {
-                    account: Arc::new(account),
-                    data_slice: FilterAccountsDataSlice::default(),
-                })
-            }
-            UpdateOneof::Slot(msg) => {
-                let slot = MessageSlot::from_update_oneof(&msg, created_at)?;
-                FilteredUpdateOneof::Slot(FilteredUpdateSlot(slot))
-            }
-            UpdateOneof::Transaction(msg) => {
-                let tx = MessageTransaction::from_update_oneof(msg, created_at)?;
-                FilteredUpdateOneof::Transaction(FilteredUpdateTransaction {
-                    slot: tx.slot,
-                    transaction: Arc::new(tx),
-                })
-            }
-            UpdateOneof::TransactionStatus(msg) => {
-                FilteredUpdateOneof::TransactionStatus(FilteredUpdateTransactionStatus {
-                    transaction: Arc::new(MessageTransaction {
-                        transaction: MessageTransactionInfo {
-                            signature: Signature::try_from(msg.signature.as_slice())
-                                .map_err(|_| "invalid signature length")?,
-                            is_vote: msg.is_vote,
-                            transaction: confirmed_block::Transaction::default(),
-                            meta: confirmed_block::TransactionStatusMeta {
-                                err: msg.err,
-                                ..confirmed_block::TransactionStatusMeta::default()
-                            },
-                            index: msg.index as usize,
-                            account_keys: FoldHashSet::new(),
-                            pre_encoded: OnceLock::new(),
-                            token_owners_all: OnceLock::new(),
-                            token_owners_changed: OnceLock::new(),
-                        },
-                        created_at,
-                        slot: msg.slot,
-                    }),
-                })
-            }
-            UpdateOneof::Block(msg) => {
-                let block = MessageBlock::from_update_oneof(msg, created_at)?;
-                FilteredUpdateOneof::Block(Box::new(FilteredUpdateBlock {
-                    meta: block.meta,
-                    transactions: block.transactions,
-                    updated_account_count: block.updated_account_count,
-                    accounts: block.accounts,
-                    accounts_data_slice: FilterAccountsDataSlice::default(),
-                    entries: block.entries,
-                }))
-            }
-            UpdateOneof::Ping(_) => FilteredUpdateOneof::Ping,
-            UpdateOneof::Pong(msg) => FilteredUpdateOneof::Pong(msg),
-            UpdateOneof::BlockMeta(msg) => {
-                let block_meta = MessageBlockMeta::from_update_oneof(msg, created_at);
-                FilteredUpdateOneof::BlockMeta(Arc::new(block_meta))
-            }
-            UpdateOneof::Entry(msg) => {
-                let entry = MessageEntry::from_update_oneof(&msg, created_at)?;
-                FilteredUpdateOneof::Entry(FilteredUpdateEntry(Arc::new(entry)))
-            }
-        };
-
-        Ok(Self {
-            filters: update.filters.into_iter().map(FilterName::new).collect(),
-            message,
-            created_at,
-        })
     }
 }
 
@@ -1583,11 +1504,6 @@ pub mod tests {
         assert_eq!(
             SubscribeUpdate::decode(msg.encode_to_vec().as_slice()).expect("failed to decode"),
             update
-        );
-        assert_eq!(
-            FilteredUpdate::from_subscribe_update(update.clone())
-                .map(|msg| msg.as_subscribe_update()),
-            Ok(update)
         );
     }
 

--- a/yellowstone-grpc-geyser/src/plugin/message.rs
+++ b/yellowstone-grpc-geyser/src/plugin/message.rs
@@ -19,10 +19,8 @@ use {
     },
     yellowstone_grpc_proto::{
         geyser::{
-            subscribe_update::UpdateOneof, CommitmentLevel as CommitmentLevelProto,
-            SlotStatus as SlotStatusProto, SubscribeUpdateAccount, SubscribeUpdateAccountInfo,
-            SubscribeUpdateBlock, SubscribeUpdateBlockMeta, SubscribeUpdateEntry,
-            SubscribeUpdateSlot, SubscribeUpdateTransaction, SubscribeUpdateTransactionInfo,
+            CommitmentLevel as CommitmentLevelProto, SlotStatus as SlotStatusProto,
+            SubscribeUpdateBlockMeta,
         },
         solana::storage::confirmed_block,
     },
@@ -168,21 +166,6 @@ impl MessageSlot {
             created_at: Timestamp::from(SystemTime::now()),
         }
     }
-
-    pub fn from_update_oneof(
-        msg: &SubscribeUpdateSlot,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            slot: msg.slot,
-            parent: msg.parent,
-            status: SlotStatusProto::try_from(msg.status)
-                .map_err(|_| "failed to parse slot status")?
-                .into(),
-            dead_error: msg.dead_error.clone(),
-            created_at,
-        })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -215,25 +198,6 @@ impl MessageAccountInfo {
         }
     }
 
-    pub fn from_update_oneof(msg: SubscribeUpdateAccountInfo) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            pubkey: Pubkey::try_from(msg.pubkey.as_slice()).map_err(|_| "invalid pubkey length")?,
-            lamports: msg.lamports,
-            owner: Pubkey::try_from(msg.owner.as_slice()).map_err(|_| "invalid owner length")?,
-            executable: msg.executable,
-            rent_epoch: msg.rent_epoch,
-            data: msg.data,
-            write_version: msg.write_version,
-            txn_signature: msg
-                .txn_signature
-                .map(|sig| {
-                    Signature::try_from(sig.as_slice()).map_err(|_| "invalid signature length")
-                })
-                .transpose()?,
-            pre_encoded: OnceLock::new(),
-        })
-    }
-
     pub fn get_pre_encoded(&self) -> Option<&Vec<u8>> {
         self.pre_encoded.get()
     }
@@ -255,34 +219,6 @@ impl MessageAccount {
             is_startup,
             created_at: Timestamp::from(SystemTime::now()),
         }
-    }
-
-    pub fn from_update_oneof(
-        msg: SubscribeUpdateAccount,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            account: MessageAccountInfo::from_update_oneof(
-                msg.account.ok_or("account message should be defined")?,
-            )?,
-            slot: msg.slot,
-            is_startup: msg.is_startup,
-            created_at,
-        })
-    }
-
-    pub fn from_update_oneof_block(
-        msg: SubscribeUpdateAccountInfo,
-        slot: u64,
-        is_startup: bool,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            account: MessageAccountInfo::from_update_oneof(msg)?,
-            slot,
-            is_startup,
-            created_at,
-        })
     }
 }
 
@@ -339,23 +275,6 @@ impl MessageTransactionInfo {
         }
     }
 
-    pub fn from_update_oneof(msg: SubscribeUpdateTransactionInfo) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            signature: Signature::try_from(msg.signature.as_slice())
-                .map_err(|_| "invalid signature length")?,
-            is_vote: msg.is_vote,
-            transaction: msg
-                .transaction
-                .ok_or("transaction message should be defined")?,
-            meta: msg.meta.ok_or("meta message should be defined")?,
-            index: msg.index as usize,
-            account_keys: FoldHashSet::new(),
-            pre_encoded: OnceLock::new(),
-            token_owners_all: OnceLock::new(),
-            token_owners_changed: OnceLock::new(),
-        })
-    }
-
     pub fn fill_account_keys(&mut self) -> FromUpdateOneofResult<()> {
         let mut account_keys = FoldHashSet::new();
 
@@ -407,32 +326,6 @@ impl MessageTransaction {
             slot,
             created_at: Timestamp::from(SystemTime::now()),
         }
-    }
-
-    pub fn from_update_oneof(
-        msg: SubscribeUpdateTransaction,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            transaction: MessageTransactionInfo::from_update_oneof(
-                msg.transaction
-                    .ok_or("transaction message should be defined")?,
-            )?,
-            slot: msg.slot,
-            created_at,
-        })
-    }
-
-    pub fn from_update_oneof_block(
-        msg: SubscribeUpdateTransactionInfo,
-        slot: u64,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            transaction: MessageTransactionInfo::from_update_oneof(msg)?,
-            slot,
-            created_at,
-        })
     }
 }
 
@@ -565,24 +458,6 @@ impl MessageEntry {
             created_at: Timestamp::from(SystemTime::now()),
         }
     }
-
-    pub fn from_update_oneof(
-        msg: &SubscribeUpdateEntry,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            slot: msg.slot,
-            index: msg.index as usize,
-            num_hashes: msg.num_hashes,
-            hash: Hash::new_from_array(
-                <[u8; HASH_BYTES]>::try_from(msg.hash.as_slice())
-                    .map_err(|_| "invalid hash length")?,
-            ),
-            executed_transaction_count: msg.executed_transaction_count,
-            starting_transaction_index: msg.starting_transaction_index,
-            created_at,
-        })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -663,51 +538,6 @@ impl MessageBlock {
             created_at: Timestamp::from(SystemTime::now()),
         }
     }
-
-    pub fn from_update_oneof(
-        msg: SubscribeUpdateBlock,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(Self {
-            meta: Arc::new(MessageBlockMeta {
-                block_meta: SubscribeUpdateBlockMeta {
-                    slot: msg.slot,
-                    blockhash: msg.blockhash,
-                    rewards: msg.rewards,
-                    block_time: msg.block_time,
-                    block_height: msg.block_height,
-                    parent_slot: msg.parent_slot,
-                    parent_blockhash: msg.parent_blockhash,
-                    executed_transaction_count: msg.executed_transaction_count,
-                    entries_count: msg.entries_count,
-                },
-                created_at,
-            }),
-            transactions: msg
-                .transactions
-                .into_iter()
-                .map(|tx| {
-                    MessageTransaction::from_update_oneof_block(tx, msg.slot, created_at)
-                        .map(Arc::new)
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-            updated_account_count: msg.updated_account_count,
-            accounts: msg
-                .accounts
-                .into_iter()
-                .map(|account| {
-                    MessageAccount::from_update_oneof_block(account, msg.slot, false, created_at)
-                        .map(Arc::new)
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-            entries: msg
-                .entries
-                .iter()
-                .map(|entry| MessageEntry::from_update_oneof(entry, created_at).map(Arc::new))
-                .collect::<Result<Vec<_>, _>>()?,
-            created_at,
-        })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -733,36 +563,5 @@ impl Message {
             Self::BlockMeta(msg) => msg.slot,
             Self::Block(msg) => msg.meta.slot,
         }
-    }
-
-    pub fn from_update_oneof(
-        oneof: UpdateOneof,
-        created_at: Timestamp,
-    ) -> FromUpdateOneofResult<Self> {
-        Ok(match oneof {
-            UpdateOneof::Account(msg) => Self::Account(Arc::new(
-                MessageAccount::from_update_oneof(msg, created_at)?,
-            )),
-            UpdateOneof::Slot(msg) => {
-                Self::Slot(Arc::new(MessageSlot::from_update_oneof(&msg, created_at)?))
-            }
-            UpdateOneof::Transaction(msg) => Self::Transaction(Arc::new(
-                MessageTransaction::from_update_oneof(msg, created_at)?,
-            )),
-            UpdateOneof::TransactionStatus(_) => {
-                return Err("TransactionStatus message is not supported")
-            }
-            UpdateOneof::Block(msg) => {
-                Self::Block(Arc::new(MessageBlock::from_update_oneof(msg, created_at)?))
-            }
-            UpdateOneof::Ping(_) => return Err("Ping message is not supported"),
-            UpdateOneof::Pong(_) => return Err("Pong message is not supported"),
-            UpdateOneof::BlockMeta(msg) => Self::BlockMeta(Arc::new(
-                MessageBlockMeta::from_update_oneof(msg, created_at),
-            )),
-            UpdateOneof::Entry(msg) => {
-                Self::Entry(Arc::new(MessageEntry::from_update_oneof(&msg, created_at)?))
-            }
-        })
     }
 }


### PR DESCRIPTION
I removed the following

`FilteredUpdate::from_subscribe_update` which was created 20 months ago by one software developer to test new ways of encoding/decoding protobuf message. The only usage was in the example rust client.

This created a tight coupling between example client <--> internal geyser message.
The internal geyser `Message` should stay private.

Since this "verify" encoding feature is never actually used by the team and created mostly for testing purposes we should not carry this technical debt any longer.

Because of the leaky coupling that is happening, trying to transition to v4.3.0 creates funky situation where we need to add a new field in `Message` taht only makes sense in geyser plugin internal but not at the client level.
