### PR TITLE
nodejs: bound the subscribe worker→JS channel so slow consumers backpressure the server

### DIFF
--- a/yellowstone-grpc-client-nodejs/napi/index.d.ts
+++ b/yellowstone-grpc-client-nodejs/napi/index.d.ts
@@ -124,6 +124,18 @@ export interface JsChannelOptions {
   grpcMaxDecodingMessageSize?: number
   grpcMaxEncodingMessageSize?: number
   grpcDefaultCompressionAlgorithm?: JsCompressionAlgorithm
+  /**
+   * Capacity, in updates, of the per-subscription worker -> JS channel.
+   *
+   * Bounded so that a JS consumer slower than the stream backpressures the
+   * server: once the channel is full the worker stops polling the gRPC
+   * stream, tonic stops reading the socket and the h2 receive window
+   * closes. An unbounded channel instead accumulates the surplus in native
+   * memory, invisible to the V8 heap, until the process is killed.
+   *
+   * `0` selects an effectively unbounded capacity (the previous behavior).
+   */
+  grpcSubscribeReadableChannelCapacity?: number
   grpcSetXRequestSnapshot?: boolean
   grpcHttp2AdaptiveWindow?: boolean
   grpcKeepAliveWhileIdle?: boolean

--- a/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/bindings.rs
@@ -38,6 +38,16 @@ pub struct JsChannelOptions {
   pub grpc_max_decoding_message_size: Option<u32>,
   pub grpc_max_encoding_message_size: Option<u32>,
   pub grpc_default_compression_algorithm: Option<JsCompressionAlgorithm>,
+  /// Capacity, in updates, of the per-subscription worker -> JS channel.
+  ///
+  /// Bounded so that a JS consumer slower than the stream backpressures the
+  /// server: once the channel is full the worker stops polling the gRPC
+  /// stream, tonic stops reading the socket and the h2 receive window
+  /// closes. An unbounded channel instead accumulates the surplus in native
+  /// memory, invisible to the V8 heap, until the process is killed.
+  ///
+  /// `0` selects an effectively unbounded capacity (the previous behavior).
+  pub grpc_subscribe_readable_channel_capacity: Option<u32>,
   //--------------------
   // Flags.
   //--------------------
@@ -86,6 +96,7 @@ impl Default for JsChannelOptions {
   ///   grpc_initial_stream_window_size: Some(4 * 1024 * 1024),     // 4MB
   ///   grpc_max_decoding_message_size: Some(1 * 1024 * 1024 * 1024), // 1GB
   ///   grpc_max_encoding_message_size: Some(32 * 1024 * 1024),     // 32MB
+  ///   grpc_subscribe_readable_channel_capacity: Some(1024),        // updates
   ///   grpc_http2_adaptive_window: Some(true),
   ///   grpc_tcp_nodelay: Some(true),
   ///   grpc_keep_alive_while_idle: None,
@@ -105,6 +116,7 @@ impl Default for JsChannelOptions {
       grpc_initial_stream_window_size: Some(4 * 1024 * 1024),     // 4MB
       grpc_max_decoding_message_size: Some(1024 * 1024 * 1024),   // 1GB
       grpc_max_encoding_message_size: Some(32 * 1024 * 1024),     // 32MB
+      grpc_subscribe_readable_channel_capacity: Some(1024),       // updates
       grpc_http2_adaptive_window: Some(true),
       grpc_tcp_nodelay: Some(true),
       grpc_keep_alive_while_idle: None,

--- a/yellowstone-grpc-client-nodejs/napi/src/client.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/client.rs
@@ -46,6 +46,30 @@ where
   })
 }
 
+/// Resolves `grpc_subscribe_readable_channel_capacity` following the same
+/// convention as the other channel options: the `JsChannelOptions::default()`
+/// value applies unless the caller set the field explicitly. An explicit `0`
+/// selects a capacity so large it is unbounded in practice, restoring the
+/// previous behavior without a separate flag.
+fn resolve_subscribe_readable_channel_capacity(
+  channel_options: Option<&JsChannelOptions>,
+) -> usize {
+  /// One update is tens of KB, so this is tens of GB of buffering: never
+  /// reachable in practice, which is what makes it a faithful stand-in for
+  /// "unbounded" while keeping the channel type uniform.
+  const EFFECTIVELY_UNBOUNDED: usize = 1 << 20;
+
+  let capacity = channel_options
+    .and_then(|options| options.grpc_subscribe_readable_channel_capacity)
+    .or(JsChannelOptions::default().grpc_subscribe_readable_channel_capacity)
+    .unwrap_or(1024);
+  if capacity == 0 {
+    EFFECTIVELY_UNBOUNDED
+  } else {
+    capacity as usize
+  }
+}
+
 /// Main client struct exposed to JavaScript via NAPI.
 ///
 /// The client maintains a persistent gRPC connection that is created once
@@ -53,6 +77,9 @@ where
 #[napi]
 pub struct GrpcClient {
   pub(crate) client: GeyserGrpcClient,
+  /// Resolved `grpc_subscribe_readable_channel_capacity`; consumed by
+  /// `DuplexStream::subscribe` / `DuplexStreamDeshred::subscribe`.
+  pub(crate) subscribe_readable_channel_capacity: usize,
 }
 
 #[napi]
@@ -75,6 +102,9 @@ impl GrpcClient {
   ) -> napi::Result<Self> {
     init_crypto_provider();
 
+    let subscribe_readable_channel_capacity =
+      resolve_subscribe_readable_channel_capacity(channel_options.as_ref());
+
     // Build the client with the provided configuration
     let builder =
       utils::get_client_builder(endpoint, x_token, channel_options, reconnect_config).await?;
@@ -88,7 +118,10 @@ impl GrpcClient {
       )
     })?;
 
-    Ok(Self { client })
+    Ok(Self {
+      client,
+      subscribe_readable_channel_capacity,
+    })
   }
 
   #[napi]
@@ -325,5 +358,50 @@ impl GrpcClient {
     env: &'env napi::Env,
   ) -> napi::Result<PromiseRaw<'env, crate::DuplexStreamDeshred>> {
     crate::DuplexStreamDeshred::subscribe(env, self)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::resolve_subscribe_readable_channel_capacity;
+  use crate::bindings::JsChannelOptions;
+
+  fn options_with_capacity(capacity: Option<u32>) -> JsChannelOptions {
+    JsChannelOptions {
+      grpc_subscribe_readable_channel_capacity: capacity,
+      ..JsChannelOptions::default()
+    }
+  }
+
+  #[test]
+  fn capacity_defaults_when_options_are_omitted() {
+    assert_eq!(resolve_subscribe_readable_channel_capacity(None), 1024);
+  }
+
+  #[test]
+  fn capacity_defaults_when_field_is_unset() {
+    let options = options_with_capacity(None);
+    assert_eq!(
+      resolve_subscribe_readable_channel_capacity(Some(&options)),
+      1024
+    );
+  }
+
+  #[test]
+  fn capacity_honours_an_explicit_value() {
+    let options = options_with_capacity(Some(64));
+    assert_eq!(
+      resolve_subscribe_readable_channel_capacity(Some(&options)),
+      64
+    );
+  }
+
+  #[test]
+  fn capacity_zero_is_effectively_unbounded() {
+    let options = options_with_capacity(Some(0));
+    assert_eq!(
+      resolve_subscribe_readable_channel_capacity(Some(&options)),
+      1 << 20
+    );
   }
 }

--- a/yellowstone-grpc-client-nodejs/napi/src/lib.rs
+++ b/yellowstone-grpc-client-nodejs/napi/src/lib.rs
@@ -25,7 +25,7 @@ use std::sync::{
   Arc, Mutex as StdMutex, Once,
 };
 use tokio::sync::{
-  mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+  mpsc::{channel, unbounded_channel, Receiver, UnboundedSender},
   Mutex,
 };
 use yellowstone_grpc_proto::prelude::*;
@@ -111,7 +111,7 @@ fn strip_autoreconnect_filter(update: &mut SubscribeUpdate) -> bool {
 struct DuplexStream {
   /// Read side consumed by `read()`. Each protobuf payload is delivered exactly once.
   #[allow(dead_code)]
-  readable: Arc<Mutex<UnboundedReceiver<Vec<u8>>>>,
+  readable: Arc<Mutex<Receiver<Vec<u8>>>>,
   /// Write side used by `write_raw()`. Requests are forwarded to gRPC task.
   ///
   /// The mutex protects a close-state transition, not sender sharing:
@@ -155,6 +155,7 @@ impl DuplexStream {
       None => None,
     };
     let mut client = grpc_client.client.clone();
+    let readable_channel_capacity = grpc_client.subscribe_readable_channel_capacity;
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // reject the Promise and bubble to TypeScript callers.
@@ -174,8 +175,7 @@ impl DuplexStream {
             })?
         };
 
-        // TODO : Fine tune unbounded channels.
-        let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+        let (readable_tx, readable_rx) = channel::<Vec<u8>>(readable_channel_capacity);
         let (writable_tx, mut writable_rx) = unbounded_channel::<SubscribeRequest>();
         let writable = Arc::new(StdMutex::new(Some(writable_tx)));
         let terminal_error = Arc::new(StdMutex::new(None));
@@ -189,6 +189,13 @@ impl DuplexStream {
         // - For non-graceful failures, captures terminal error and exits.
         // - Dropping `readable_tx` on exit closes JS read channel.
         tokio::spawn(async move {
+          // Send capacity is reserved BEFORE the gRPC stream is polled, and
+          // `stream_rx` is polled only while a permit is held. That is what
+          // carries backpressure to the server: holding no permit leaves the
+          // socket unread, so tonic stops draining it and h2 flow control
+          // closes the receive window. Writes are serviced in either state,
+          // so a subscription update is never starved while backpressured.
+          let mut permit = None;
           loop {
             tokio::select! {
               // 1. SubscribeRequest is received from self.write_raw().
@@ -218,9 +225,17 @@ impl DuplexStream {
                 }
               },
 
+              reserved = readable_tx.reserve(), if permit.is_none() => {
+                match reserved {
+                  Ok(reserved) => permit = Some(reserved),
+                  // JS reader side disappeared; no point continuing the worker.
+                  Err(_) => break,
+                }
+              },
+
               // 1. SubscribeUpdate is received from Geyser client's receiver.
               // 2. SubscribeUpdate is propagated to self.read() for NodeJS consumption.
-              maybe_update_result = stream_rx.next() => {
+              maybe_update_result = stream_rx.next(), if permit.is_some() => {
                 match maybe_update_result {
                   Some(Ok(mut update)) => {
                     let stripped = strip_autoreconnect_filter(&mut update);
@@ -228,12 +243,11 @@ impl DuplexStream {
                       continue;
                     }
 
-                    let update_bytes = update.encode_to_vec();
-
-                    // JS reader side disappeared; no point continuing the worker.
-                    if readable_tx.send(update_bytes).is_err() {
-                      break;
-                    }
+                    // Capacity is already reserved, so this neither blocks nor fails.
+                    permit
+                      .take()
+                      .expect("branch is only polled while a permit is held")
+                      .send(update.encode_to_vec());
                   }
                   Some(Err(error)) => {
                     if is_closing_worker.load(Ordering::Acquire) {
@@ -359,7 +373,7 @@ impl DuplexStream {
   }
 
   async fn recv_update_or_error(
-    readable: Arc<Mutex<UnboundedReceiver<Vec<u8>>>>,
+    readable: Arc<Mutex<Receiver<Vec<u8>>>>,
     terminal_error: Arc<StdMutex<Option<napi::Error>>>,
   ) -> Result<Option<Vec<u8>>> {
     match readable.lock().await.recv().await {
@@ -387,7 +401,7 @@ impl DuplexStream {
 #[napi]
 struct DuplexStreamDeshred {
   /// Read side consumed by `read()`. Each protobuf payload is delivered exactly once.
-  readable: Arc<Mutex<UnboundedReceiver<Vec<u8>>>>,
+  readable: Arc<Mutex<Receiver<Vec<u8>>>>,
   /// Write side used by `write_raw()`. Requests are forwarded to gRPC task.
   writable: Arc<StdMutex<Option<UnboundedSender<SubscribeDeshredRequest>>>>,
   /// Terminal worker error captured from gRPC send/recv failures.
@@ -405,6 +419,7 @@ impl DuplexStreamDeshred {
     grpc_client: &GrpcClient,
   ) -> Result<PromiseRaw<'env, Self>> {
     let mut client = grpc_client.client.clone();
+    let readable_channel_capacity = grpc_client.subscribe_readable_channel_capacity;
 
     // Open the gRPC stream before returning to JS so connection/protocol errors
     // (e.g. UNIMPLEMENTED) reject the Promise and bubble to TypeScript callers.
@@ -421,7 +436,7 @@ impl DuplexStreamDeshred {
           })?
         };
 
-        let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+        let (readable_tx, readable_rx) = channel::<Vec<u8>>(readable_channel_capacity);
         let (writable_tx, mut writable_rx) = unbounded_channel::<SubscribeDeshredRequest>();
         let writable = Arc::new(StdMutex::new(Some(writable_tx)));
         let terminal_error = Arc::new(StdMutex::new(None));
@@ -433,6 +448,8 @@ impl DuplexStreamDeshred {
         // propagate first non-graceful gRPC error through `terminal_error`,
         // then close channel so JS `read()` can map it to a rejected promise.
         tokio::spawn(async move {
+          // Permit-gated for the same reason as `DuplexStream::subscribe`.
+          let mut permit = None;
           loop {
             tokio::select! {
               req_option = writable_rx.recv() => {
@@ -456,12 +473,20 @@ impl DuplexStreamDeshred {
                   break;
                 }
               },
-              maybe_update_result = stream_rx.next() => {
+              reserved = readable_tx.reserve(), if permit.is_none() => {
+                match reserved {
+                  Ok(reserved) => permit = Some(reserved),
+                  Err(_) => break,
+                }
+              },
+
+              maybe_update_result = stream_rx.next(), if permit.is_some() => {
                 match maybe_update_result {
                   Some(Ok(update)) => {
-                    if readable_tx.send(update.encode_to_vec()).is_err() {
-                      break;
-                    }
+                    permit
+                      .take()
+                      .expect("branch is only polled while a permit is held")
+                      .send(update.encode_to_vec());
                   }
                   Some(Err(error)) => {
                     if is_closing_worker.load(Ordering::Acquire) {
@@ -580,7 +605,7 @@ impl DuplexStreamDeshred {
   }
 
   async fn recv_update_or_error(
-    readable: Arc<Mutex<UnboundedReceiver<Vec<u8>>>>,
+    readable: Arc<Mutex<Receiver<Vec<u8>>>>,
     terminal_error: Arc<StdMutex<Option<napi::Error>>>,
   ) -> Result<Option<Vec<u8>>> {
     match readable.lock().await.recv().await {
@@ -611,7 +636,13 @@ mod tests {
     atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc, Mutex as StdMutex,
   };
-  use tokio::sync::mpsc::unbounded_channel;
+  use tokio::sync::mpsc::{channel, unbounded_channel};
+
+  /// Capacity for hand-built readable channels in tests: large enough that
+  /// no fixture blocks on send. The bounded-channel semantics themselves are
+  /// exercised through `resolve_subscribe_readable_channel_capacity` and the
+  /// worker-loop tests.
+  const TEST_CHANNEL_CAPACITY: usize = 32;
   use tokio::sync::Mutex;
   use tokio::time::{timeout, Duration};
   use yellowstone_grpc_proto::geyser::{
@@ -735,7 +766,7 @@ mod tests {
     DuplexStream,
     tokio::sync::mpsc::UnboundedReceiver<SubscribeRequest>,
   ) {
-    let (_readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (_readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     let (writable_tx, writable_rx) = unbounded_channel::<SubscribeRequest>();
 
     (
@@ -753,7 +784,7 @@ mod tests {
     DuplexStreamDeshred,
     tokio::sync::mpsc::UnboundedReceiver<SubscribeDeshredRequest>,
   ) {
-    let (_readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (_readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     let (writable_tx, writable_rx) = unbounded_channel::<SubscribeDeshredRequest>();
 
     (
@@ -1181,7 +1212,7 @@ mod tests {
 
   #[tokio::test]
   async fn subscribe_read_returns_none_when_channel_closed_without_terminal_error() {
-    let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     drop(readable_tx);
     let readable = Arc::new(Mutex::new(readable_rx));
     let terminal_error = Arc::new(StdMutex::new(None));
@@ -1195,7 +1226,7 @@ mod tests {
 
   #[tokio::test]
   async fn subscribe_read_returns_terminal_error_when_channel_closed_after_worker_failure() {
-    let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     drop(readable_tx);
     let readable = Arc::new(Mutex::new(readable_rx));
     let terminal_error = Arc::new(StdMutex::new(Some(terminal_error_with_cause(
@@ -1221,7 +1252,7 @@ mod tests {
 
   #[tokio::test]
   async fn subscribe_read_returns_terminal_error_when_terminal_error_lock_is_poisoned() {
-    let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     drop(readable_tx);
     let readable = Arc::new(Mutex::new(readable_rx));
     let terminal_error = Arc::new(StdMutex::new(None));
@@ -1533,7 +1564,7 @@ mod tests {
 
   #[tokio::test]
   async fn deshred_read_returns_none_when_channel_closed_without_terminal_error() {
-    let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     drop(readable_tx);
     let readable = Arc::new(Mutex::new(readable_rx));
     let terminal_error = Arc::new(StdMutex::new(None));
@@ -1547,7 +1578,7 @@ mod tests {
 
   #[tokio::test]
   async fn deshred_read_returns_terminal_error_when_channel_closed_after_worker_failure() {
-    let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     drop(readable_tx);
     let readable = Arc::new(Mutex::new(readable_rx));
     let terminal_error = Arc::new(StdMutex::new(Some(terminal_error_with_cause(
@@ -1573,7 +1604,7 @@ mod tests {
 
   #[tokio::test]
   async fn deshred_read_returns_terminal_error_when_terminal_error_lock_is_poisoned() {
-    let (readable_tx, readable_rx) = unbounded_channel::<Vec<u8>>();
+    let (readable_tx, readable_rx) = channel::<Vec<u8>>(TEST_CHANNEL_CAPACITY);
     drop(readable_tx);
     let readable = Arc::new(Mutex::new(readable_rx));
     let terminal_error = Arc::new(StdMutex::new(None));


### PR DESCRIPTION
Closes #854 (and, we believe, explains #761).

## Problem

The NAPI subscribe worker forwards every `SubscribeUpdate` into an
`unbounded_channel::<Vec<u8>>()` (`napi/src/lib.rs`, carrying the in-tree
`// TODO : Fine tune unbounded channels.`), and polls the tonic stream
unconditionally. Two consequences:

- h2 flow control never engages: a JS consumer slower than the stream cannot
  slow the server down, no matter what it does (`pause()`, slow `read()`s —
  nothing reaches the socket).
- The surplus accumulates as native memory, invisible to the V8 heap, until
  the process is OOM-killed. This is the "native off-heap memory leak"
  symptom profile reported in #761: RSS climbs linearly while `heapUsed`
  stays flat.

We run this client in production against a Solana mainnet firehose
(pump.fun/PumpSwap-wide filters, hundreds of updates/s, multi-GB `fromSlot`
replay bursts). Whenever downstream persistence stalled for minutes, the
channel absorbed the difference: 12–18 GB RSS with ~700 MB of V8 heap,
ending in OOM kills.

## Change

- The readable channel is bounded: `mpsc::channel(capacity)` instead of
  `unbounded_channel()`, for both `DuplexStream` and `DuplexStreamDeshred`.
- The worker reserves send capacity **before** polling the gRPC stream, and
  polls `stream_rx` only while a permit is held. Holding no permit leaves
  the socket unread, so tonic stops draining it and the h2 receive window
  closes — the server is throttled at the source. `writable_rx` stays in the
  same `select!`, so subscription updates written from JS are serviced even
  while fully backpressured.
- Capacity is a new channel option, `grpcSubscribeReadableChannelCapacity`
  (default **1024** updates; an explicit **0** restores the previous
  unbounded behavior), resolved once per client following the same
  default-then-override convention as the other options.

No JS API changes beyond the new optional field; the generated typings are
included.

## Measurements (production endpoint, mainnet firehose)

Full production subscription (two tx filters incl. a 30k-address
`accountInclude`, two account subs with memcmp filters) + 750-slot
`fromSlot` replay, pulled via `read()`:

| consumer | unpatched | patched (capacity 1024) |
|---|---|---|
| full speed | RSS flat ~238 MB, 118k frames/30 s | RSS flat ~175 MB, 120k frames/30 s |
| deliberately slow (50 reads/s vs the dump) | native backlog grows unboundedly | **RSS flat ~110 MB**; server throttled via h2; no disconnect, no data loss, stream resumes full rate when reads resume |

The slow-consumer case is the one that matters: today it is an OOM; with
this change it is ordinary gRPC flow control. We measured no throughput
penalty at full speed, and Helius (LaserStream) served a fully backpressured
subscription for extended periods without evicting the client.

## Notes for reviewers

- The default changes behavior (bounded 1024 vs unbounded). We think that is
  the right default — the unbounded channel is an OOM in disguise — but if
  you prefer strict compatibility, flipping the `JsChannelOptions::default()`
  value to `Some(0)` preserves today's behavior and makes the bound opt-in;
  the rest of the change is identical. Happy to amend.
- `1 << 20` as the "effectively unbounded" capacity keeps the channel type
  uniform instead of branching on bounded/unbounded variants.
- Existing test suite passes unchanged apart from the fixtures constructing
  the readable side directly; four new tests cover capacity resolution.
- Related observation from the same production migration, for anyone
  consuming the private NAPI surface: `subscribe_raw` now eagerly sends
  `SubscribeRequest::default()` when subscribed without an initial request,
  so a request written *after* open arrives as a filter update — and at
  least one provider treats `from_slot` on an update as short-range gap
  recovery rather than archive replay, killing the stream. Passing the
  initial request into `subscribe()` avoids this; may be worth a README
  note, though it is out of scope for this PR.