### PR TITLE
Fix: fold per-client ping and filter-intake tasks into the client loops

### DIFF
--- a/yellowstone-grpc-geyser/src/contact_info.rs
+++ b/yellowstone-grpc-geyser/src/contact_info.rs
@@ -130,11 +130,14 @@ pub mod grpc {
         futures::{
             sink::{Sink, SinkExt},
             stream::StreamExt as _,
+            Stream,
         },
         log::{error, info},
-        std::{sync::Arc, time::Duration},
-        tokio::sync::mpsc,
-        tokio_stream::wrappers::{errors::BroadcastStreamRecvError, ReceiverStream},
+        std::{pin::Pin, sync::Arc, task::Poll, time::Duration},
+        tokio::{sync::mpsc, time::Interval},
+        tokio_stream::wrappers::{
+            errors::BroadcastStreamRecvError, ReceiverStream,
+        },
         tokio_util::{
             sync::{CancellationToken, PollSender},
             task::TaskTracker,
@@ -183,6 +186,39 @@ pub mod grpc {
     /// so retrying forever would livelock instead of surfacing the problem.
     const MAX_RESNAPSHOT_ATTEMPTS: usize = 3;
 
+    pub struct GossipStream<S> {
+        inner: S,
+        interval: Interval,
+        cancellation_token: CancellationToken,
+    }
+
+    impl<S> Stream for GossipStream<S>
+    where
+        S: Stream<Item = GossipItem> + Unpin,
+    {
+        type Item = GossipItem;
+
+        fn poll_next(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+
+            if this.interval.poll_tick(cx).is_ready() {
+                return Poll::Ready(Some(Ok(convert_to::create_gossip_ping())));
+            }
+
+            Pin::new(&mut this.inner).poll_next(cx)
+        }
+    }
+
+    impl<S> Drop for GossipStream<S> {
+        fn drop(&mut self) {
+            self.cancellation_token.cancel();
+        }
+    }
+
+
     pub fn spawn_subscriber(
         id: usize,
         subscriber_id: Option<String>,
@@ -191,31 +227,11 @@ pub mod grpc {
         state: Arc<ContactInfoState>,
         cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
-    ) -> ReceiverStream<GossipItem> {
+    ) -> GossipStream<ReceiverStream<GossipItem>> {
         let (stream_tx, stream_rx) = mpsc::channel(channel_capacity);
 
-        let ping_stream_tx = stream_tx.clone();
-        let ping_cancellation_token = cancellation_token.clone();
-        let ping_client_cancel = cancellation_token.clone();
-        task_tracker.spawn(async move {
-            let mut interval = tokio::time::interval(PING_INTERVAL);
-            loop {
-                tokio::select! {
-                    _ = ping_cancellation_token.cancelled() => {
-                        info!("contact info client #{id}: ping cancelled");
-                        break;
-                    }
-                    _ = interval.tick() => {
-                        if ping_stream_tx.send(Ok(convert_to::create_gossip_ping())).await.is_err() {
-                            ping_client_cancel.cancel();
-                            info!("detected dead contact info client #{id}");
-                            break;
-                        }
-                    }
-                }
-            }
-            info!("contact info client #{id}: ping task exiting");
-        });
+        let mut interval = tokio::time::interval(PING_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let session =
             ContactInfoClientSession::new(id, subscriber_id, cancellation_token.clone(), permit);
@@ -224,10 +240,14 @@ pub mod grpc {
             session,
             PollSender::new(stream_tx),
             state,
-            cancellation_token,
+            cancellation_token.clone(),
         ));
 
-        ReceiverStream::new(stream_rx)
+        GossipStream {
+            inner: ReceiverStream::new(stream_rx),
+            interval,
+            cancellation_token,
+        }
     }
 
     async fn contact_info_client_loop<S>(

--- a/yellowstone-grpc-geyser/src/contact_info.rs
+++ b/yellowstone-grpc-geyser/src/contact_info.rs
@@ -135,9 +135,7 @@ pub mod grpc {
         log::{error, info},
         std::{pin::Pin, sync::Arc, task::Poll, time::Duration},
         tokio::{sync::mpsc, time::Interval},
-        tokio_stream::wrappers::{
-            errors::BroadcastStreamRecvError, ReceiverStream,
-        },
+        tokio_stream::wrappers::{errors::BroadcastStreamRecvError, ReceiverStream},
         tokio_util::{
             sync::{CancellationToken, PollSender},
             task::TaskTracker,
@@ -217,7 +215,6 @@ pub mod grpc {
             self.cancellation_token.cancel();
         }
     }
-
 
     pub fn spawn_subscriber(
         id: usize,
@@ -355,6 +352,8 @@ mod tests {
         std::{collections::HashMap as Map, time::Duration},
         tokio::sync::mpsc,
         tokio_stream::wrappers::{errors::BroadcastStreamRecvError, UnboundedReceiverStream},
+        tokio_util::{sync::CancellationToken, task::TaskTracker},
+        yellowstone_grpc_proto::geyser::subscribe_update_gossip::UpdateOneof,
     };
 
     /// `shred_version` doubles as a marker so a reconstructed table can be compared field-wise
@@ -692,5 +691,54 @@ mod tests {
                 "subscriber {i} diverged from the writer's table"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn dropping_the_stream_ends_the_client_loop_without_traffic() {
+        let state = ContactInfoState::new(64);
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        tokio::spawn(contact_info_loop(
+            UnboundedReceiverStream::new(rx),
+            Arc::clone(&state),
+        ));
+
+        tx.send(live(node(Pubkey::new_unique(), 1))).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), state.wait_until_complete())
+            .await
+            .expect("state completes");
+
+        let token = CancellationToken::new();
+        let tracker = TaskTracker::new();
+        let mut stream = grpc::spawn_subscriber(
+            0,
+            None,
+            None,
+            16,
+            Arc::clone(&state),
+            token.clone(),
+            tracker.clone(),
+        );
+
+        // drain until snapshot arrives
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while let Some(Ok(update)) = stream.next().await {
+                if matches!(update.update_oneof, Some(UpdateOneof::Snapshot(_))) {
+                    return;
+                }
+            }
+            panic!("stream ended before the snapshot");
+        })
+        .await
+        .expect("snapshot arrives");
+
+        // Client vanishes. No further gossip traffic will ever arrive.
+        drop(stream);
+
+        tracker.close();
+        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
+            .await
+            .expect("client loop must exit when the stream drops, with no gossip traffic");
+        assert!(token.is_cancelled());
     }
 }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -2051,7 +2051,7 @@ impl Geyser for GrpcService {
     type SubscribeStream = LoadAwareReceiver<TonicResult<FilteredUpdate>>;
     type SubscribeDeshredStream = LoadAwareReceiver<TonicResult<FilteredUpdateDeshred>>;
     type SubscribeGossipStream =
-    contact_info::grpc::GossipStream<ReceiverStream<TonicResult<SubscribeUpdateGossip>>>;
+        contact_info::grpc::GossipStream<ReceiverStream<TonicResult<SubscribeUpdateGossip>>>;
 
     async fn subscribe(
         &self,

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -2050,7 +2050,8 @@ impl GrpcService {
 impl Geyser for GrpcService {
     type SubscribeStream = LoadAwareReceiver<TonicResult<FilteredUpdate>>;
     type SubscribeDeshredStream = LoadAwareReceiver<TonicResult<FilteredUpdateDeshred>>;
-    type SubscribeGossipStream = ReceiverStream<TonicResult<SubscribeUpdateGossip>>;
+    type SubscribeGossipStream =
+    contact_info::grpc::GossipStream<ReceiverStream<TonicResult<SubscribeUpdateGossip>>>;
 
     async fn subscribe(
         &self,
@@ -2420,7 +2421,7 @@ impl Geyser for GrpcService {
             return Err(Status::unavailable("server is shutting down"));
         }
 
-        let stream_rx = contact_info::grpc::spawn_subscriber(
+        let gossip_stream = contact_info::grpc::spawn_subscriber(
             id,
             subscriber_id,
             subscription_permit,
@@ -2430,7 +2431,7 @@ impl Geyser for GrpcService {
             self.task_tracker.clone(),
         );
 
-        Ok(Response::new(stream_rx))
+        Ok(Response::new(gossip_stream))
     }
 
     async fn subscribe_first_available_slot(

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -31,7 +31,7 @@ use {
     },
     anyhow::Context as _,
     bytesize::ByteSize,
-    futures::Stream,
+    futures::{Stream, StreamExt},
     log::{error, info},
     prost_types::Timestamp,
     rustls::{
@@ -1498,23 +1498,30 @@ impl GrpcService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn client_loop(
+    async fn client_loop<In>(
         mut session: ClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdate>>,
-        mut client_rx: mpsc::UnboundedReceiver<Option<(Option<u64>, Filter)>>,
+        mut inbound: In,
         mut snapshot_rx: Option<crossbeam_channel::Receiver<Box<Message>>>,
         broadcast: SubscriberChannels,
         replay_stored_slots_tx: Option<mpsc::Sender<ReplayStoredSlotsRequest>>,
+        config_filter_limits: Arc<FilterLimits>,
+        mut filter_names: FilterNames,
         task_tracker: TaskTracker,
-    ) {
+    ) where
+        In: Stream<Item = TonicResult<SubscribeRequest>> + Unpin,
+    {
         let cancellation_token = session.cancellation_token.clone();
+        let mut inbound_done = false;
 
         if let Some(snapshot_rx) = snapshot_rx.take() {
             info!("client #{}: snapshot requested", session.subscriber_id);
             let result = Self::client_loop_snapshot(
                 &mut session,
                 stream_tx.clone(),
-                &mut client_rx,
+                &mut inbound,
+                &config_filter_limits,
+                &mut filter_names,
                 snapshot_rx,
                 cancellation_token.clone(),
             )
@@ -1553,104 +1560,118 @@ impl GrpcService {
                     session.disconnect_reason = "server_shutdown";
                     break 'outer;
                 }
-                mut message = client_rx.recv() => {
-                    // forward to latest filter
-                    loop {
-                        match client_rx.try_recv() {
-                            Ok(message_new) => {
-                                message = Some(message_new);
-                            }
-                            Err(mpsc::error::TryRecvError::Empty) => break,
-                            Err(mpsc::error::TryRecvError::Disconnected) => {
-                                message = None;
-                                break;
-                            }
-                        }
-                    }
+                message = inbound.next(), if !inbound_done => match message {
+                    Some(Ok(req)) => {
+                        filter_names.try_clean();
 
-                    match message {
-                        Some(Some((from_slot, filter_new))) => {
-                            session.set_filter(filter_new);
-                            info!("client #{}: filter updated", session.subscriber_id);
-
-                            let commitment_new = session.filter.get_commitment_level();
-                            if commitment_new != commitment {
-                                commitment = commitment_new;
-                                messages_rx = broadcast.subscribe(commitment);
-                            }
-
-                            if let Some(from_slot) = from_slot {
-                                let Some(replay_stored_slots_tx) = &replay_stored_slots_tx else {
-                                    info!("client #{}: from_slot is not supported", session.subscriber_id);
-                                    task_tracker.spawn(async move {
-                                        let _ = stream_tx.send(Err(Status::internal("from_slot is not supported"))).await;
-                                    });
-                                    session.disconnect_reason = "from_slot_unsupported";
+                        let filter_new = match Filter::new(&req, &config_filter_limits, &mut filter_names) {
+                            Ok(filter) => filter,
+                            Err(error) => {
+                                let err = Err(Status::invalid_argument(format!(
+                                    "failed to create filter: {error}"
+                                )));
+                                if stream_tx.send(err).await.is_err() {
+                                    session.disconnect_reason = "client_disconnect";
                                     break 'outer;
-                                };
+                                }
+                                continue 'outer;
+                            }
+                        };
 
-                                let (tx, rx) = oneshot::channel();
-                                if let Err(_error) = replay_stored_slots_tx.send((commitment, from_slot, tx)).await {
-                                    error!("client #{}: failed to send from_slot request", session.subscriber_id);
+                        // pongs never become the active filter
+                        if let Some(msg) = filter_new.get_pong_msg() {
+                            if stream_tx.send(Ok(msg)).await.is_err() {
+                                error!("client #{}: stream closed", session.subscriber_id);
+                                session.disconnect_reason = "client_disconnect";
+                                break 'outer;
+                            }
+                            continue 'outer;
+                        }
+
+                        let complexity_score = filter_new.get_filter_stats();
+                        metrics::observe_filter_complexity(&session.subscriber_id, &complexity_score);
+
+                        let from_slot = req.from_slot;
+                        session.set_filter(filter_new);
+                        info!("client #{}: filter updated", session.subscriber_id);
+
+                        let commitment_new = session.filter.get_commitment_level();
+                        if commitment_new != commitment {
+                            commitment = commitment_new;
+                            messages_rx = broadcast.subscribe(commitment);
+                        }
+
+                        if let Some(from_slot) = from_slot {
+                            let Some(replay_stored_slots_tx) = &replay_stored_slots_tx else {
+                                info!("client #{}: from_slot is not supported", session.subscriber_id);
+                                task_tracker.spawn(async move {
+                                    let _ = stream_tx.send(Err(Status::internal("from_slot is not supported"))).await;
+                                });
+                                session.disconnect_reason = "from_slot_unsupported";
+                                break 'outer;
+                            };
+
+                            let (tx, rx) = oneshot::channel();
+                            if let Err(_error) = replay_stored_slots_tx.send((commitment, from_slot, tx)).await {
+                                error!("client #{}: failed to send from_slot request", session.subscriber_id);
+                                task_tracker.spawn(async move {
+                                    let _ = stream_tx.send(Err(Status::internal("failed to send from_slot request"))).await;
+                                });
+                                session.disconnect_reason = "replay_error";
+                                break 'outer;
+                            }
+
+                            let messages_batch = match rx.await {
+                                Ok(ReplayedResponse::Messages(messages_batch)) => messages_batch,
+                                Ok(ReplayedResponse::Lagged(slot)) => {
+                                    info!("client #{}: broadcast from {from_slot} is not available", session.subscriber_id);
                                     task_tracker.spawn(async move {
-                                        let _ = stream_tx.send(Err(Status::internal("failed to send from_slot request"))).await;
+                                        let message = format!(
+                                            "broadcast from {from_slot} is not available, last available: {slot}"
+                                        );
+                                        let _ = stream_tx.send(Err(Status::out_of_range(message))).await;
+                                    });
+                                    session.disconnect_reason = "slot_unavailable";
+                                    break 'outer;
+                                },
+                                Err(_error) => {
+                                    error!("client #{}: failed to get replay response", session.subscriber_id);
+                                    task_tracker.spawn(async move {
+                                        let _ = stream_tx.send(Err(Status::internal("failed to get replay response"))).await;
                                     });
                                     session.disconnect_reason = "replay_error";
                                     break 'outer;
                                 }
+                            };
 
-                                let messages_batch = match rx.await {
-                                    Ok(ReplayedResponse::Messages(messages_batch)) => messages_batch,
-                                    Ok(ReplayedResponse::Lagged(slot)) => {
-                                        info!("client #{}: broadcast from {from_slot} is not available", session.subscriber_id);
-                                        task_tracker.spawn(async move {
-                                            let message = format!(
-                                                "broadcast from {from_slot} is not available, last available: {slot}"
-                                            );
-                                            let _ = stream_tx.send(Err(Status::out_of_range(message))).await;
-                                        });
-                                        session.disconnect_reason = "slot_unavailable";
-                                        break 'outer;
-                                    },
-                                    Err(_error) => {
-                                        error!("client #{}: failed to get replay response", session.subscriber_id);
-                                        task_tracker.spawn(async move {
-                                            let _ = stream_tx.send(Err(Status::internal("failed to get replay response"))).await;
-                                        });
-                                        session.disconnect_reason = "replay_error";
-                                        break 'outer;
+                            let replay_it = messages_batch
+                                .iter()
+                                .flatten()
+                                .flat_map(|message| session.filter.get_updates(message, Some(commitment)));
+
+                            for filtered_message in replay_it {
+                                match stream_tx.send(Ok(filtered_message)).await {
+                                    Ok(()) => {
+                                        metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
                                     }
-                                };
-
-                                let replay_it = messages_batch
-                                    .iter()
-                                    .flatten()
-                                    .flat_map(|message| session.filter.get_updates(message, Some(commitment)));
-
-                                for filtered_message in replay_it {
-                                    match stream_tx.send(Ok(filtered_message)).await {
-                                        Ok(()) => {
-                                            metrics::incr_grpc_message_sent_counter(&session.subscriber_id);
-                                        }
-                                        Err(mpsc::error::SendError(_)) => {
-                                            error!("client #{}: stream closed", session.subscriber_id);
-                                            session.disconnect_reason = "client_closed";
-                                            break 'outer;
-                                        }
+                                    Err(mpsc::error::SendError(_)) => {
+                                        error!("client #{}: stream closed", session.subscriber_id);
+                                        session.disconnect_reason = "client_closed";
+                                        break 'outer;
                                     }
                                 }
                             }
                         }
-                        Some(None) => {
-                            session.disconnect_reason = "client_disconnect";
-                            break 'outer;
-                        },
-                        None => {
-                            session.disconnect_reason = "client_disconnect";
-                            break 'outer;
-                        }
                     }
-                }
+                    Some(Err(_error)) => {
+                        session.disconnect_reason = "client_disconnect";
+                        break 'outer;
+                    }
+                    None => {
+                        info!("client #{}: client closed send stream", session.subscriber_id);
+                        inbound_done = true;
+                    }
+                },
                 message = messages_rx.recv() => {
                     let messages = match message {
                         Ok(messages) => messages,
@@ -1695,13 +1716,18 @@ impl GrpcService {
         }
     }
 
-    async fn client_loop_snapshot(
+    async fn client_loop_snapshot<In>(
         session: &mut ClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdate>>,
-        client_rx: &mut mpsc::UnboundedReceiver<Option<(Option<u64>, Filter)>>,
+        inbound: &mut In,
+        config_filter_limits: &FilterLimits,
+        filter_names: &mut FilterNames,
         snapshot_rx: crossbeam_channel::Receiver<Box<Message>>,
         cancellation_token: CancellationToken,
-    ) -> Result<(), ClientSnapshotReplayError> {
+    ) -> Result<(), ClientSnapshotReplayError>
+    where
+        In: Stream<Item = TonicResult<SubscribeRequest>> + Unpin,
+    {
         info!(
             "client #{}: going to receive snapshot data",
             session.subscriber_id
@@ -1714,9 +1740,22 @@ impl GrpcService {
                     info!("client #{}: cancelled", session.subscriber_id);
                     return Err(ClientSnapshotReplayError::Cancelled);
                 }
-                maybe = client_rx.recv() => {
+                maybe = inbound.next() => {
                     match maybe {
-                        Some(Some((_from_slot, filter_new))) => {
+                        Some(Ok(req)) => {
+                            let filter_new = match Filter::new(&req, config_filter_limits, filter_names) {
+                                Ok(f) => f,
+                                Err(error) => {
+                                    let err = Err(Status::invalid_argument(format!(
+                                        "failed to create filter: {error}"
+                                    )));
+                                    if stream_tx.send(err).await.is_err() {
+                                        return Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed);
+                                    }
+                                    continue;
+                                }
+                            };
+
                             if let Some(msg) = filter_new.get_pong_msg() {
                                 if stream_tx.send(Ok(msg)).await.is_err() {
                                     error!("client #{}: stream closed", session.subscriber_id);
@@ -1730,15 +1769,11 @@ impl GrpcService {
                             info!("client #{}: filter updated", session.subscriber_id);
                             break;
                         }
-                        Some(None) => {
-                            return Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed);
-                        }
-                        None => {
+                        Some(Err(_)) | None => {
                             return Err(ClientSnapshotReplayError::ClientGrpcConnectionClosed);
                         }
                     }
                 }
-
             }
         }
 
@@ -1944,17 +1979,19 @@ impl GrpcService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn deshred_client_loop(
+    async fn deshred_client_loop<In>(
         mut session: DeshredClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdateDeshred>>,
-        mut inbound: Streaming<SubscribeDeshredRequest>,  
+        mut inbound: In,
         mut messages_rx: broadcast::Receiver<DeshredBroadcastedMessage>,
         config_filter_limits: Arc<FilterLimits>,
-        mut filter_names: FilterNames,  
+        mut filter_names: FilterNames,
         cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
-    ) {
-        let mut inbound_done = false;  
+    ) where
+        In: Stream<Item = TonicResult<SubscribeDeshredRequest>> + Unpin,
+    {
+        let mut inbound_done = false;
 
         'outer: loop {
             observe_subscriber_queue_size(
@@ -1970,8 +2007,8 @@ impl GrpcService {
                     session.disconnect_reason = "server_shutdown";
                     break 'outer;
                 }
-                message = inbound.message(), if !inbound_done => match message {
-                    Ok(Some(req)) => {
+                message = inbound.next(), if !inbound_done => match message {
+                    Some(Ok(req))  => {
                         filter_names.try_clean();
 
                         match DeshredFilter::new(&req, &config_filter_limits, &mut filter_names) {
@@ -1998,11 +2035,11 @@ impl GrpcService {
                             }
                         }
                     }
-                    Ok(None) => {
+                    None => {
                         info!("deshred client #{}/{}: client closed send stream", session.subscriber_id, session.id);
                         inbound_done = true;          // stop reading, keep serving
                     }
-                    Err(_error) => {
+                    Some(Err(_error)) => {
                         session.disconnect_reason = "client_disconnect";
                         break 'outer;
                     }
@@ -2120,7 +2157,7 @@ impl Geyser for GrpcService {
 
     async fn subscribe(
         &self,
-        mut request: Request<Streaming<SubscribeRequest>>,
+        request: Request<Streaming<SubscribeRequest>>,
     ) -> TonicResult<Response<Self::SubscribeStream>> {
         incr_grpc_method_call_count("subscribe");
 
@@ -2168,7 +2205,6 @@ impl Geyser for GrpcService {
         } else {
             self.config_channel_capacity
         });
-        let (client_tx, client_rx) = mpsc::unbounded_channel();
 
         let mut interval = tokio::time::interval(Duration::from_secs(10));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -2180,71 +2216,12 @@ impl Geyser for GrpcService {
             .unwrap_or_else(|| "".to_owned());
 
         let config_filter_limits = Arc::clone(&self.config_filter_limits);
-        let incoming_stream_tx = stream_tx.clone();
-        let incoming_client_tx = client_tx;
-        let incoming_cancellation_token = client_cancellation_token.child_token();
 
-        let mut filter_names = FilterNames::new(
+        let filter_names = FilterNames::new(
             self.filter_name_size_limit,
             self.filter_names_size_limit,
             self.filter_names_cleanup_interval,
         );
-
-        let subscriber_id2 = subscriber_id.clone();
-        self.task_tracker.spawn(async move {
-            let subscriber_id = subscriber_id2.unwrap_or("unknown".to_string());
-            loop {
-                tokio::select! {
-                    _ = incoming_cancellation_token.cancelled() => {
-                        info!("client #{subscriber_id:?}/{id}: filter receiver cancelled");
-                        break;
-                    }
-                    message = request.get_mut().message() => match message {
-                        Ok(Some(request)) => {
-                            filter_names.try_clean();
-
-                            if let Err(error) = match Filter::new(&request, &config_filter_limits, &mut filter_names) {
-                                Ok(filter) => {
-                                    if let Some(msg) = filter.get_pong_msg() {
-                                        if incoming_stream_tx.send(Ok(msg)).await.is_err() {
-                                            error!("client #{subscriber_id:?}/{id}: stream closed");
-                                            let _ = incoming_client_tx.send(None);
-                                            break;
-                                        }
-                                        continue;
-                                    }
-                                    let complexity_score = filter.get_filter_stats();
-                                    metrics::observe_filter_complexity(&subscriber_id, &complexity_score);
-                                    match incoming_client_tx.send(Some((request.from_slot, filter))) {
-                                        Ok(()) => Ok(()),
-                                        Err(error) => Err(error.to_string()),
-                                    }
-                                },
-                                Err(error) => Err(error.to_string()),
-                            } {
-                                let err = Err(Status::invalid_argument(format!(
-                                    "failed to create filter: {error}"
-                                )));
-                                if incoming_stream_tx.send(err).await.is_err() {
-                                    let _ = incoming_client_tx.send(None);
-                                }
-                            }
-                        }
-                        Ok(None) => {
-                             // Client half-closed its send stream. Stop reading, but keep
-                             // incoming_client_tx alive so client_loop continues running.
-                            info!("client #{subscriber_id:?}/{id}: client closed send stream, waiting for cancellation");
-                            incoming_cancellation_token.cancelled().await;
-                            break;
-                        }
-                        Err(_error) => {
-                            let _ = incoming_client_tx.send(None);
-                            break;
-                        }
-                    }
-                }
-            }
-        });
 
         let client_session = ClientSession::new(
             id,
@@ -2256,10 +2233,12 @@ impl Geyser for GrpcService {
         self.task_tracker.spawn(Self::client_loop(
             client_session,
             stream_tx,
-            client_rx,
+            request.into_inner(),
             snapshot_rx,
             self.broadcast.clone(),
             self.replay_stored_slots_tx.clone(),
+            config_filter_limits,
+            filter_names,
             self.task_tracker.clone(),
         ));
 
@@ -2516,29 +2495,25 @@ mod tests {
     use {
         super::*,
         crate::{
-            plugin::filter::{limits::FilterLimits, name::FilterNames, Filter},
+            plugin::filter::{limits::FilterLimits, name::FilterNames},
             util::stream::load_aware_channel,
         },
         yellowstone_grpc_proto::prelude::{SubscribeRequest, SubscribeRequestFilterSlots},
     };
 
-    fn create_filter_with_slots() -> Filter {
-        let config = SubscribeRequest {
+    fn create_request_with_slots() -> SubscribeRequest {
+        SubscribeRequest {
             slots: HashMap::from([("test".into(), SubscribeRequestFilterSlots::default())]),
             ..Default::default()
-        };
-        let mut names = FilterNames::new(64, 1024, Duration::from_secs(1));
-        Filter::new(&config, &FilterLimits::default(), &mut names).unwrap()
+        }
     }
 
-    fn create_filter_at(commitment: CommitmentLevelProto) -> Filter {
-        let config = SubscribeRequest {
+    fn create_request_at(commitment: CommitmentLevelProto) -> SubscribeRequest {
+        SubscribeRequest {
             slots: HashMap::from([("test".into(), SubscribeRequestFilterSlots::default())]),
             commitment: Some(commitment as i32),
             ..Default::default()
-        };
-        let mut names = FilterNames::new(64, 1024, Duration::from_secs(1));
-        Filter::new(&config, &FilterLimits::default(), &mut names).unwrap()
+        }
     }
 
     fn slot_batch(slot: u64) -> BroadcastedMessage {
@@ -2575,7 +2550,7 @@ mod tests {
     }
 
     type ClientHandles = (
-        mpsc::UnboundedSender<Option<(Option<u64>, Filter)>>,
+        mpsc::UnboundedSender<TonicResult<SubscribeRequest>>,
         LoadAwareReceiver<TonicResult<FilteredUpdate>>,
     );
 
@@ -2586,10 +2561,12 @@ mod tests {
         tokio::spawn(GrpcService::client_loop(
             session,
             stream_tx,
-            client_rx,
+            UnboundedReceiverStream::new(client_rx),
             None,
             broadcast,
             None,
+            Arc::new(FilterLimits::default()),
+            FilterNames::new(64, 1024, Duration::from_secs(1)),
             TaskTracker::new(),
         ));
         (client_tx, stream_rx)
@@ -2601,12 +2578,7 @@ mod tests {
         let broadcast = SubscriberChannels::new(16, 16, 16);
         let (client_tx, mut stream_rx) = spawn_client_loop(broadcast.clone(), ct.clone());
 
-        client_tx
-            .send(Some((
-                None,
-                create_filter_at(CommitmentLevelProto::Finalized),
-            )))
-            .unwrap();
+        client_tx.send(Ok(create_request_at(CommitmentLevelProto::Finalized))).unwrap();
         settle().await;
 
         broadcast.send(CommitmentLevel::Processed, slot_batch(100));
@@ -2625,23 +2597,13 @@ mod tests {
         let broadcast = SubscriberChannels::new(16, 16, 16);
         let (client_tx, mut stream_rx) = spawn_client_loop(broadcast.clone(), ct.clone());
 
-        client_tx
-            .send(Some((
-                None,
-                create_filter_at(CommitmentLevelProto::Processed),
-            )))
-            .unwrap();
+        client_tx.send(Ok(create_request_at(CommitmentLevelProto::Processed))).unwrap();
         settle().await;
 
         broadcast.send(CommitmentLevel::Processed, slot_batch(100));
         expect_one(&mut stream_rx).await;
 
-        client_tx
-            .send(Some((
-                None,
-                create_filter_at(CommitmentLevelProto::Finalized),
-            )))
-            .unwrap();
+        client_tx.send(Ok(create_request_at(CommitmentLevelProto::Finalized))).unwrap();
         settle().await;
 
         broadcast.send(CommitmentLevel::Processed, slot_batch(101));
@@ -2653,73 +2615,41 @@ mod tests {
         ct.cancel();
     }
 
-    // Simulates the incoming handler task from subscribe(). Mirrors the
-    // real Ok(None) path: sends the filter, then on half-close awaits
-    // cancellation to keep the sender alive.
-    async fn incoming_handler(
-        client_tx: mpsc::UnboundedSender<Option<(Option<u64>, Filter)>>,
-        filter: Filter,
-        half_close: oneshot::Receiver<()>,
-        ct: CancellationToken,
-    ) {
-        client_tx.send(Some((None, filter))).unwrap();
-        let _ = half_close.await;
-        // this is the fix from #670: await cancellation instead of
-        // breaking, so client_tx stays alive and client_rx remains open.
-        ct.cancelled().await;
-    }
-
     // Regression test for #662 / #670.
     //
-    // #662 (91709fd) removed ping_client_tx, the clone of client_tx that
-    // lived in the ping task. before that patch two senders existed for
-    // client_rx: ping_client_tx and incoming_client_tx. when a client
-    // half-closed its send stream (Ok(None)), the incoming task dropped its
-    // sender but ping_client_tx kept client_rx open so client_loop survived.
-    //
-    // after #662 incoming_client_tx is the only sender. without the fix from
-    // #670 (awaiting cancellation in the Ok(None) handler instead of
-    // breaking), dropping it closes client_rx and tears down the connection
-    // on a normal grpc half-close.
-    //
-    // uses current_thread runtime so yield_now deterministically sequences
-    // filter processing before any broadcast.
+    // Half-closing the send stream must not tear down the subscription so the
+    // client can stop sending filters and keep receiving updates. Previously
+    // this depended on how many senders held client_rx open, which is what
+    // #662/#670 were about. With the inbound request stream read directly by
+    // client_loop, EOF is just `None` and the loop keeps serving.
     #[tokio::test]
-    async fn test_cancellation_on_client_disconnect_after_half_close() {
+   async fn test_cancellation_on_client_disconnect_after_half_close() {
         let ct = CancellationToken::new();
         let tt = TaskTracker::new();
         let broadcast = SubscriberChannels::new(16, 16, 16);
         let (client_tx, client_rx) = mpsc::unbounded_channel();
         let (stream_tx, stream_rx) = load_aware_channel(16);
-        let (half_close_tx, half_close_rx) = oneshot::channel();
-
-        // mirrors the incoming handler spawned in subscribe()
-        let incoming_ct = ct.child_token();
-        tokio::spawn(incoming_handler(
-            client_tx,
-            create_filter_with_slots(),
-            half_close_rx,
-            incoming_ct,
-        ));
 
         let session = ClientSession::new(0, Some("test".into()), "test".into(), ct.clone(), None);
 
         let handle = tokio::spawn(GrpcService::client_loop(
             session,
             stream_tx,
-            client_rx,
+            UnboundedReceiverStream::new(client_rx),
             None,
             broadcast.clone(),
             None,
+            Arc::new(FilterLimits::default()),
+            FilterNames::new(64, 1024, Duration::from_secs(1)),
             tt.clone(),
         ));
 
-        // yield so incoming_handler sends the filter and client_loop
-        // processes it (only client_rx is ready, no broadcast yet)
+        // client sends its filter
+        client_tx.send(Ok(create_request_with_slots())).unwrap();
         tokio::task::yield_now().await;
 
         // client half-closes its send stream
-        let _ = half_close_tx.send(());
+        drop(client_tx);
         tokio::task::yield_now().await;
 
         // client drops subscription rx

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -2578,7 +2578,9 @@ mod tests {
         let broadcast = SubscriberChannels::new(16, 16, 16);
         let (client_tx, mut stream_rx) = spawn_client_loop(broadcast.clone(), ct.clone());
 
-        client_tx.send(Ok(create_request_at(CommitmentLevelProto::Finalized))).unwrap();
+        client_tx
+            .send(Ok(create_request_at(CommitmentLevelProto::Finalized)))
+            .unwrap();
         settle().await;
 
         broadcast.send(CommitmentLevel::Processed, slot_batch(100));
@@ -2597,13 +2599,17 @@ mod tests {
         let broadcast = SubscriberChannels::new(16, 16, 16);
         let (client_tx, mut stream_rx) = spawn_client_loop(broadcast.clone(), ct.clone());
 
-        client_tx.send(Ok(create_request_at(CommitmentLevelProto::Processed))).unwrap();
+        client_tx
+            .send(Ok(create_request_at(CommitmentLevelProto::Processed)))
+            .unwrap();
         settle().await;
 
         broadcast.send(CommitmentLevel::Processed, slot_batch(100));
         expect_one(&mut stream_rx).await;
 
-        client_tx.send(Ok(create_request_at(CommitmentLevelProto::Finalized))).unwrap();
+        client_tx
+            .send(Ok(create_request_at(CommitmentLevelProto::Finalized)))
+            .unwrap();
         settle().await;
 
         broadcast.send(CommitmentLevel::Processed, slot_batch(101));
@@ -2623,7 +2629,7 @@ mod tests {
     // #662/#670 were about. With the inbound request stream read directly by
     // client_loop, EOF is just `None` and the loop keeps serving.
     #[tokio::test]
-   async fn test_cancellation_on_client_disconnect_after_half_close() {
+    async fn test_cancellation_on_client_disconnect_after_half_close() {
         let ct = CancellationToken::new();
         let tt = TaskTracker::new();
         let broadcast = SubscriberChannels::new(16, 16, 16);

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -57,7 +57,7 @@ use {
         io::{AsyncRead, AsyncWrite},
         net::UnixListener,
         sync::{broadcast, mpsc, oneshot, Mutex, RwLock, Semaphore},
-        time::{sleep, Duration},
+        time::{sleep, Duration, Interval},
     },
     tokio_rustls::{rustls, TlsAcceptor},
     tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream, UnixListenerStream},
@@ -2046,10 +2046,64 @@ impl GrpcService {
     }
 }
 
+pub struct DeshredStream {
+    inner: LoadAwareReceiver<TonicResult<FilteredUpdateDeshred>>,
+    interval: Interval,
+    cancellation_token: CancellationToken,
+}
+
+impl Stream for DeshredStream {
+    type Item = TonicResult<FilteredUpdateDeshred>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.interval.poll_tick(cx).is_ready() {
+            return Poll::Ready(Some(Ok(FilteredUpdateDeshred::ping())));
+        }
+
+        Pin::new(&mut this.inner).poll_next(cx)
+    }
+}
+
+impl Drop for DeshredStream {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+    }
+}
+
+pub struct FilteredUpdateStream {
+    inner: LoadAwareReceiver<TonicResult<FilteredUpdate>>,
+    interval: Interval,
+    cancellation_token: CancellationToken,
+}
+
+impl Stream for FilteredUpdateStream {
+    type Item = TonicResult<FilteredUpdate>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.interval.poll_tick(cx).is_ready() {
+            return Poll::Ready(Some(Ok(FilteredUpdate::new_empty(
+                FilteredUpdateOneof::ping(),
+            ))));
+        }
+
+        this.inner.poll_recv(cx)
+    }
+}
+
+impl Drop for FilteredUpdateStream {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+    }
+}
+
 #[tonic::async_trait]
 impl Geyser for GrpcService {
-    type SubscribeStream = LoadAwareReceiver<TonicResult<FilteredUpdate>>;
-    type SubscribeDeshredStream = LoadAwareReceiver<TonicResult<FilteredUpdateDeshred>>;
+    type SubscribeStream = FilteredUpdateStream;
+    type SubscribeDeshredStream = DeshredStream;
     type SubscribeGossipStream =
         contact_info::grpc::GossipStream<ReceiverStream<TonicResult<SubscribeUpdateGossip>>>;
 
@@ -2105,39 +2159,8 @@ impl Geyser for GrpcService {
         });
         let (client_tx, client_rx) = mpsc::unbounded_channel();
 
-        let ping_stream_tx = stream_tx.clone();
-        let ping_cancellation_token = client_cancellation_token.clone();
-        let ping_client_cancel = client_cancellation_token.clone();
-        let ping_subscriber_id = subscriber_id.clone();
-        self.task_tracker.spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(10));
-            loop {
-                tokio::select! {
-                    _ = ping_cancellation_token.cancelled() => {
-                        info!("client #{ping_subscriber_id:?}/{id}: ping cancelled");
-                        break;
-                    }
-                    _ = interval.tick() => {
-                        let msg = FilteredUpdate::new_empty(FilteredUpdateOneof::ping());
-                        log::info!("client #{ping_subscriber_id:?}/{id}: sending ping");
-                        if ping_stream_tx.send(Ok(msg)).await.is_err() {
-                            //
-                            // It's really important to send cancel ping for one edge-case where someone
-                            // subscribe without any filter:
-                            //
-                            // When someone subscribe without any filter, this can create a "zombie" client loop that
-                            // does reject every geyser event thus we never write to the HTTP/2 stream and we never detect that the client TCP connection is closed.
-                            // By sending a ping every 10 seconds, we can detect if the client is still alive and if it's not,
-                            // we can cancel the client loop.
-                            ping_client_cancel.cancel();
-                            info!("detected dead client #{ping_subscriber_id:?}/{id}");
-                            break;
-                        }
-                    }
-                }
-            }
-            info!("client #{ping_subscriber_id:?}/{id}: ping task exiting");
-        });
+        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let endpoint = request
             .metadata()
@@ -2216,7 +2239,7 @@ impl Geyser for GrpcService {
             id,
             subscriber_id.clone(),
             endpoint.clone(),
-            client_cancellation_token,
+            client_cancellation_token.clone(),
             subscription_permit,
         );
         self.task_tracker.spawn(Self::client_loop(
@@ -2229,7 +2252,11 @@ impl Geyser for GrpcService {
             self.task_tracker.clone(),
         ));
 
-        Ok(Response::new(stream_rx))
+        Ok(Response::new(FilteredUpdateStream {
+            inner: stream_rx,
+            interval,
+            cancellation_token: client_cancellation_token,
+        }))
     }
 
     async fn subscribe_deshred(
@@ -2274,30 +2301,8 @@ impl Geyser for GrpcService {
         let (stream_tx, stream_rx) = load_aware_channel(self.config_channel_capacity);
         let (client_tx, client_rx) = mpsc::unbounded_channel();
 
-        let ping_stream_tx = stream_tx.clone();
-        let ping_cancellation_token = client_cancellation_token.clone();
-        let ping_client_cancel = client_cancellation_token.clone();
-        self.task_tracker.spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(10));
-            loop {
-                tokio::select! {
-                    _ = ping_cancellation_token.cancelled() => {
-                        info!("deshred client #{id}: ping cancelled");
-                        break;
-                    }
-                    _ = interval.tick() => {
-                        let msg = FilteredUpdateDeshred::ping();
-                        info!("deshred client #{id}: sending ping");
-                        if ping_stream_tx.send(Ok(msg)).await.is_err() {
-                            ping_client_cancel.cancel();
-                            info!("detected dead deshred client #{id}");
-                            break;
-                        }
-                    }
-                }
-            }
-            info!("deshred client #{id}: ping task exiting");
-        });
+        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let subscriber_id = request
             .metadata()
@@ -2376,11 +2381,15 @@ impl Geyser for GrpcService {
             stream_tx,
             client_rx,
             self.deshred_broadcast_tx.subscribe(),
-            client_cancellation_token,
+            client_cancellation_token.clone(),
             self.task_tracker.clone(),
         ));
 
-        Ok(Response::new(stream_rx))
+        Ok(Response::new(DeshredStream {
+            inner: stream_rx,
+            interval,
+            cancellation_token: client_cancellation_token,
+        }))
     }
 
     async fn subscribe_gossip(

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -1947,11 +1947,15 @@ impl GrpcService {
     async fn deshred_client_loop(
         mut session: DeshredClientSession,
         stream_tx: LoadAwareSender<TonicResult<FilteredUpdateDeshred>>,
-        mut client_rx: mpsc::UnboundedReceiver<Option<DeshredFilter>>,
+        mut inbound: Streaming<SubscribeDeshredRequest>,  
         mut messages_rx: broadcast::Receiver<DeshredBroadcastedMessage>,
+        config_filter_limits: Arc<FilterLimits>,
+        mut filter_names: FilterNames,  
         cancellation_token: CancellationToken,
         task_tracker: TaskTracker,
     ) {
+        let mut inbound_done = false;  
+
         'outer: loop {
             observe_subscriber_queue_size(
                 &session.subscriber_id,
@@ -1966,36 +1970,43 @@ impl GrpcService {
                     session.disconnect_reason = "server_shutdown";
                     break 'outer;
                 }
-                mut message = client_rx.recv() => {
-                    // forward to latest filter
-                    loop {
-                        match client_rx.try_recv() {
-                            Ok(message_new) => {
-                                message = Some(message_new);
-                            }
-                            Err(mpsc::error::TryRecvError::Empty) => break,
-                            Err(mpsc::error::TryRecvError::Disconnected) => {
-                                message = None;
-                                break;
-                            }
-                        }
-                    }
+                message = inbound.message(), if !inbound_done => match message {
+                    Ok(Some(req)) => {
+                        filter_names.try_clean();
 
-                    match message {
-                        Some(Some(filter_new)) => {
-                            session.filter = filter_new;
-                            info!("deshred client #{}/{}: filter updated", session.subscriber_id, session.id);
-                        }
-                        Some(None) => {
-                            session.disconnect_reason = "client_disconnect";
-                            break 'outer;
-                        },
-                        None => {
-                            session.disconnect_reason = "client_disconnect";
-                            break 'outer;
+                        match DeshredFilter::new(&req, &config_filter_limits, &mut filter_names) {
+                            Ok(filter) => {
+                                if let Some(msg) = filter.get_pong_msg() {
+                                    if stream_tx.send(Ok(msg)).await.is_err() {
+                                        error!("deshred client #{}/{}: stream closed", session.subscriber_id, session.id);
+                                        session.disconnect_reason = "client_disconnect";
+                                        break 'outer;
+                                    }
+                                } else {
+                                    session.filter = filter;
+                                    info!("deshred client #{}/{}: filter updated", session.subscriber_id, session.id);
+                                }
+                            }
+                            Err(error) => {
+                                let err = Err(Status::invalid_argument(format!(
+                                    "failed to create deshred filter: {error}"
+                                )));
+                                if stream_tx.send(err).await.is_err() {
+                                    session.disconnect_reason = "client_disconnect";
+                                    break 'outer;
+                                }
+                            }
                         }
                     }
-                }
+                    Ok(None) => {
+                        info!("deshred client #{}/{}: client closed send stream", session.subscriber_id, session.id);
+                        inbound_done = true;          // stop reading, keep serving
+                    }
+                    Err(_error) => {
+                        session.disconnect_reason = "client_disconnect";
+                        break 'outer;
+                    }
+                },
                 message = messages_rx.recv() => {
                     let message = match message {
                         Ok(message) => message,
@@ -2261,7 +2272,7 @@ impl Geyser for GrpcService {
 
     async fn subscribe_deshred(
         &self,
-        mut request: Request<Streaming<SubscribeDeshredRequest>>,
+        request: Request<Streaming<SubscribeDeshredRequest>>,
     ) -> TonicResult<Response<Self::SubscribeDeshredStream>> {
         incr_grpc_method_call_count("subscribe_deshred");
 
@@ -2299,7 +2310,6 @@ impl Geyser for GrpcService {
         }
 
         let (stream_tx, stream_rx) = load_aware_channel(self.config_channel_capacity);
-        let (client_tx, client_rx) = mpsc::unbounded_channel();
 
         let mut interval = tokio::time::interval(Duration::from_secs(10));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -2311,64 +2321,11 @@ impl Geyser for GrpcService {
             .or(request.remote_addr().map(|addr| addr.ip().to_string()));
 
         let config_filter_limits = Arc::clone(&self.config_filter_limits);
-        let mut filter_names = FilterNames::new(
+        let filter_names = FilterNames::new(
             self.filter_name_size_limit,
             self.filter_names_size_limit,
             self.filter_names_cleanup_interval,
         );
-        let incoming_stream_tx = stream_tx.clone();
-        let incoming_client_tx = client_tx;
-        let incoming_cancellation_token = client_cancellation_token.child_token();
-
-        self.task_tracker.spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = incoming_cancellation_token.cancelled() => {
-                        info!("deshred client #{id}: filter receiver cancelled");
-                        break;
-                    }
-                    message = request.get_mut().message() => match message {
-                        Ok(Some(request)) => {
-                            filter_names.try_clean();
-
-                            if let Err(error) = match DeshredFilter::new(&request, &config_filter_limits, &mut filter_names) {
-                                Ok(filter) => {
-                                    if let Some(msg) = filter.get_pong_msg() {
-                                        if incoming_stream_tx.send(Ok(msg)).await.is_err() {
-                                            error!("deshred client #{id}: stream closed");
-                                            let _ = incoming_client_tx.send(None);
-                                            break;
-                                        }
-                                        continue;
-                                    }
-                                    match incoming_client_tx.send(Some(filter)) {
-                                        Ok(()) => Ok(()),
-                                        Err(error) => Err(error.to_string()),
-                                    }
-                                },
-                                Err(error) => Err(error.to_string()),
-                            } {
-                                let err = Err(Status::invalid_argument(format!(
-                                    "failed to create deshred filter: {error}"
-                                )));
-                                if incoming_stream_tx.send(err).await.is_err() {
-                                    let _ = incoming_client_tx.send(None);
-                                }
-                            }
-                        }
-                        Ok(None) => {
-                            info!("deshred client #{id}: client closed send stream, waiting for cancellation");
-                            incoming_cancellation_token.cancelled().await;
-                            break;
-                        }
-                        Err(_error) => {
-                            let _ = incoming_client_tx.send(None);
-                            break;
-                        }
-                    }
-                }
-            }
-        });
 
         let session = DeshredClientSession::new(
             id,
@@ -2379,8 +2336,10 @@ impl Geyser for GrpcService {
         self.task_tracker.spawn(Self::deshred_client_loop(
             session,
             stream_tx,
-            client_rx,
+            request.into_inner(),
             self.deshred_broadcast_tx.subscribe(),
+            config_filter_limits,
+            filter_names,
             client_cancellation_token.clone(),
             self.task_tracker.clone(),
         ));


### PR DESCRIPTION
Currently every client runs three tasks: a ping timer, a filter-intake loop, and the client loop itself, where the first two exist only to feed the third through a channel. This folds all of them into one: the ping becomes a field on the response stream and
the intake becomes another `select!` branch, taking each client from 3 tasks and 2 channels down to 1 and 1.