### PR TITLE
fix(plugin): respect inner_instructions_none and log_messages_none in create_tx_meta

### DIFF
--- a/yellowstone-grpc-geyser/src/plugin/convert_from.rs
+++ b/yellowstone-grpc-geyser/src/plugin/convert_from.rs
@@ -191,8 +191,16 @@ pub fn create_tx_meta(meta: proto::TransactionStatusMeta) -> CreateResult<Transa
         fee: meta.fee,
         pre_balances: meta.pre_balances,
         post_balances: meta.post_balances,
-        inner_instructions: Some(create_meta_inner_instructions(meta.inner_instructions)?),
-        log_messages: Some(meta.log_messages),
+        inner_instructions: if meta.inner_instructions_none {
+            None
+        } else {
+            Some(create_meta_inner_instructions(meta.inner_instructions)?)
+        },
+        log_messages: if meta.log_messages_none {
+            None
+        } else {
+            Some(meta.log_messages)
+        },
         pre_token_balances: Some(create_token_balances(meta.pre_token_balances)?),
         post_token_balances: Some(create_token_balances(meta.post_token_balances)?),
         rewards: Some(meta_rewards),
@@ -373,4 +381,44 @@ pub fn create_account(
         rent_epoch: account.rent_epoch,
     };
     Ok((pubkey, account))
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::create_tx_meta, yellowstone_grpc_proto::prelude as proto};
+
+    fn base_proto_meta() -> proto::TransactionStatusMeta {
+        proto::TransactionStatusMeta {
+            return_data_none: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tx_meta_respects_none_flags_set() {
+        let meta = create_tx_meta(proto::TransactionStatusMeta {
+            inner_instructions_none: true,
+            log_messages_none: true,
+            ..base_proto_meta()
+        })
+        .expect("failed to create meta");
+
+        assert_eq!(meta.inner_instructions, None);
+        assert_eq!(meta.log_messages, None);
+    }
+
+    #[test]
+    fn tx_meta_respects_none_flags_unset() {
+        let log_messages = vec!["Program log: hello".to_owned()];
+        let meta = create_tx_meta(proto::TransactionStatusMeta {
+            inner_instructions_none: false,
+            log_messages_none: false,
+            log_messages: log_messages.clone(),
+            ..base_proto_meta()
+        })
+        .expect("failed to create meta");
+
+        assert_eq!(meta.inner_instructions, Some(vec![]));
+        assert_eq!(meta.log_messages, Some(log_messages));
+    }
 }


### PR DESCRIPTION
## Problem

`TransactionStatusMeta` uses `Option` to separate two different things: `None` means the validator did not record the field, `Some(vec![])` means it recorded it and it was empty.

The wire format carries that distinction explicitly — `solana-storage.proto` declares `inner_instructions_none` (field 10) and `log_messages_none` (field 11) — and `convert_to` writes both faithfully:

```rust
let inner_instructions_none = inner_instructions.is_none();
let log_messages_none = log_messages.is_none();
```

`convert_from::create_tx_meta` never read either one:

```rust
inner_instructions: Some(create_meta_inner_instructions(meta.inner_instructions)?),
log_messages: Some(meta.log_messages),
...
return_data: if meta.return_data_none { None } else { ... }   // handled correctly
```

So a `convert_to` -> `convert_from` round trip silently turns "not recorded" into an empty collection. `return_data_none` being handled right next to them is what makes the other two read as an oversight rather than a deliberate choice.

Visible today in `examples/rust`, which renders `[]` where the plugin signalled none.

## Change

Read the two flags, mirroring the `return_data_none` branch directly below. Nothing else in the function changes.

Plus tests for both flags set and unset.

## Verification

Rust 1.96.1 per `rust-toolchain.toml`:

- `cargo test -p yellowstone-grpc-geyser --lib` — 160 passed, 0 failed
- `cargo clippy -p yellowstone-grpc-geyser --all-targets` — clean
- `cargo fmt --all -- --check` — clean

Negative control, so the tests aren't passing vacuously: with the fix reverted and the tests kept, `tx_meta_respects_none_flags_set` fails with `left: Some([])`, `right: None`, and `tx_meta_respects_none_flags_unset` still passes.

## No version bump

Deliberately left out, along with a CHANGELOG entry: `convert_from` is not reachable from the plugin's serving path — the only consumer in the repo is `examples/rust` — so the released plugin binary behaves identically either way, and a release line would point at a change nobody running the plugin can observe.

Note that #855 took a `15.1.1` bump for a same-shaped `convert_from` fix, so if you would rather keep that precedent, say the word and I will add the bump and the CHANGELOG line.
